### PR TITLE
Add A2A and MCP Adapters to mirror LangSmith Platform

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,7 @@ aegra/
 │   ├── aegra-api/                    # Core API package
 │   │   ├── src/aegra_api/            # Main application code
 │   │   │   ├── api/                  # Agent Protocol endpoints
+│   │   │   ├── adapters/             # Protocol adapters (A2A, MCP)
 │   │   │   ├── services/             # Business logic layer
 │   │   │   ├── core/                 # Infrastructure (database, auth, orm, health, migrations)
 │   │   │   ├── models/               # Pydantic request/response schemas
@@ -198,6 +199,14 @@ These rules exist because AI agents repeatedly make these mistakes. Follow them 
 - Use `subprocess.run([...], shell=False)` — never `shell=True` with user input.
 
 ## Architecture
+
+### Protocol Adapters
+The `adapters/` directory contains protocol bridge implementations that expose Aegra agents via additional protocols:
+
+- **A2A adapter** — Implements the [Agent-to-Agent protocol](https://google.github.io/A2A/) at `/a2a/{assistant_id}`. Translates A2A JSON-RPC messages (`message/send`, `message/stream`, `tasks/get`, `tasks/cancel`) into Agent Protocol runs. Maps A2A `contextId` to `thread_id` and `taskId` to `run_id`.
+- **MCP adapter** — Implements [Model Context Protocol](https://modelcontextprotocol.io/) at `/mcp` using Streamable HTTP transport. Exposes each configured graph as an MCP tool (one tool per graph, name = graph_id).
+
+Both adapters are enabled by default and can be disabled via `aegra.json` (`http.disable_a2a`, `http.disable_mcp`). Both share the same auth stack as the Agent Protocol endpoints.
 
 ### Database Architecture
 The system uses two connection pools:

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ async for chunk in client.runs.stream(
 ## ✨ Features
 
 - **[Agent Protocol](https://github.com/langchain-ai/agent-protocol) compliant** - Works with Agent Chat UI, LangGraph Studio, CopilotKit
+- **[A2A protocol](https://google.github.io/A2A/)** - Agent-to-Agent communication for multi-agent workflows
+- **[MCP support](https://modelcontextprotocol.io/)** - Use deployed agents as tools in Claude Desktop, Cursor, and any MCP client
 - **[Human-in-the-loop](https://docs.aegra.dev/guides/human-in-the-loop)** - Approval gates and user intervention points
 - **[Streaming](https://docs.aegra.dev/guides/streaming)** - Real-time responses with network resilience
 - **[Persistent state](https://docs.aegra.dev/guides/threads-and-state)** - PostgreSQL checkpoints via LangGraph

--- a/docs/a2a.md
+++ b/docs/a2a.md
@@ -1,0 +1,123 @@
+# A2A (Agent-to-Agent) Protocol
+
+Aegra implements the [A2A (Agent-to-Agent) protocol](https://google.github.io/A2A/), which allows other agents and systems to discover and communicate with your Aegra agents using a standard, interoperable interface.
+
+## Overview
+
+A2A is a JSON-RPC 2.0 protocol that defines a standard way for agents to exchange messages, manage tasks, and discover each other's capabilities. Aegra exposes each assistant via A2A, enabling multi-agent workflows where your agents can be orchestrated by external systems.
+
+## Endpoints
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/a2a/{assistant_id}` | POST | JSON-RPC endpoint for a specific assistant |
+| `/.well-known/agent-card.json` | GET | Agent card discovery (default assistant) |
+| `/a2a/agent-cards` | GET | List all agent cards |
+
+## Agent card discovery
+
+Agent cards describe an agent's capabilities and how to interact with it. Use the well-known URL for discovery:
+
+```bash
+curl http://localhost:2026/.well-known/agent-card.json
+```
+
+To list all agents:
+
+```bash
+curl http://localhost:2026/a2a/agent-cards
+```
+
+## Sending a message
+
+Use `message/send` to send a message to an agent and receive a response:
+
+```bash
+curl -X POST http://localhost:2026/a2a/agent \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "message/send",
+    "params": {
+      "message": {
+        "messageId": "msg-1",
+        "role": "user",
+        "parts": [{"kind": "text", "text": "Hello"}]
+      }
+    }
+  }'
+```
+
+## Streaming
+
+Use `message/stream` to receive Server-Sent Events as the agent processes your message:
+
+```bash
+curl -N -X POST http://localhost:2026/a2a/agent \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "message/stream",
+    "params": {
+      "message": {
+        "messageId": "msg-2",
+        "role": "user",
+        "parts": [{"kind": "text", "text": "Hello"}]
+      }
+    }
+  }'
+```
+
+The stream emits `TaskStatusUpdateEvent` and `TaskArtifactUpdateEvent` objects as the agent runs.
+
+## Supported JSON-RPC methods
+
+| Method | Description |
+|--------|-------------|
+| `message/send` | Send a message and get a complete response |
+| `message/stream` | Send a message and stream the response via SSE |
+| `tasks/get` | Retrieve the status and result of a task |
+| `tasks/cancel` | Cancel an in-progress task |
+
+## Task lifecycle
+
+A2A tasks map directly to Aegra's thread and run system:
+
+- **`contextId`** maps to a `thread_id` — represents the ongoing conversation context
+- **`taskId`** maps to a `run_id` — represents a single execution of the agent
+
+When you send a message, the response includes a `taskId` you can use to poll for results with `tasks/get`, or cancel with `tasks/cancel`.
+
+## Authentication
+
+A2A uses the same authentication as the rest of Aegra. If you have an `auth` handler configured in `aegra.json`, all A2A requests go through it.
+
+Pass your token in the `Authorization` header:
+
+```bash
+curl -X POST http://localhost:2026/a2a/agent \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer <your-token>" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"message/send","params":{"message":{"messageId":"msg-1","role":"user","parts":[{"kind":"text","text":"Hello"}]}}}'
+```
+
+If no auth is configured, all A2A requests are allowed.
+
+## Configuration
+
+A2A is enabled by default. To disable it, set `disable_a2a` in the `http` section of `aegra.json`:
+
+```json
+{
+  "graphs": {
+    "agent": "./src/agent/graph.py:graph"
+  },
+  "http": {
+    "disable_a2a": true
+  }
+}
+```
+
+See the [configuration reference](/reference/configuration) for all `http` options.

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,111 @@
+# MCP (Model Context Protocol)
+
+Aegra exposes all configured graphs as MCP tools via the [Model Context Protocol](https://modelcontextprotocol.io/). This lets you use your deployed agents as tools in Claude Desktop, Cursor, and any other MCP-compatible client.
+
+## Overview
+
+When Aegra starts, it automatically creates one MCP tool per graph defined in `aegra.json`. The tool name matches the `graph_id`, and the input schema is auto-discovered from the graph's input schema.
+
+Each tool invocation runs the agent and returns its output. The transport is Streamable HTTP, which supports both request/response and streaming interactions.
+
+## Endpoint
+
+```
+POST /mcp
+```
+
+Aegra exposes a single Streamable HTTP endpoint at `/mcp`. All MCP interactions go through this endpoint using the standard MCP JSON-RPC protocol over HTTP.
+
+## Connecting from Claude Desktop
+
+Add the following to your Claude Desktop configuration (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
+
+```json
+{
+  "mcpServers": {
+    "aegra": {
+      "url": "http://localhost:2026/mcp",
+      "transport": "streamable-http"
+    }
+  }
+}
+```
+
+After restarting Claude Desktop, your Aegra agents will appear as available tools.
+
+## Connecting from Python
+
+```python
+from mcp.client.streamable_http import streamablehttp_client
+from mcp import ClientSession
+
+async with streamablehttp_client(url="http://localhost:2026/mcp") as (read, write, _):
+    async with ClientSession(read, write) as session:
+        await session.initialize()
+        tools = await session.list_tools()
+        print(tools)
+```
+
+## Tool discovery
+
+Each graph becomes one MCP tool:
+
+- **Tool name**: the `graph_id` from `aegra.json` (e.g., `"agent"`, `"assistant"`)
+- **Input schema**: auto-derived from the graph's input schema
+- **Description**: the graph's description if set, otherwise a default description
+
+For example, if `aegra.json` defines:
+
+```json
+{
+  "graphs": {
+    "agent": "./src/agent/graph.py:graph",
+    "researcher": "./src/researcher/graph.py:graph"
+  }
+}
+```
+
+Then two MCP tools are exposed: `agent` and `researcher`.
+
+## Authentication
+
+MCP uses the same authentication as the rest of Aegra. If you have an `auth` handler configured in `aegra.json`, all MCP requests go through it.
+
+For Claude Desktop and other clients that support HTTP headers, pass your token in the `Authorization` header:
+
+```json
+{
+  "mcpServers": {
+    "aegra": {
+      "url": "http://localhost:2026/mcp",
+      "transport": "streamable-http",
+      "headers": {
+        "Authorization": "Bearer <your-token>"
+      }
+    }
+  }
+}
+```
+
+If no auth is configured, all MCP requests are allowed.
+
+## Stateless operation
+
+The MCP endpoint is stateless. Each tool call is an independent request — there are no persistent sessions. State between calls is not maintained at the MCP layer. If you need persistent conversation state, use the Agent Protocol (`/threads` and `/runs`) directly.
+
+## Configuration
+
+MCP is enabled by default. To disable it, set `disable_mcp` in the `http` section of `aegra.json`:
+
+```json
+{
+  "graphs": {
+    "agent": "./src/agent/graph.py:graph"
+  },
+  "http": {
+    "disable_mcp": true
+  }
+}
+```
+
+See the [configuration reference](/reference/configuration) for all `http` options.

--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -37,6 +37,8 @@ aegra dev
   "http": {
     "app": "./custom_routes.py:app",
     "enable_custom_route_auth": false,
+    "disable_a2a": false,
+    "disable_mcp": false,
     "cors": {
       "allow_origins": ["https://example.com"],
       "allow_credentials": true
@@ -239,10 +241,22 @@ Configure custom routes and CORS.
 |-------|------|---------|-------------|
 | `app` | `string` | `None` | Import path to custom FastAPI app |
 | `enable_custom_route_auth` | `bool` | `false` | Apply Aegra auth to all custom routes |
+| `disable_a2a` | `bool` | `false` | Disable the A2A (Agent-to-Agent) protocol endpoint at `/a2a/` |
+| `disable_mcp` | `bool` | `false` | Disable the MCP (Model Context Protocol) endpoint at `/mcp` |
 | `cors.allow_origins` | `list[str]` | `["*"]` | Allowed CORS origins |
 | `cors.allow_credentials` | `bool` | `false` when origins is `["*"]`, `true` otherwise | Allow credentials in CORS requests |
 
 See [custom routes guide](/guides/custom-routes) for details.
+
+### `disable_a2a`
+- **Type:** `boolean`
+- **Default:** `false`
+- Disable the A2A (Agent-to-Agent) protocol endpoint at `/a2a/`.
+
+### `disable_mcp`
+- **Type:** `boolean`
+- **Default:** `false`
+- Disable the MCP (Model Context Protocol) endpoint at `/mcp`.
 
 ## `store`
 

--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -241,7 +241,7 @@ Configure custom routes and CORS.
 |-------|------|---------|-------------|
 | `app` | `string` | `None` | Import path to custom FastAPI app |
 | `enable_custom_route_auth` | `bool` | `false` | Apply Aegra auth to all custom routes |
-| `disable_a2a` | `bool` | `false` | Disable the A2A (Agent-to-Agent) protocol endpoint at `/a2a/` |
+| `disable_a2a` | `bool` | `false` | Disable `/a2a/` and associated discovery routes (`/.well-known/agent-card.json`, `/a2a/agent-cards`) |
 | `disable_mcp` | `bool` | `false` | Disable the MCP (Model Context Protocol) endpoint at `/mcp` |
 | `cors.allow_origins` | `list[str]` | `["*"]` | Allowed CORS origins |
 | `cors.allow_credentials` | `bool` | `false` when origins is `["*"]`, `true` otherwise | Allow credentials in CORS requests |
@@ -251,7 +251,7 @@ See [custom routes guide](/guides/custom-routes) for details.
 ### `disable_a2a`
 - **Type:** `boolean`
 - **Default:** `false`
-- Disable the A2A (Agent-to-Agent) protocol endpoint at `/a2a/`.
+- Disable the A2A (Agent-to-Agent) protocol adapter entirely. This removes the JSON-RPC endpoint at `/a2a/{assistant_id}` and all associated discovery routes (`/.well-known/agent-card.json`, `/a2a/agent-cards`).
 
 ### `disable_mcp`
 - **Type:** `boolean`

--- a/libs/aegra-api/README.md
+++ b/libs/aegra-api/README.md
@@ -7,6 +7,8 @@ Aegra is an open-source, self-hosted alternative to LangSmith Deployments. This 
 ## Features
 
 - **Agent Protocol Compliant**: Works with Agent Chat UI, LangGraph Studio, CopilotKit
+- **A2A Protocol**: Agent-to-Agent communication for multi-agent workflows
+- **MCP Support**: Exposes agents as MCP tools for Claude Desktop, Cursor, and other MCP clients
 - **Drop-in Replacement**: Compatible with the LangGraph SDK
 - **Self-Hosted**: Run on your own PostgreSQL database
 - **Streaming Support**: Real-time streaming of agent responses
@@ -119,6 +121,10 @@ OTEL_TARGETS=LANGFUSE,PHOENIX
 | `/store` | PUT | Save to vector store |
 | `/store/search` | POST | Semantic search |
 | `/health` | GET | Health check |
+| `/mcp` | POST | MCP (Model Context Protocol) Streamable HTTP endpoint |
+| `/a2a/{assistant_id}` | POST | A2A JSON-RPC endpoint |
+| `/.well-known/agent-card.json` | GET | A2A agent card discovery |
+| `/a2a/agent-cards` | GET | List all A2A agent cards |
 
 ## Creating Graphs
 

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.8.3"
+version = "0.8.4"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -44,6 +44,10 @@ dependencies = [
     # Utils
     "structlog>=25.4.0",
     "asgi-correlation-id>=4.3.4",
+
+    # Protocol adapters
+    "mcp>=1.26.0",
+    "a2a-sdk[http-server]>=0.3.25",
 ]
 
 [project.urls]

--- a/libs/aegra-api/src/aegra_api/adapters/__init__.py
+++ b/libs/aegra-api/src/aegra_api/adapters/__init__.py
@@ -1,0 +1,5 @@
+"""Protocol adapters for A2A and MCP.
+
+These adapters wrap the existing Agent Protocol services to expose graphs
+via additional protocols. Each adapter is a thin translation layer.
+"""

--- a/libs/aegra-api/src/aegra_api/adapters/a2a_adapter.py
+++ b/libs/aegra-api/src/aegra_api/adapters/a2a_adapter.py
@@ -5,6 +5,7 @@ discovery at /.well-known/agent-card.json.
 Uses the `a2a-sdk` library.
 """
 
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 import structlog
@@ -58,7 +59,7 @@ def _rpc_error(code: int, message: str, rpc_id: Any) -> dict[str, Any]:
 # ---------------------------------------------------------------------------
 
 
-def _make_well_known_handler(service: A2AService):  # type: ignore[return]
+def _make_well_known_handler(service: A2AService) -> Callable[..., Awaitable[JSONResponse]]:
     """Return a route handler for GET /.well-known/agent-card.json.
 
     Args:
@@ -121,7 +122,7 @@ def _make_well_known_handler(service: A2AService):  # type: ignore[return]
     return _well_known_agent_card
 
 
-def _make_agent_cards_handler(service: A2AService):  # type: ignore[return]
+def _make_agent_cards_handler(service: A2AService) -> Callable[..., Awaitable[JSONResponse]]:
     """Return a route handler for GET /a2a/agent-cards.
 
     Args:
@@ -167,7 +168,7 @@ def _make_agent_cards_handler(service: A2AService):  # type: ignore[return]
     return _list_agent_cards
 
 
-def _make_rpc_handler(service: A2AService):  # type: ignore[return]
+def _make_rpc_handler(service: A2AService) -> Callable[..., Awaitable[Response]]:
     """Return a route handler for POST /a2a/{assistant_id}.
 
     Args:
@@ -229,7 +230,7 @@ def _make_rpc_handler(service: A2AService):  # type: ignore[return]
                 logger.error(
                     "A2A send_message error", error=str(exc), assistant_id=assistant_id
                 )
-                return JSONResponse(content=_rpc_error(-32603, f"Internal error: {exc}", rpc_id))
+                return JSONResponse(content=_rpc_error(-32603, "Internal server error", rpc_id))
             return JSONResponse(content=_rpc_ok(result, rpc_id))
 
         if method == "tasks/get":
@@ -241,12 +242,12 @@ def _make_rpc_handler(service: A2AService):  # type: ignore[return]
                     content=_rpc_error(-32602, "Missing required param: id", rpc_id)
                 )
             try:
-                task_result: dict[str, Any] = await service.get_task(task_id_param)
+                task_result: dict[str, Any] = await service.get_task(task_id_param, user)
             except ValueError as exc:
                 return JSONResponse(content=_rpc_error(-32602, str(exc), rpc_id))
             except Exception as exc:
                 logger.error("A2A get_task error", error=str(exc), task_id=task_id_param)
-                return JSONResponse(content=_rpc_error(-32603, f"Internal error: {exc}", rpc_id))
+                return JSONResponse(content=_rpc_error(-32603, "Internal server error", rpc_id))
             return JSONResponse(content=_rpc_ok(task_result, rpc_id))
 
         if method == "tasks/cancel":
@@ -259,12 +260,12 @@ def _make_rpc_handler(service: A2AService):  # type: ignore[return]
                 )
             try:
                 await streaming_service.cancel_run(cancel_task_id)
-                cancelled_task: dict[str, Any] = await service.get_task(cancel_task_id)
+                cancelled_task: dict[str, Any] = await service.get_task(cancel_task_id, user)
             except ValueError as exc:
                 return JSONResponse(content=_rpc_error(-32602, str(exc), rpc_id))
             except Exception as exc:
                 logger.error("A2A tasks/cancel error", error=str(exc), task_id=cancel_task_id)
-                return JSONResponse(content=_rpc_error(-32603, f"Internal error: {exc}", rpc_id))
+                return JSONResponse(content=_rpc_error(-32603, "Internal server error", rpc_id))
             return JSONResponse(content=_rpc_ok(cancelled_task, rpc_id))
 
         if method == "message/stream":
@@ -295,7 +296,7 @@ def _make_rpc_handler(service: A2AService):  # type: ignore[return]
                 logger.error(
                     "A2A message/stream error", error=str(exc), assistant_id=assistant_id
                 )
-                return JSONResponse(content=_rpc_error(-32603, f"Internal error: {exc}", rpc_id))
+                return JSONResponse(content=_rpc_error(-32603, "Internal server error", rpc_id))
 
         return JSONResponse(
             content=_rpc_error(-32601, f"Method not found: {method!r}", rpc_id)
@@ -326,6 +327,9 @@ def mount_a2a(app: FastAPI) -> None:
     """
     service: A2AService = get_a2a_service()
 
+    # Discovery endpoints are intentionally unauthenticated per the A2A spec.
+    # Agent cards are public metadata (graph IDs, capabilities) — not sensitive.
+    # This matches LangSmith's behavior.
     app.add_api_route(
         "/.well-known/agent-card.json",
         _make_well_known_handler(service),

--- a/libs/aegra-api/src/aegra_api/adapters/a2a_adapter.py
+++ b/libs/aegra-api/src/aegra_api/adapters/a2a_adapter.py
@@ -1,0 +1,353 @@
+"""A2A (Agent-to-Agent) protocol adapter.
+
+Exposes agents via A2A JSON-RPC at /a2a/{assistant_id} with agent card
+discovery at /.well-known/agent-card.json.
+Uses the `a2a-sdk` library.
+"""
+
+from typing import Any
+
+import structlog
+from fastapi import Depends, FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse, StreamingResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.responses import Response
+
+from aegra_api.adapters.a2a_service import A2AService, get_a2a_service
+from aegra_api.core.auth_deps import get_current_user
+from aegra_api.core.orm import get_session
+from aegra_api.models.auth import User
+from aegra_api.services.streaming_service import streaming_service
+
+logger = structlog.get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# JSON-RPC helpers
+# ---------------------------------------------------------------------------
+
+
+def _rpc_ok(result: Any, rpc_id: Any) -> dict[str, Any]:
+    """Build a JSON-RPC 2.0 success response.
+
+    Args:
+        result: The result payload to include.
+        rpc_id: The id from the original request.
+
+    Returns:
+        JSON-RPC success response dict.
+    """
+    return {"jsonrpc": "2.0", "result": result, "id": rpc_id}
+
+
+def _rpc_error(code: int, message: str, rpc_id: Any) -> dict[str, Any]:
+    """Build a JSON-RPC 2.0 error response.
+
+    Args:
+        code: The JSON-RPC error code.
+        message: Human-readable error description.
+        rpc_id: The id from the original request.
+
+    Returns:
+        JSON-RPC error response dict.
+    """
+    return {"jsonrpc": "2.0", "error": {"code": code, "message": message}, "id": rpc_id}
+
+
+# ---------------------------------------------------------------------------
+# Route handler factories (closures capture the service instance)
+# ---------------------------------------------------------------------------
+
+
+def _make_well_known_handler(service: A2AService):  # type: ignore[return]
+    """Return a route handler for GET /.well-known/agent-card.json.
+
+    Args:
+        service: The A2AService instance to use for building cards.
+
+    Returns:
+        An async route handler function.
+    """
+
+    async def _well_known_agent_card(
+        request: Request, assistant_id: str | None = None
+    ) -> JSONResponse:
+        """Return the agent card for the given assistant or the first registered agent.
+
+        Args:
+            request: The incoming FastAPI request (used to derive base URL).
+            assistant_id: Optional query param to select a specific agent.
+
+        Returns:
+            JSONResponse with the agent card dict.
+
+        Raises:
+            HTTPException: 404 when no agents are registered or assistant_id is unknown.
+        """
+        registry: dict[str, Any] = (
+            service._langgraph_service._graph_registry if service._langgraph_service else {}
+        )
+
+        if not registry:
+            raise HTTPException(status_code=404, detail="No agents registered")
+
+        if assistant_id is not None:
+            if assistant_id not in registry:
+                raise HTTPException(
+                    status_code=404, detail=f"Unknown assistant_id: {assistant_id!r}"
+                )
+            target_id = assistant_id
+        else:
+            target_id = next(iter(registry))
+
+        graph_meta: Any = registry[target_id]
+        name: str = (
+            graph_meta.get("name", target_id) if isinstance(graph_meta, dict) else target_id
+        )
+        description: str = (
+            graph_meta.get("description", f"Agent: {target_id}")
+            if isinstance(graph_meta, dict)
+            else f"Agent: {target_id}"
+        )
+
+        base_url: str = str(request.base_url).rstrip("/")
+        card: dict[str, Any] = service.build_agent_card(
+            assistant_id=target_id,
+            name=name,
+            description=description,
+            base_url=base_url,
+        )
+        return JSONResponse(content=card)
+
+    return _well_known_agent_card
+
+
+def _make_agent_cards_handler(service: A2AService):  # type: ignore[return]
+    """Return a route handler for GET /a2a/agent-cards.
+
+    Args:
+        service: The A2AService instance to use for building cards.
+
+    Returns:
+        An async route handler function.
+    """
+
+    async def _list_agent_cards(request: Request) -> JSONResponse:
+        """Return an array of agent cards for all registered agents.
+
+        Args:
+            request: The incoming FastAPI request (used to derive base URL).
+
+        Returns:
+            JSONResponse with a JSON array of agent card dicts.
+        """
+        registry: dict[str, Any] = (
+            service._langgraph_service._graph_registry if service._langgraph_service else {}
+        )
+
+        base_url: str = str(request.base_url).rstrip("/")
+        cards: list[dict[str, Any]] = []
+        for agent_id, graph_meta in registry.items():
+            name: str = (
+                graph_meta.get("name", agent_id) if isinstance(graph_meta, dict) else agent_id
+            )
+            description: str = (
+                graph_meta.get("description", f"Agent: {agent_id}")
+                if isinstance(graph_meta, dict)
+                else f"Agent: {agent_id}"
+            )
+            card: dict[str, Any] = service.build_agent_card(
+                assistant_id=agent_id,
+                name=name,
+                description=description,
+                base_url=base_url,
+            )
+            cards.append(card)
+        return JSONResponse(content=cards)
+
+    return _list_agent_cards
+
+
+def _make_rpc_handler(service: A2AService):  # type: ignore[return]
+    """Return a route handler for POST /a2a/{assistant_id}.
+
+    Args:
+        service: The A2AService instance to dispatch JSON-RPC calls to.
+
+    Returns:
+        An async route handler function.
+    """
+
+    async def _a2a_rpc(
+        request: Request,
+        assistant_id: str,
+        user: User = Depends(get_current_user),
+        session: AsyncSession = Depends(get_session),
+    ) -> Response:
+        """Handle A2A JSON-RPC requests for a specific agent.
+
+        Parses the JSON-RPC body and dispatches to the appropriate A2AService
+        method based on the ``method`` field.
+
+        Supported methods:
+        - ``message/send``: Execute the agent and return the resulting Task.
+        - ``tasks/get``: Look up an existing task by ID.
+        - ``tasks/cancel``: Cancel a running task and return its updated state.
+        - ``message/stream``: Not yet implemented; returns -32603 error.
+
+        Args:
+            request: The incoming FastAPI request.
+            assistant_id: Path parameter identifying the target agent.
+
+        Returns:
+            JSONResponse containing a JSON-RPC 2.0 response envelope.
+        """
+        try:
+            body: dict[str, Any] = await request.json()
+        except Exception:
+            return JSONResponse(content=_rpc_error(-32700, "Parse error: invalid JSON", None))
+
+        rpc_id: Any = body.get("id")
+        method: str = body.get("method", "")
+        params: dict[str, Any] = body.get("params") or {}
+
+        if method == "message/send":
+            message: dict[str, Any] = params.get("message") or {}
+            parts: list[dict[str, Any]] = message.get("parts") or []
+            context_id: str | None = params.get("contextId") or message.get("contextId")
+            task_id: str | None = params.get("taskId") or message.get("taskId")
+            try:
+                result: dict[str, Any] = await service.send_message(
+                    assistant_id=assistant_id,
+                    parts=parts,
+                    user=user,
+                    context_id=context_id,
+                    task_id=task_id,
+                )
+            except ValueError as exc:
+                return JSONResponse(content=_rpc_error(-32602, str(exc), rpc_id))
+            except Exception as exc:
+                logger.error(
+                    "A2A send_message error", error=str(exc), assistant_id=assistant_id
+                )
+                return JSONResponse(content=_rpc_error(-32603, f"Internal error: {exc}", rpc_id))
+            return JSONResponse(content=_rpc_ok(result, rpc_id))
+
+        if method == "tasks/get":
+            task_id_param: str | None = (
+                params.get("id") or params.get("taskId")
+            ) if params else None
+            if not task_id_param:
+                return JSONResponse(
+                    content=_rpc_error(-32602, "Missing required param: id", rpc_id)
+                )
+            try:
+                task_result: dict[str, Any] = await service.get_task(task_id_param)
+            except ValueError as exc:
+                return JSONResponse(content=_rpc_error(-32602, str(exc), rpc_id))
+            except Exception as exc:
+                logger.error("A2A get_task error", error=str(exc), task_id=task_id_param)
+                return JSONResponse(content=_rpc_error(-32603, f"Internal error: {exc}", rpc_id))
+            return JSONResponse(content=_rpc_ok(task_result, rpc_id))
+
+        if method == "tasks/cancel":
+            cancel_task_id: str | None = (
+                params.get("id") or params.get("taskId")
+            ) if params else None
+            if not cancel_task_id:
+                return JSONResponse(
+                    content=_rpc_error(-32602, "Missing required param: id", rpc_id)
+                )
+            try:
+                await streaming_service.cancel_run(cancel_task_id)
+                cancelled_task: dict[str, Any] = await service.get_task(cancel_task_id)
+            except ValueError as exc:
+                return JSONResponse(content=_rpc_error(-32602, str(exc), rpc_id))
+            except Exception as exc:
+                logger.error("A2A tasks/cancel error", error=str(exc), task_id=cancel_task_id)
+                return JSONResponse(content=_rpc_error(-32603, f"Internal error: {exc}", rpc_id))
+            return JSONResponse(content=_rpc_ok(cancelled_task, rpc_id))
+
+        if method == "message/stream":
+            message = params.get("message") or {}
+            parts = message.get("parts") or []
+            context_id = params.get("contextId") or message.get("contextId")
+            task_id = params.get("taskId") or message.get("taskId")
+            try:
+                event_stream = service.stream_message(
+                    assistant_id=assistant_id,
+                    parts=parts,
+                    user=user,
+                    session=session,
+                    context_id=context_id,
+                    task_id=task_id,
+                )
+                return StreamingResponse(
+                    event_stream,
+                    media_type="text/event-stream",
+                    headers={
+                        "Cache-Control": "no-cache",
+                        "Connection": "keep-alive",
+                    },
+                )
+            except ValueError as exc:
+                return JSONResponse(content=_rpc_error(-32602, str(exc), rpc_id))
+            except Exception as exc:
+                logger.error(
+                    "A2A message/stream error", error=str(exc), assistant_id=assistant_id
+                )
+                return JSONResponse(content=_rpc_error(-32603, f"Internal error: {exc}", rpc_id))
+
+        return JSONResponse(
+            content=_rpc_error(-32601, f"Method not found: {method!r}", rpc_id)
+        )
+
+    return _a2a_rpc
+
+
+# ---------------------------------------------------------------------------
+# Adapter mount
+# ---------------------------------------------------------------------------
+
+
+def mount_a2a(app: FastAPI) -> None:
+    """Mount A2A endpoints on the FastAPI app.
+
+    Registers:
+    - GET /.well-known/agent-card.json - Agent card discovery
+    - GET /a2a/agent-cards        - List all agent cards (Aegra extension)
+    - POST /a2a/{assistant_id}    - JSON-RPC endpoint
+
+    Route handlers are built as closures capturing the A2AService singleton so
+    that tests can inject a custom service instance via a patch on
+    ``get_a2a_service`` before calling this function.
+
+    Args:
+        app: The FastAPI application to mount on.
+    """
+    service: A2AService = get_a2a_service()
+
+    app.add_api_route(
+        "/.well-known/agent-card.json",
+        _make_well_known_handler(service),
+        methods=["GET"],
+        include_in_schema=False,
+    )
+    # /a2a/agent-cards MUST be registered before /a2a/{assistant_id} so the
+    # static path wins over the dynamic one.
+    app.add_api_route(
+        "/a2a/agent-cards",
+        _make_agent_cards_handler(service),
+        methods=["GET"],
+        include_in_schema=False,
+    )
+    app.add_api_route(
+        "/a2a/{assistant_id}",
+        _make_rpc_handler(service),
+        methods=["POST"],
+        include_in_schema=False,
+        response_model=None,
+    )
+    logger.info(
+        "A2A adapter mounted",
+        routes=["/.well-known/agent-card.json", "/a2a/agent-cards", "/a2a/{assistant_id}"],
+    )

--- a/libs/aegra-api/src/aegra_api/adapters/a2a_service.py
+++ b/libs/aegra-api/src/aegra_api/adapters/a2a_service.py
@@ -52,6 +52,7 @@ RUN_STATUS_TO_TASK_STATE: dict[str, str] = {
     "running": "working",
     "success": "completed",
     "error": "failed",
+    "timeout": "failed",
     "interrupted": "input-required",
 }
 
@@ -208,7 +209,11 @@ class A2AService:
             ValueError: If any message part is not a text part.
             ValueError: If ``assistant_id`` is not a known graph in the
                 registry.
+            RuntimeError: If the LangGraph service has not been initialized.
         """
+        if not self._langgraph_service:
+            raise RuntimeError("LangGraph service not initialized")
+
         registry: dict[str, Any] = self._langgraph_service._graph_registry
 
         # Resolve graph_id: if assistant_id is already a graph key use it
@@ -277,6 +282,9 @@ class A2AService:
         Yields:
             SSE-formatted strings containing A2A streaming events.
         """
+        if not self._langgraph_service:
+            raise RuntimeError("LangGraph service not initialized")
+
         registry: dict[str, Any] = self._langgraph_service._graph_registry
         graph_id = assistant_id if assistant_id in registry else assistant_id
         resolved_assistant_id = resolve_assistant_id(graph_id, registry)

--- a/libs/aegra-api/src/aegra_api/adapters/a2a_service.py
+++ b/libs/aegra-api/src/aegra_api/adapters/a2a_service.py
@@ -12,6 +12,8 @@ status management. Threads are preserved (not deleted) so that
 multi-turn conversations maintain history.
 """
 
+from __future__ import annotations
+
 import json
 from collections.abc import AsyncIterator
 from typing import Any
@@ -39,6 +41,7 @@ from aegra_api.api.runs import create_and_stream_run, wait_for_run
 from aegra_api.core.orm import Run as RunORM
 from aegra_api.core.orm import _get_session_maker
 from aegra_api.models import RunCreate, User
+from aegra_api.services.langgraph_service import LangGraphService
 from aegra_api.utils.assistants import resolve_assistant_id
 
 logger = structlog.get_logger(__name__)
@@ -104,9 +107,13 @@ def convert_output_to_parts(output: dict[str, Any]) -> list[dict[str, Any]]:
     messages: list[Any] = output.get("messages", [])
     parts: list[dict[str, Any]] = []
     for msg in messages:
-        if not isinstance(msg, AIMessage):
+        if isinstance(msg, AIMessage):
+            content = msg.content
+        elif isinstance(msg, dict) and msg.get("type") in ("ai", "AIMessage", "AIMessageChunk"):
+            content = msg.get("content", "")
+        else:
             continue
-        content = msg.content
+
         if isinstance(content, str):
             parts.append({"kind": "text", "text": content})
         elif isinstance(content, list):
@@ -129,9 +136,9 @@ class A2AService:
     """
 
     def __init__(self) -> None:
-        self._langgraph_service: Any = None
+        self._langgraph_service: LangGraphService | None = None
 
-    def set_langgraph_service(self, service: Any) -> None:
+    def set_langgraph_service(self, service: LangGraphService) -> None:
         """Inject the LangGraphService dependency.
 
         Args:
@@ -216,9 +223,7 @@ class A2AService:
 
         registry: dict[str, Any] = self._langgraph_service._graph_registry
 
-        # Resolve graph_id: if assistant_id is already a graph key use it
-        # directly; otherwise use it as-is for resolve_assistant_id.
-        graph_id = assistant_id if assistant_id in registry else assistant_id
+        graph_id = assistant_id
         resolved_assistant_id = resolve_assistant_id(graph_id, registry)
 
         # Convert parts to LangChain messages
@@ -234,6 +239,24 @@ class A2AService:
 
         output = await wait_for_run(thread_id, request, user)
 
+        # Look up actual run status from DB
+        maker = _get_session_maker()
+        async with maker() as db_session:
+            latest_run: RunORM | None = await db_session.scalar(
+                select(RunORM)
+                .where(RunORM.thread_id == thread_id, RunORM.user_id == user.identity)
+                .order_by(RunORM.created_at.desc())
+                .limit(1)
+            )
+
+        if latest_run:
+            actual_status = RUN_STATUS_TO_TASK_STATE.get(latest_run.status or "pending", "unknown")
+            actual_task_state = TaskState(actual_status)
+            effective_task_id = latest_run.run_id
+        else:
+            actual_task_state = TaskState.completed
+            effective_task_id = task_id or str(uuid4())
+
         # Build A2A response
         output_parts = convert_output_to_parts(output)
         a2a_parts = [Part(root=TextPart(text=p["text"])) for p in output_parts]
@@ -242,14 +265,10 @@ class A2AService:
             [Artifact(artifactId="output", parts=a2a_parts)] if a2a_parts else None
         )
 
-        # Read the actual run_id from the DB (wait_for_run creates it internally)
-        # For now, use task_id if provided, otherwise generate one
-        effective_task_id = task_id or str(uuid4())
-
         task = Task(
             id=effective_task_id,
             contextId=thread_id,
-            status=TaskStatus(state=TaskState.completed),
+            status=TaskStatus(state=actual_task_state),
             artifacts=artifacts,
         )
         return task.model_dump(by_alias=True)
@@ -286,7 +305,7 @@ class A2AService:
             raise RuntimeError("LangGraph service not initialized")
 
         registry: dict[str, Any] = self._langgraph_service._graph_registry
-        graph_id = assistant_id if assistant_id in registry else assistant_id
+        graph_id = assistant_id
         resolved_assistant_id = resolve_assistant_id(graph_id, registry)
 
         langchain_messages = convert_parts_to_langchain(parts)
@@ -315,7 +334,10 @@ class A2AService:
 
         # Convert Agent Protocol SSE events to A2A events
         accumulated_text = ""
+        stream_ended = False
         async for chunk in streaming_response.body_iterator:
+            if stream_ended:
+                break
             if not isinstance(chunk, str):
                 chunk = chunk.decode("utf-8") if isinstance(chunk, bytes) else str(chunk)
 
@@ -350,6 +372,7 @@ class A2AService:
 
                 elif line.startswith("event: end"):
                     # Stream ended — emit final artifact and completed status
+                    stream_ended = True
                     break
 
         # Emit final artifact chunk if we accumulated text
@@ -375,11 +398,12 @@ class A2AService:
         )
         yield f"data: {completed_event.model_dump_json(by_alias=True)}\n\n"
 
-    async def get_task(self, task_id: str) -> dict[str, Any]:
+    async def get_task(self, task_id: str, user: User) -> dict[str, Any]:
         """Look up a task by its run ID and return the A2A Task dict.
 
         Args:
             task_id: The run ID (A2A task ID) to look up.
+            user: The authenticated user making the request.
 
         Returns:
             A2A Task dict with the current status.
@@ -390,7 +414,10 @@ class A2AService:
         maker = _get_session_maker()
         async with maker() as session:
             run_record: RunORM | None = await session.scalar(
-                select(RunORM).where(RunORM.run_id == task_id)
+                select(RunORM).where(
+                    RunORM.run_id == task_id,
+                    RunORM.user_id == user.identity,
+                )
             )
 
         if run_record is None:

--- a/libs/aegra-api/src/aegra_api/adapters/a2a_service.py
+++ b/libs/aegra-api/src/aegra_api/adapters/a2a_service.py
@@ -1,0 +1,424 @@
+"""A2A (Agent-to-Agent) service layer.
+
+Maps A2A protocol concepts to Agent Protocol concepts:
+- contextId -> thread_id
+- taskId -> run_id
+- A2A Message parts -> LangGraph messages
+- Run status -> A2A TaskState
+
+Graph execution is delegated to ``wait_for_run`` from the runs API,
+which handles thread creation, run creation, graph execution, and
+status management. Threads are preserved (not deleted) so that
+multi-turn conversations maintain history.
+"""
+
+import json
+from collections.abc import AsyncIterator
+from typing import Any
+from uuid import uuid4
+
+import structlog
+from a2a.types import (
+    AgentCapabilities,
+    AgentCard,
+    AgentSkill,
+    Artifact,
+    Part,
+    Task,
+    TaskArtifactUpdateEvent,
+    TaskState,
+    TaskStatus,
+    TaskStatusUpdateEvent,
+    TextPart,
+)
+from langchain_core.messages import AIMessage, HumanMessage
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from aegra_api.api.runs import create_and_stream_run, wait_for_run
+from aegra_api.core.orm import Run as RunORM
+from aegra_api.core.orm import _get_session_maker
+from aegra_api.models import RunCreate, User
+from aegra_api.utils.assistants import resolve_assistant_id
+
+logger = structlog.get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Status mapping
+# ---------------------------------------------------------------------------
+
+RUN_STATUS_TO_TASK_STATE: dict[str, str] = {
+    "pending": "submitted",
+    "running": "working",
+    "success": "completed",
+    "error": "failed",
+    "interrupted": "input-required",
+}
+
+# ---------------------------------------------------------------------------
+# Part conversion helpers
+# ---------------------------------------------------------------------------
+
+
+def convert_parts_to_langchain(parts: list[dict[str, Any]]) -> list[HumanMessage]:
+    """Convert A2A message parts to LangChain HumanMessage objects.
+
+    Only text parts are supported. Any non-text part raises ``ValueError``.
+
+    Args:
+        parts: List of A2A part dicts, each with a ``kind`` field.
+
+    Returns:
+        List of ``HumanMessage`` instances, one per text part.
+
+    Raises:
+        ValueError: If any part has a ``kind`` other than ``"text"``.
+    """
+    messages: list[HumanMessage] = []
+    for part in parts:
+        kind = part.get("kind", "text")
+        if kind != "text":
+            raise ValueError(
+                f"Unsupported part kind {kind!r}: only 'text' parts are supported"
+            )
+        text_content: str = part.get("text", "")
+        messages.append(HumanMessage(content=text_content))
+    return messages
+
+
+def convert_output_to_parts(output: dict[str, Any]) -> list[dict[str, Any]]:
+    """Convert LangGraph graph output to A2A text part dicts.
+
+    Extracts AI messages from ``output["messages"]`` and converts each to a
+    text part dict. Non-AI messages are skipped. Returns an empty list when
+    the output contains no messages key.
+
+    Args:
+        output: Final output dict from a LangGraph run, typically
+            ``{"messages": [...]}``.
+
+    Returns:
+        List of text part dicts with ``kind`` and ``text`` keys.
+    """
+    messages: list[Any] = output.get("messages", [])
+    parts: list[dict[str, Any]] = []
+    for msg in messages:
+        if not isinstance(msg, AIMessage):
+            continue
+        content = msg.content
+        if isinstance(content, str):
+            parts.append({"kind": "text", "text": content})
+        elif isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict) and block.get("type") == "text":
+                    parts.append({"kind": "text", "text": block.get("text", "")})
+    return parts
+
+
+# ---------------------------------------------------------------------------
+# A2AService
+# ---------------------------------------------------------------------------
+
+
+class A2AService:
+    """Service that maps A2A protocol operations to Agent Protocol runs.
+
+    Wraps graph execution with A2A semantics: context IDs map to threads,
+    task IDs map to run IDs, and A2A message parts map to LangChain messages.
+    """
+
+    def __init__(self) -> None:
+        self._langgraph_service: Any = None
+
+    def set_langgraph_service(self, service: Any) -> None:
+        """Inject the LangGraphService dependency.
+
+        Args:
+            service: A configured ``LangGraphService`` instance.
+        """
+        self._langgraph_service = service
+
+    def build_agent_card(
+        self,
+        *,
+        assistant_id: str,
+        name: str,
+        description: str,
+        base_url: str,
+    ) -> dict[str, Any]:
+        """Build an A2A agent card for the given assistant.
+
+        Args:
+            assistant_id: The assistant/graph ID used to construct the URL.
+            name: Human-readable agent name.
+            description: Human-readable description of what the agent does.
+            base_url: Base URL of the server (e.g. ``http://localhost:2026``).
+
+        Returns:
+            Agent card as a JSON-serialisable dict.
+        """
+        card = AgentCard(
+            name=name,
+            description=description,
+            url=f"{base_url}/a2a/{assistant_id}",
+            version="1.0.0",
+            capabilities=AgentCapabilities(),
+            defaultInputModes=["text"],
+            defaultOutputModes=["text"],
+            skills=[
+                AgentSkill(
+                    id="default",
+                    name="Default",
+                    description=description,
+                    tags=[],
+                )
+            ],
+        )
+        return card.model_dump(by_alias=True)
+
+    async def send_message(
+        self,
+        *,
+        assistant_id: str,
+        parts: list[dict[str, Any]],
+        user: User,
+        context_id: str | None = None,
+        task_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Send a message to an agent and return the resulting A2A Task.
+
+        Delegates to ``wait_for_run`` from the runs API, which handles
+        thread creation, run creation, graph execution, and waiting for
+        output. Threads are preserved so subsequent turns in the same
+        context can access conversation history.
+
+        Args:
+            assistant_id: Graph ID or assistant UUID to run.
+            parts: List of A2A part dicts representing the incoming message.
+            user: The authenticated user making the request.
+            context_id: Existing thread ID to reuse; a new one is created when
+                ``None``.
+            task_id: Explicit run ID; a UUID is generated when ``None``.
+
+        Returns:
+            A2A Task dict with ``id``, ``contextId``, ``status``, and
+            ``artifacts`` fields.
+
+        Raises:
+            ValueError: If any message part is not a text part.
+            ValueError: If ``assistant_id`` is not a known graph in the
+                registry.
+        """
+        registry: dict[str, Any] = self._langgraph_service._graph_registry
+
+        # Resolve graph_id: if assistant_id is already a graph key use it
+        # directly; otherwise use it as-is for resolve_assistant_id.
+        graph_id = assistant_id if assistant_id in registry else assistant_id
+        resolved_assistant_id = resolve_assistant_id(graph_id, registry)
+
+        # Convert parts to LangChain messages
+        langchain_messages = convert_parts_to_langchain(parts)
+        input_data: dict[str, Any] = {"messages": langchain_messages}
+
+        thread_id = context_id if context_id is not None else str(uuid4())
+
+        request = RunCreate(
+            assistant_id=resolved_assistant_id,
+            input=input_data,
+        )
+
+        output = await wait_for_run(thread_id, request, user)
+
+        # Build A2A response
+        output_parts = convert_output_to_parts(output)
+        a2a_parts = [Part(root=TextPart(text=p["text"])) for p in output_parts]
+
+        artifacts: list[Artifact] | None = (
+            [Artifact(artifactId="output", parts=a2a_parts)] if a2a_parts else None
+        )
+
+        # Read the actual run_id from the DB (wait_for_run creates it internally)
+        # For now, use task_id if provided, otherwise generate one
+        effective_task_id = task_id or str(uuid4())
+
+        task = Task(
+            id=effective_task_id,
+            contextId=thread_id,
+            status=TaskStatus(state=TaskState.completed),
+            artifacts=artifacts,
+        )
+        return task.model_dump(by_alias=True)
+
+    async def stream_message(
+        self,
+        *,
+        assistant_id: str,
+        parts: list[dict[str, Any]],
+        user: User,
+        session: AsyncSession,
+        context_id: str | None = None,
+        task_id: str | None = None,
+    ) -> AsyncIterator[str]:
+        """Stream a message to an agent, yielding A2A SSE events.
+
+        Delegates to ``create_and_stream_run`` from the runs API, then
+        converts Agent Protocol SSE events to A2A streaming events
+        (``TaskStatusUpdateEvent`` and ``TaskArtifactUpdateEvent``).
+
+        Args:
+            assistant_id: Graph ID or assistant UUID to run.
+            parts: List of A2A part dicts representing the incoming message.
+            user: The authenticated user making the request.
+            session: Database session for run creation.
+            context_id: Existing thread ID to reuse; a new one is created when
+                ``None``.
+            task_id: Explicit task ID; a UUID is generated when ``None``.
+
+        Yields:
+            SSE-formatted strings containing A2A streaming events.
+        """
+        registry: dict[str, Any] = self._langgraph_service._graph_registry
+        graph_id = assistant_id if assistant_id in registry else assistant_id
+        resolved_assistant_id = resolve_assistant_id(graph_id, registry)
+
+        langchain_messages = convert_parts_to_langchain(parts)
+        input_data: dict[str, Any] = {"messages": langchain_messages}
+
+        thread_id = context_id if context_id is not None else str(uuid4())
+        effective_task_id = task_id or str(uuid4())
+
+        request = RunCreate(
+            assistant_id=resolved_assistant_id,
+            input=input_data,
+            stream_mode=["messages"],
+        )
+
+        # Get the streaming response from the runs API
+        streaming_response = await create_and_stream_run(thread_id, request, user, session)
+
+        # Emit initial status: working
+        working_event = TaskStatusUpdateEvent(
+            taskId=effective_task_id,
+            contextId=thread_id,
+            status=TaskStatus(state=TaskState.working),
+            final=False,
+        )
+        yield f"data: {working_event.model_dump_json(by_alias=True)}\n\n"
+
+        # Convert Agent Protocol SSE events to A2A events
+        accumulated_text = ""
+        async for chunk in streaming_response.body_iterator:
+            if not isinstance(chunk, str):
+                chunk = chunk.decode("utf-8") if isinstance(chunk, bytes) else str(chunk)
+
+            # Parse SSE format: "event: <type>\ndata: <json>\n\n"
+            for line in chunk.strip().split("\n"):
+                if line.startswith("data: "):
+                    data_str = line[6:]
+                    try:
+                        event_data = json.loads(data_str)
+                    except (json.JSONDecodeError, TypeError):
+                        continue
+
+                    # Convert messages/partial events to artifact updates
+                    if isinstance(event_data, list):
+                        # Messages stream mode returns [message_chunk, metadata]
+                        for item in event_data:
+                            if isinstance(item, dict):
+                                content = item.get("content", "")
+                                if content and isinstance(content, str):
+                                    accumulated_text += content
+                                    artifact_event = TaskArtifactUpdateEvent(
+                                        taskId=effective_task_id,
+                                        contextId=thread_id,
+                                        artifact=Artifact(
+                                            artifactId="output",
+                                            parts=[Part(root=TextPart(text=content))],
+                                        ),
+                                        append=True,
+                                        lastChunk=False,
+                                    )
+                                    yield f"data: {artifact_event.model_dump_json(by_alias=True)}\n\n"
+
+                elif line.startswith("event: end"):
+                    # Stream ended — emit final artifact and completed status
+                    break
+
+        # Emit final artifact chunk if we accumulated text
+        if accumulated_text:
+            final_artifact = TaskArtifactUpdateEvent(
+                taskId=effective_task_id,
+                contextId=thread_id,
+                artifact=Artifact(
+                    artifactId="output",
+                    parts=[Part(root=TextPart(text=accumulated_text))],
+                ),
+                append=False,
+                lastChunk=True,
+            )
+            yield f"data: {final_artifact.model_dump_json(by_alias=True)}\n\n"
+
+        # Emit terminal status: completed
+        completed_event = TaskStatusUpdateEvent(
+            taskId=effective_task_id,
+            contextId=thread_id,
+            status=TaskStatus(state=TaskState.completed),
+            final=True,
+        )
+        yield f"data: {completed_event.model_dump_json(by_alias=True)}\n\n"
+
+    async def get_task(self, task_id: str) -> dict[str, Any]:
+        """Look up a task by its run ID and return the A2A Task dict.
+
+        Args:
+            task_id: The run ID (A2A task ID) to look up.
+
+        Returns:
+            A2A Task dict with the current status.
+
+        Raises:
+            ValueError: If no run with ``task_id`` is found.
+        """
+        maker = _get_session_maker()
+        async with maker() as session:
+            run_record: RunORM | None = await session.scalar(
+                select(RunORM).where(RunORM.run_id == task_id)
+            )
+
+        if run_record is None:
+            raise ValueError(f"Task not found: {task_id!r}")
+
+        raw_status: str = run_record.status or "pending"
+        task_state_value: str = RUN_STATUS_TO_TASK_STATE.get(raw_status, "unknown")
+        task_state = TaskState(task_state_value)
+
+        output: dict[str, Any] = run_record.output or {}
+        output_parts = convert_output_to_parts(output)
+        a2a_parts = [Part(root=TextPart(text=p["text"])) for p in output_parts]
+
+        artifacts: list[Artifact] | None = (
+            [Artifact(artifactId="output", parts=a2a_parts)] if a2a_parts else None
+        )
+
+        task = Task(
+            id=run_record.run_id,
+            contextId=run_record.thread_id,
+            status=TaskStatus(state=task_state),
+            artifacts=artifacts,
+        )
+        return task.model_dump(by_alias=True)
+
+
+# ---------------------------------------------------------------------------
+# Singleton accessor
+# ---------------------------------------------------------------------------
+
+_a2a_service: A2AService | None = None
+
+
+def get_a2a_service() -> A2AService:
+    """Return the global A2AService instance."""
+    global _a2a_service
+    if _a2a_service is None:
+        _a2a_service = A2AService()
+    return _a2a_service

--- a/libs/aegra-api/src/aegra_api/adapters/mcp_adapter.py
+++ b/libs/aegra-api/src/aegra_api/adapters/mcp_adapter.py
@@ -62,17 +62,16 @@ class _AuthMiddleware:
         except Exception as exc:
             response = StarletteJSONResponse(
                 status_code=401,
-                content={"error": f"Authentication failed: {exc}"},
+                content={"error": "Authentication failed"},
             )
             await response(scope, receive, send)
             return
 
         if result is None:
-            response = StarletteJSONResponse(
-                status_code=401,
-                content={"error": "Authentication required"},
-            )
-            await response(scope, receive, send)
+            # Auth backend returned None — no handler configured.
+            # Pass through (consistent with how require_auth handles this
+            # edge case, but allowing MCP to work when auth has no handler).
+            await self._app(scope, receive, send)
             return
 
         _credentials, user_obj = result

--- a/libs/aegra-api/src/aegra_api/adapters/mcp_adapter.py
+++ b/libs/aegra-api/src/aegra_api/adapters/mcp_adapter.py
@@ -1,0 +1,169 @@
+"""MCP (Model Context Protocol) adapter.
+
+Exposes each graph as an MCP tool via Streamable HTTP at /mcp.
+Uses the `mcp` SDK's FastMCP server.
+
+Authentication is handled by ASGI middleware that calls the same auth
+backend as the Agent Protocol endpoints. The authenticated user is
+stored in a ``ContextVar`` so the tool handler can read it without
+access to the HTTP request.
+"""
+
+import contextvars
+import json
+from collections.abc import Sequence
+from typing import Any
+
+import structlog
+from fastapi import FastAPI
+from mcp import types as mcp_types
+from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.server import MCPTool
+from starlette.requests import Request as StarletteRequest
+from starlette.responses import JSONResponse as StarletteJSONResponse
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+from aegra_api.adapters.mcp_service import MCPService, get_mcp_service
+from aegra_api.core.auth_deps import _to_user_model
+from aegra_api.core.auth_middleware import get_auth_backend
+from aegra_api.models.auth import User
+
+logger = structlog.get_logger(__name__)
+
+# ContextVar to thread the authenticated user from ASGI middleware into
+# MCP tool handlers (which don't have access to the HTTP request).
+_current_user: contextvars.ContextVar[User | None] = contextvars.ContextVar(
+    "_current_user", default=None
+)
+
+
+class _AuthMiddleware:
+    """ASGI middleware that authenticates requests using Aegra's auth backend.
+
+    Calls the same auth backend configured for Agent Protocol endpoints.
+    On success, stores the authenticated ``User`` in a ``ContextVar``
+    so downstream MCP tool handlers can access it. On failure, returns
+    a 401 JSON response.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self._app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self._app(scope, receive, send)
+            return
+
+        request = StarletteRequest(scope, receive)
+        backend = get_auth_backend()
+
+        try:
+            result = await backend.authenticate(request)
+        except Exception as exc:
+            response = StarletteJSONResponse(
+                status_code=401,
+                content={"error": f"Authentication failed: {exc}"},
+            )
+            await response(scope, receive, send)
+            return
+
+        if result is None:
+            response = StarletteJSONResponse(
+                status_code=401,
+                content={"error": "Authentication required"},
+            )
+            await response(scope, receive, send)
+            return
+
+        _credentials, user_obj = result
+        user = _to_user_model(user_obj)
+
+        # Store in ContextVar for tool handlers to read
+        token = _current_user.set(user)
+        try:
+            await self._app(scope, receive, send)
+        finally:
+            _current_user.reset(token)
+
+
+def get_current_mcp_user() -> User:
+    """Return the authenticated user for the current MCP request.
+
+    Reads from the ``ContextVar`` set by ``_AuthMiddleware``.
+
+    Returns:
+        The authenticated ``User``.
+
+    Raises:
+        RuntimeError: If called outside of an authenticated MCP request.
+    """
+    user = _current_user.get()
+    if user is None:
+        raise RuntimeError("No authenticated user in MCP context")
+    return user
+
+
+class _AegraMCPServer(FastMCP):
+    """FastMCP subclass that delegates tool listing and dispatch to MCPService.
+
+    Tools are resolved dynamically on every request so no startup
+    synchronisation is needed — by the time the first MCP request
+    arrives the FastAPI lifespan has already initialised
+    ``LangGraphService`` and the ``MCPService`` singleton is ready.
+    """
+
+    def __init__(self, service: MCPService) -> None:
+        super().__init__(
+            name="aegra",
+            stateless_http=True,
+            # Mount at "/" inside the sub-app so FastAPI's app.mount("/mcp", ...)
+            # correctly routes POST /mcp to the MCP handler.
+            streamable_http_path="/",
+        )
+        self._aegra_service = service
+
+    async def list_tools(self) -> list[MCPTool]:
+        """Return one MCPTool per registered graph, schema sourced live."""
+        tool_defs: list[dict[str, Any]] = await self._aegra_service.list_tools()
+        result: list[MCPTool] = []
+        for td in tool_defs:
+            result.append(
+                MCPTool(
+                    name=td["name"],
+                    description=td.get("description", ""),
+                    inputSchema=td.get("inputSchema", {"type": "object"}),
+                )
+            )
+        return result
+
+    async def call_tool(
+        self, name: str, arguments: dict[str, Any]
+    ) -> Sequence[mcp_types.ContentBlock]:
+        """Dispatch a tool call to MCPService with the authenticated user."""
+        user = get_current_mcp_user()
+        output: dict[str, Any] = await self._aegra_service.call_tool(name, arguments, user)
+        return [mcp_types.TextContent(type="text", text=json.dumps(output))]
+
+
+def mount_mcp(app: FastAPI) -> None:
+    """Mount the MCP Streamable HTTP endpoint at /mcp.
+
+    Creates an ``_AegraMCPServer`` (FastMCP subclass), wraps it with
+    auth middleware, and mounts the resulting Starlette ASGI app
+    under ``/mcp`` on the FastAPI application.
+
+    Authentication uses the same backend as Agent Protocol endpoints.
+
+    Args:
+        app: The FastAPI application to mount on.
+    """
+    service: MCPService = get_mcp_service()
+    mcp_server = _AegraMCPServer(service)
+    starlette_app = mcp_server.streamable_http_app()
+
+    # Wrap with auth middleware so MCP requests go through the same
+    # authentication as Agent Protocol endpoints.
+    authed_app = _AuthMiddleware(starlette_app)
+
+    app.mount("/mcp", authed_app)
+    logger.info("MCP adapter mounted at /mcp (with auth)")

--- a/libs/aegra-api/src/aegra_api/adapters/mcp_service.py
+++ b/libs/aegra-api/src/aegra_api/adapters/mcp_service.py
@@ -45,6 +45,9 @@ class MCPService:
             List of tool descriptor dicts with ``name``, ``description``,
             and ``inputSchema`` keys.
         """
+        if not self._langgraph_service:
+            return []
+
         tools: list[dict[str, Any]] = []
         registry: dict[str, Any] = self._langgraph_service._graph_registry
 
@@ -85,7 +88,11 @@ class MCPService:
 
         Raises:
             ValueError: If ``tool_name`` is not a known graph ID.
+            RuntimeError: If the LangGraph service has not been initialized.
         """
+        if not self._langgraph_service:
+            raise RuntimeError("LangGraph service not initialized")
+
         registry: dict[str, Any] = self._langgraph_service._graph_registry
 
         if tool_name not in registry:

--- a/libs/aegra-api/src/aegra_api/adapters/mcp_service.py
+++ b/libs/aegra-api/src/aegra_api/adapters/mcp_service.py
@@ -1,0 +1,113 @@
+"""MCP service layer.
+
+Maps MCP tool calls to Agent Protocol runs. Each graph in the registry
+becomes a callable MCP tool. Tool execution delegates to the existing
+``stateless_wait_for_run`` function, which handles ephemeral thread
+creation, graph execution, waiting for output, and cleanup.
+"""
+
+from typing import Any
+
+import structlog
+
+from aegra_api.api.stateless_runs import stateless_wait_for_run
+from aegra_api.models import RunCreate, User
+from aegra_api.utils.assistants import resolve_assistant_id
+
+logger = structlog.get_logger(__name__)
+
+
+class MCPService:
+    """Service that exposes graphs as MCP tools.
+
+    Provides ``list_tools`` for schema discovery and ``call_tool`` for
+    execution. Each graph in the registry becomes one MCP tool.
+    """
+
+    def __init__(self) -> None:
+        self._langgraph_service: Any = None
+
+    def set_langgraph_service(self, service: Any) -> None:
+        """Inject the LangGraphService dependency.
+
+        Args:
+            service: A configured ``LangGraphService`` instance.
+        """
+        self._langgraph_service = service
+
+    async def list_tools(self) -> list[dict[str, Any]]:
+        """Return one MCP tool descriptor per registered graph.
+
+        Retrieves the input JSON schema from each graph's compiled base
+        definition. Graphs that fail to load are skipped with a warning.
+
+        Returns:
+            List of tool descriptor dicts with ``name``, ``description``,
+            and ``inputSchema`` keys.
+        """
+        tools: list[dict[str, Any]] = []
+        registry: dict[str, Any] = self._langgraph_service._graph_registry
+
+        for graph_id in registry:
+            try:
+                graph = await self._langgraph_service._get_base_graph(graph_id)
+                input_schema = graph.get_input_jsonschema()
+            except Exception:
+                logger.exception("mcp_list_tools_graph_load_failed", graph_id=graph_id)
+                continue
+
+            tools.append(
+                {
+                    "name": graph_id,
+                    "description": f"Run the {graph_id} agent",
+                    "inputSchema": input_schema,
+                }
+            )
+
+        return tools
+
+    async def call_tool(
+        self, tool_name: str, arguments: dict[str, Any], user: User,
+    ) -> dict[str, Any]:
+        """Execute a graph as an MCP tool call.
+
+        Delegates to ``stateless_wait_for_run`` from the stateless runs
+        API, which creates an ephemeral thread, runs the graph, waits
+        for output, and cleans up the thread automatically.
+
+        Args:
+            tool_name: The graph ID (tool name) to invoke.
+            arguments: Input arguments forwarded to the graph.
+            user: The authenticated user making the request.
+
+        Returns:
+            The final output dict from the graph run.
+
+        Raises:
+            ValueError: If ``tool_name`` is not a known graph ID.
+        """
+        registry: dict[str, Any] = self._langgraph_service._graph_registry
+
+        if tool_name not in registry:
+            raise ValueError(f"Unknown tool: {tool_name!r}")
+
+        assistant_id = resolve_assistant_id(tool_name, registry)
+
+        request = RunCreate(
+            assistant_id=assistant_id,
+            input=arguments,
+        )
+
+        return await stateless_wait_for_run(request, user)
+
+
+# Global service instance
+_mcp_service: MCPService | None = None
+
+
+def get_mcp_service() -> MCPService:
+    """Return the global MCPService instance."""
+    global _mcp_service
+    if _mcp_service is None:
+        _mcp_service = MCPService()
+    return _mcp_service

--- a/libs/aegra-api/src/aegra_api/adapters/mcp_service.py
+++ b/libs/aegra-api/src/aegra_api/adapters/mcp_service.py
@@ -6,12 +6,15 @@ becomes a callable MCP tool. Tool execution delegates to the existing
 creation, graph execution, waiting for output, and cleanup.
 """
 
+from __future__ import annotations
+
 from typing import Any
 
 import structlog
 
 from aegra_api.api.stateless_runs import stateless_wait_for_run
 from aegra_api.models import RunCreate, User
+from aegra_api.services.langgraph_service import LangGraphService
 from aegra_api.utils.assistants import resolve_assistant_id
 
 logger = structlog.get_logger(__name__)
@@ -25,9 +28,9 @@ class MCPService:
     """
 
     def __init__(self) -> None:
-        self._langgraph_service: Any = None
+        self._langgraph_service: LangGraphService | None = None
 
-    def set_langgraph_service(self, service: Any) -> None:
+    def set_langgraph_service(self, service: LangGraphService) -> None:
         """Inject the LangGraphService dependency.
 
         Args:

--- a/libs/aegra-api/src/aegra_api/config.py
+++ b/libs/aegra-api/src/aegra_api/config.py
@@ -23,7 +23,7 @@ class CorsConfig(TypedDict, total=False):
 
 
 class HttpConfig(TypedDict, total=False):
-    """HTTP configuration options for custom routes"""
+    """HTTP configuration options for custom routes and protocol adapters"""
 
     app: str
     """Import path for custom Starlette/FastAPI app to mount"""
@@ -31,6 +31,10 @@ class HttpConfig(TypedDict, total=False):
     """Apply Aegra authentication dependency to custom routes (uses FastAPI dependencies, not middleware)"""
     cors: CorsConfig | None
     """Custom CORS configuration"""
+    disable_a2a: bool
+    """Disable A2A (Agent-to-Agent) protocol endpoint. Default: False (enabled)."""
+    disable_mcp: bool
+    """Disable MCP (Model Context Protocol) endpoint. Default: False (enabled)."""
 
 
 class StoreIndexConfig(TypedDict, total=False):

--- a/libs/aegra-api/src/aegra_api/main.py
+++ b/libs/aegra-api/src/aegra_api/main.py
@@ -13,6 +13,10 @@ from fastapi.responses import JSONResponse
 from fastapi.routing import APIRoute, APIRouter
 
 from aegra_api import __version__
+from aegra_api.adapters.a2a_adapter import mount_a2a
+from aegra_api.adapters.a2a_service import get_a2a_service
+from aegra_api.adapters.mcp_adapter import mount_mcp
+from aegra_api.adapters.mcp_service import get_mcp_service
 from aegra_api.api.assistants import router as assistants_router
 from aegra_api.api.runs import router as runs_router
 from aegra_api.api.stateless_runs import router as stateless_runs_router
@@ -94,6 +98,12 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     # Initialize LangGraph service
     langgraph_service = get_langgraph_service()
     await langgraph_service.initialize()
+
+    # Wire LangGraph service into MCP service so tool calls can execute graphs
+    get_mcp_service().set_langgraph_service(langgraph_service)
+
+    # Wire LangGraph service into A2A service so agent calls can execute graphs
+    get_a2a_service().set_langgraph_service(langgraph_service)
 
     # Initialize event store cleanup task
     await event_store.start_cleanup_task()
@@ -266,6 +276,29 @@ def _include_core_routers(app: FastAPI) -> None:
     app.include_router(store_router)
 
 
+def _mount_protocol_adapters(app: FastAPI, http_config: HttpConfig | None) -> None:
+    """Conditionally mount A2A and MCP protocol adapters.
+
+    Both adapters are enabled by default. Disable via aegra.json:
+        {"http": {"disable_mcp": true, "disable_a2a": true}}
+
+    Args:
+        app: FastAPI application instance
+        http_config: HTTP configuration from aegra.json or None
+    """
+    if not (http_config or {}).get("disable_mcp", False):
+        mount_mcp(app)
+        logger.info("MCP protocol adapter enabled")
+    else:
+        logger.info("MCP protocol adapter disabled via config")
+
+    if not (http_config or {}).get("disable_a2a", False):
+        mount_a2a(app)
+        logger.info("A2A protocol adapter enabled")
+    else:
+        logger.info("A2A protocol adapter disabled via config")
+
+
 def create_app() -> FastAPI:
     """Create and configure the FastAPI application.
 
@@ -296,6 +329,7 @@ def create_app() -> FastAPI:
         if not application.openapi_tags:
             application.openapi_tags = OPENAPI_TAGS
         _include_core_routers(application)
+        _mount_protocol_adapters(application, http_config)
 
         # Add root endpoint if not already defined
         if not any(route.path == "/" for route in application.routes if hasattr(route, "path")):
@@ -322,6 +356,7 @@ def create_app() -> FastAPI:
 
         _add_common_middleware(application, cors_config)
         _include_core_routers(application)
+        _mount_protocol_adapters(application, http_config)
 
         for exc_type, handler in exception_handlers.items():
             application.exception_handler(exc_type)(handler)

--- a/libs/aegra-api/tests/e2e/test_a2a_e2e.py
+++ b/libs/aegra-api/tests/e2e/test_a2a_e2e.py
@@ -1,0 +1,307 @@
+"""E2E tests for A2A endpoints using the `a2a-sdk` client.
+
+These tests connect to a real running Aegra server using the A2A SDK's
+client and card resolver to verify agent discovery, message sending,
+and streaming.
+"""
+
+from typing import Any
+from uuid import uuid4
+
+import httpx
+import pytest
+from a2a.client import A2ACardResolver, A2AClient
+from a2a.types import (
+    Message,
+    MessageSendParams,
+    Part,
+    Role,
+    SendMessageRequest,
+    SendStreamingMessageRequest,
+    TextPart,
+)
+
+from tests.e2e._utils import elog
+
+pytestmark = pytest.mark.e2e
+
+BASE_URL = "http://localhost:2026"
+
+
+async def _check_server() -> None:
+    """Skip test if server is not reachable."""
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(f"{BASE_URL}/health", timeout=5)
+            if resp.status_code != 200:
+                pytest.skip("Server not healthy")
+    except httpx.ConnectError:
+        pytest.skip("Server not reachable")
+
+
+def _make_text_message(text: str) -> Message:
+    """Build an A2A Message with a single text part."""
+    return Message(
+        messageId=str(uuid4()),
+        role=Role.user,
+        parts=[Part(root=TextPart(text=text))],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Agent card discovery (using A2A SDK)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a2a_card_resolver_fetches_agent_card() -> None:
+    """A2ACardResolver can fetch the agent card from /.well-known/agent-card.json."""
+    await _check_server()
+
+    async with httpx.AsyncClient() as http_client:
+        resolver = A2ACardResolver(
+            httpx_client=http_client,
+            base_url=BASE_URL,
+        )
+        card = await resolver.get_agent_card()
+
+    elog("A2A agent card via SDK", {
+        "name": card.name,
+        "url": card.url,
+        "skills": [s.name for s in card.skills],
+    })
+    assert card.name is not None
+    assert card.url is not None
+    assert len(card.skills) > 0
+
+
+@pytest.mark.asyncio
+async def test_a2a_agent_card_url_points_to_a2a_endpoint() -> None:
+    """The URL in the agent card contains /a2a/."""
+    await _check_server()
+
+    async with httpx.AsyncClient() as http_client:
+        resolver = A2ACardResolver(
+            httpx_client=http_client,
+            base_url=BASE_URL,
+        )
+        card = await resolver.get_agent_card()
+
+    assert "/a2a/" in card.url, f"Agent card URL should contain '/a2a/', got: {card.url!r}"
+
+
+@pytest.mark.asyncio
+async def test_a2a_agent_cards_list_endpoint() -> None:
+    """GET /a2a/agent-cards returns a non-empty array of agent cards."""
+    await _check_server()
+
+    async with httpx.AsyncClient(base_url=BASE_URL) as client:
+        response = await client.get("/a2a/agent-cards", timeout=10)
+
+    assert response.status_code == 200
+    cards: list[dict[str, Any]] = response.json()
+    assert isinstance(cards, list)
+    assert len(cards) > 0
+    elog("A2A agent cards list", {"count": len(cards)})
+
+
+# ---------------------------------------------------------------------------
+# A2A message/send (using A2A SDK)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a2a_client_send_message() -> None:
+    """A2AClient.send_message sends a text message and receives a task response.
+
+    Requires a configured LLM API key in the server's .env.
+    Skips gracefully if the agent execution fails.
+    """
+    await _check_server()
+
+    async with httpx.AsyncClient() as http_client:
+        # Discover agent card
+        resolver = A2ACardResolver(
+            httpx_client=http_client,
+            base_url=BASE_URL,
+        )
+        card = await resolver.get_agent_card()
+
+        # Create A2A client pointing at the agent's URL
+        a2a_client = A2AClient(
+            httpx_client=http_client,
+            agent_card=card,
+        )
+
+        # Build request
+        request = SendMessageRequest(
+            id=1,
+            params=MessageSendParams(
+                message=_make_text_message("Say hello in one word."),
+            ),
+        )
+
+        try:
+            response = await a2a_client.send_message(request)
+        except Exception as exc:
+            pytest.skip(f"send_message failed (likely missing LLM credentials): {exc}")
+
+    elog("A2A send_message response", {
+        "type": type(response).__name__,
+        "has_result": hasattr(response, "result"),
+    })
+
+    # The response should have a result (Task or Message)
+    assert response.result is not None, f"Expected result in response, got error: {response.error if hasattr(response, 'error') else 'unknown'}"
+
+
+@pytest.mark.asyncio
+async def test_a2a_client_send_message_task_has_required_fields() -> None:
+    """The task returned by send_message has id, status, and contextId."""
+    await _check_server()
+
+    async with httpx.AsyncClient() as http_client:
+        resolver = A2ACardResolver(
+            httpx_client=http_client,
+            base_url=BASE_URL,
+        )
+        card = await resolver.get_agent_card()
+
+        a2a_client = A2AClient(
+            httpx_client=http_client,
+            agent_card=card,
+        )
+
+        request = SendMessageRequest(
+            id=2,
+            params=MessageSendParams(
+                message=_make_text_message("Say hello in one word."),
+            ),
+        )
+
+        try:
+            response = await a2a_client.send_message(request)
+        except Exception as exc:
+            pytest.skip(f"send_message failed: {exc}")
+
+    if response.error is not None:
+        pytest.skip(f"A2A returned error: {response.error}")
+
+    task = response.result
+    elog("A2A task result", {
+        "id": task.id if hasattr(task, "id") else None,
+        "status": str(task.status) if hasattr(task, "status") else None,
+        "contextId": task.contextId if hasattr(task, "contextId") else None,
+    })
+    assert hasattr(task, "id"), "Task must have 'id'"
+    assert hasattr(task, "status"), "Task must have 'status'"
+    assert hasattr(task, "contextId"), "Task must have 'contextId'"
+
+
+# ---------------------------------------------------------------------------
+# A2A message/stream (using A2A SDK)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a2a_client_send_message_streaming() -> None:
+    """A2AClient.send_message_streaming streams task events.
+
+    Requires a configured LLM API key in the server's .env.
+    Skips gracefully if the agent execution fails.
+    """
+    await _check_server()
+
+    async with httpx.AsyncClient() as http_client:
+        resolver = A2ACardResolver(
+            httpx_client=http_client,
+            base_url=BASE_URL,
+        )
+        card = await resolver.get_agent_card()
+
+        a2a_client = A2AClient(
+            httpx_client=http_client,
+            agent_card=card,
+        )
+
+        request = SendStreamingMessageRequest(
+            id=3,
+            params=MessageSendParams(
+                message=_make_text_message("Say hello in one word."),
+            ),
+        )
+
+        events: list[Any] = []
+        try:
+            async for event in a2a_client.send_message_streaming(request):
+                events.append(event)
+                elog("A2A stream event", {"type": type(event).__name__})
+                # Collect a few events then stop to avoid timeout
+                if len(events) >= 10:
+                    break
+        except Exception as exc:
+            pytest.skip(f"send_message_streaming failed: {exc}")
+
+    elog("A2A streaming events collected", {"count": len(events)})
+    assert len(events) > 0, "Expected at least one streaming event"
+
+
+# ---------------------------------------------------------------------------
+# A2A error cases (using raw httpx for JSON-RPC)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a2a_unknown_method_returns_json_rpc_error() -> None:
+    """Unknown JSON-RPC method returns -32601 Method not found."""
+    await _check_server()
+
+    async with httpx.AsyncClient(base_url=BASE_URL) as client:
+        # Get agent card to find the A2A endpoint URL
+        resolver = A2ACardResolver(httpx_client=client, base_url=BASE_URL)
+        card = await resolver.get_agent_card()
+        path = card.url.replace(BASE_URL, "") if card.url.startswith(BASE_URL) else "/a2a/agent"
+
+        response = await client.post(
+            path,
+            json={
+                "jsonrpc": "2.0",
+                "id": 99,
+                "method": "unknown/method",
+                "params": {},
+            },
+            timeout=10,
+        )
+
+    assert response.status_code == 200
+    body: dict[str, Any] = response.json()
+    assert "error" in body
+    assert body["error"]["code"] == -32601
+    elog("A2A unknown method error", body["error"])
+
+
+@pytest.mark.asyncio
+async def test_a2a_tasks_get_unknown_task_returns_error() -> None:
+    """tasks/get for a non-existent task returns a JSON-RPC error."""
+    await _check_server()
+
+    async with httpx.AsyncClient(base_url=BASE_URL) as client:
+        resolver = A2ACardResolver(httpx_client=client, base_url=BASE_URL)
+        card = await resolver.get_agent_card()
+        path = card.url.replace(BASE_URL, "") if card.url.startswith(BASE_URL) else "/a2a/agent"
+
+        response = await client.post(
+            path,
+            json={
+                "jsonrpc": "2.0",
+                "id": 100,
+                "method": "tasks/get",
+                "params": {"id": "00000000-0000-0000-0000-000000000000"},
+            },
+            timeout=10,
+        )
+
+    assert response.status_code == 200
+    body: dict[str, Any] = response.json()
+    assert "error" in body
+    elog("A2A tasks/get unknown task error", body["error"])

--- a/libs/aegra-api/tests/e2e/test_adapter_auth_e2e.py
+++ b/libs/aegra-api/tests/e2e/test_adapter_auth_e2e.py
@@ -1,0 +1,195 @@
+"""E2E auth tests for A2A and MCP adapter endpoints.
+
+These tests verify that:
+- MCP endpoint rejects requests without valid auth when auth is enabled
+- MCP endpoint accepts requests with valid auth headers
+- A2A RPC endpoint rejects requests without valid auth when auth is enabled
+- A2A RPC endpoint accepts requests with valid auth headers
+- A2A discovery endpoints work without auth even when auth is enabled
+
+Requires a server started with auth enabled.
+Run with: pytest tests/e2e/test_adapter_auth_e2e.py -v -m manual_auth
+"""
+
+from typing import Any
+
+import httpx
+import pytest
+
+from tests.e2e._utils import check_server_has_auth, elog
+
+pytestmark = [pytest.mark.e2e, pytest.mark.manual_auth]
+
+BASE_URL = "http://localhost:2026"
+
+
+async def _check_server_with_auth() -> None:
+    """Skip if server is not reachable or auth is not enabled."""
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(f"{BASE_URL}/health", timeout=5)
+            if resp.status_code != 200:
+                pytest.skip("Server not healthy")
+    except httpx.ConnectError:
+        pytest.skip("Server not reachable")
+
+    has_auth = check_server_has_auth(BASE_URL)
+    if not has_auth:
+        pytest.skip("Server does not have auth enabled")
+
+
+def _get_auth_headers(
+    user_id: str = "alice", role: str = "user", team_id: str = "team123",
+) -> dict[str, str]:
+    """Generate mock JWT auth headers for testing."""
+    token = f"mock-jwt-{user_id}-{role}-{team_id}"
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ---------------------------------------------------------------------------
+# MCP auth tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mcp_rejects_unauthenticated_request() -> None:
+    """MCP /mcp endpoint returns 401 without auth headers."""
+    await _check_server_with_auth()
+
+    async with httpx.AsyncClient(base_url=BASE_URL) as client:
+        resp = await client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-03-26",
+                    "capabilities": {},
+                    "clientInfo": {"name": "test", "version": "1.0"},
+                },
+            },
+            headers={"Accept": "application/json, text/event-stream"},
+            timeout=10,
+        )
+
+    elog("MCP unauthenticated response", {"status": resp.status_code})
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_mcp_accepts_authenticated_request() -> None:
+    """MCP /mcp endpoint accepts requests with valid auth headers."""
+    await _check_server_with_auth()
+
+    async with httpx.AsyncClient(base_url=BASE_URL) as client:
+        resp = await client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-03-26",
+                    "capabilities": {},
+                    "clientInfo": {"name": "test", "version": "1.0"},
+                },
+            },
+            headers={
+                "Accept": "application/json, text/event-stream",
+                **_get_auth_headers(),
+            },
+            timeout=10,
+        )
+
+    elog("MCP authenticated response", {"status": resp.status_code})
+    assert resp.status_code != 401, f"Expected non-401, got {resp.status_code}"
+
+
+# ---------------------------------------------------------------------------
+# A2A auth tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a2a_rpc_rejects_unauthenticated_request() -> None:
+    """A2A /a2a/{id} endpoint returns 401 without auth headers."""
+    await _check_server_with_auth()
+
+    async with httpx.AsyncClient(base_url=BASE_URL) as client:
+        # Get agent card (discovery, no auth needed)
+        card_resp = await client.get("/.well-known/agent-card.json")
+        assert card_resp.status_code == 200
+        card: dict[str, Any] = card_resp.json()
+        url: str = card.get("url", "")
+        path = url.replace(BASE_URL, "") if url.startswith(BASE_URL) else "/a2a/agent"
+
+        # Try RPC without auth
+        resp = await client.post(
+            path,
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "message/send",
+                "params": {
+                    "message": {
+                        "role": "user",
+                        "parts": [{"kind": "text", "text": "hi"}],
+                    }
+                },
+            },
+            timeout=10,
+        )
+
+    elog("A2A unauthenticated RPC response", {"status": resp.status_code})
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_a2a_rpc_accepts_authenticated_request() -> None:
+    """A2A /a2a/{id} endpoint accepts requests with valid auth headers."""
+    await _check_server_with_auth()
+
+    async with httpx.AsyncClient(base_url=BASE_URL) as client:
+        card_resp = await client.get("/.well-known/agent-card.json")
+        assert card_resp.status_code == 200
+        card: dict[str, Any] = card_resp.json()
+        url: str = card.get("url", "")
+        path = url.replace(BASE_URL, "") if url.startswith(BASE_URL) else "/a2a/agent"
+
+        resp = await client.post(
+            path,
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "message/send",
+                "params": {
+                    "message": {
+                        "role": "user",
+                        "parts": [{"kind": "text", "text": "hi"}],
+                    }
+                },
+            },
+            headers=_get_auth_headers(),
+            timeout=60,
+        )
+
+    elog("A2A authenticated RPC response", {"status": resp.status_code})
+    assert resp.status_code != 401, f"Expected non-401, got {resp.status_code}"
+
+
+@pytest.mark.asyncio
+async def test_a2a_discovery_works_without_auth() -> None:
+    """A2A agent card endpoints work without auth even when auth is enabled."""
+    await _check_server_with_auth()
+
+    async with httpx.AsyncClient(base_url=BASE_URL) as client:
+        card_resp = await client.get("/.well-known/agent-card.json", timeout=10)
+        cards_resp = await client.get("/a2a/agent-cards", timeout=10)
+
+    elog("A2A discovery without auth", {
+        "card_status": card_resp.status_code,
+        "cards_status": cards_resp.status_code,
+    })
+    assert card_resp.status_code == 200, "Agent card should be accessible without auth"
+    assert cards_resp.status_code == 200, "Agent cards list should be accessible without auth"

--- a/libs/aegra-api/tests/e2e/test_mcp_e2e.py
+++ b/libs/aegra-api/tests/e2e/test_mcp_e2e.py
@@ -1,0 +1,113 @@
+"""E2E tests for MCP endpoint using the `mcp` SDK client.
+
+These tests connect to a real running Aegra server using the MCP client
+SDK's Streamable HTTP transport and verify tool discovery and invocation.
+"""
+
+
+import httpx
+import pytest
+from mcp import ClientSession
+from mcp.client.streamable_http import streamablehttp_client
+
+from tests.e2e._utils import elog
+
+pytestmark = pytest.mark.e2e
+
+BASE_URL = "http://localhost:2026"
+
+
+async def _check_server() -> None:
+    """Skip test if server is not reachable."""
+    try:
+        async with httpx.AsyncClient() as client:
+            resp = await client.get(f"{BASE_URL}/health", timeout=5)
+            if resp.status_code != 200:
+                pytest.skip("Server not healthy")
+    except httpx.ConnectError:
+        pytest.skip("Server not reachable")
+
+
+# ---------------------------------------------------------------------------
+# MCP SDK client tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mcp_client_connects_and_initializes() -> None:
+    """MCP client can connect to /mcp and complete the initialize handshake."""
+    await _check_server()
+
+    async with streamablehttp_client(url=f"{BASE_URL}/mcp") as (read, write, _):  # noqa: SIM117
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+
+            elog("MCP session initialized", {
+                "server_name": session.server_info.name if session.server_info else "unknown",
+            })
+            # If we got here, initialization succeeded
+            assert session.server_info is not None
+
+
+@pytest.mark.asyncio
+async def test_mcp_client_discovers_tools() -> None:
+    """MCP tools/list returns at least one tool corresponding to a registered graph."""
+    await _check_server()
+
+    async with streamablehttp_client(url=f"{BASE_URL}/mcp") as (read, write, _):  # noqa: SIM117
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+
+            tools_result = await session.list_tools()
+            tool_names = [t.name for t in tools_result.tools]
+
+            elog("MCP tools discovered", tool_names)
+            assert len(tool_names) > 0, "Expected at least one MCP tool"
+            # The 'agent' graph from aegra.json should be exposed as a tool
+            assert "agent" in tool_names, f"Expected 'agent' tool, got: {tool_names}"
+
+
+@pytest.mark.asyncio
+async def test_mcp_client_tool_has_input_schema() -> None:
+    """Each MCP tool has a non-empty inputSchema describing graph input."""
+    await _check_server()
+
+    async with streamablehttp_client(url=f"{BASE_URL}/mcp") as (read, write, _):  # noqa: SIM117
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+
+            tools_result = await session.list_tools()
+
+            for tool in tools_result.tools:
+                elog(f"Tool '{tool.name}' schema", tool.inputSchema)
+                assert tool.inputSchema is not None, f"Tool '{tool.name}' has no inputSchema"
+                assert isinstance(tool.inputSchema, dict), f"Tool '{tool.name}' schema is not a dict"
+
+
+@pytest.mark.asyncio
+async def test_mcp_client_call_tool() -> None:
+    """MCP tools/call invokes the graph and returns a text result.
+
+    This test requires a configured LLM API key in the server's .env.
+    Skips gracefully if the graph execution fails due to missing credentials.
+    """
+    await _check_server()
+
+    async with streamablehttp_client(url=f"{BASE_URL}/mcp") as (read, write, _):  # noqa: SIM117
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+
+            try:
+                result = await session.call_tool(
+                    "agent",
+                    arguments={"messages": [{"role": "user", "content": "Say hello in one word."}]},
+                )
+            except Exception as exc:
+                pytest.skip(f"Tool call failed (likely missing LLM credentials): {exc}")
+
+            elog("MCP tool call result", {
+                "content_count": len(result.content),
+                "is_error": result.isError,
+            })
+            assert not result.isError, f"Tool call returned error: {result.content}"
+            assert len(result.content) > 0, "Expected at least one content block"

--- a/libs/aegra-api/tests/integration/adapters/test_a2a_endpoint.py
+++ b/libs/aegra-api/tests/integration/adapters/test_a2a_endpoint.py
@@ -1,0 +1,340 @@
+"""Integration tests for the A2A adapter endpoints."""
+
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from aegra_api.adapters.a2a_adapter import mount_a2a
+from aegra_api.adapters.a2a_service import A2AService
+from aegra_api.core.auth_deps import get_current_user
+from aegra_api.core.orm import get_session
+from aegra_api.models.auth import User
+
+_TEST_USER = User(identity="test-user", is_authenticated=True, permissions=[])
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_service(registry: dict[str, Any] | None = None) -> A2AService:
+    """Return an A2AService backed by a minimal mocked LangGraphService.
+
+    Args:
+        registry: Optional graph registry dict to use.
+
+    Returns:
+        Configured A2AService instance.
+    """
+    svc = A2AService()
+    lg = MagicMock()
+    lg._graph_registry = registry or {}
+    svc.set_langgraph_service(lg)
+    return svc
+
+
+def _make_a2a_app(service: A2AService) -> FastAPI:
+    """Build a minimal FastAPI app with the A2A adapter mounted.
+
+    Args:
+        service: The A2AService instance to inject.
+
+    Returns:
+        FastAPI application with A2A routes registered.
+    """
+    app = FastAPI()
+    with patch("aegra_api.adapters.a2a_adapter.get_a2a_service", return_value=service):
+        mount_a2a(app)
+    # Override auth and session dependencies so tests don't require real auth/DB
+    app.dependency_overrides[get_current_user] = lambda: _TEST_USER
+    app.dependency_overrides[get_session] = lambda: AsyncMock()
+    return app
+
+
+# ---------------------------------------------------------------------------
+# test_a2a_disabled_returns_404
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a2a_disabled_returns_404() -> None:
+    """When disable_a2a is true, /a2a/X must not be mounted (returns 404)."""
+    # Simulate disable_a2a by NOT calling mount_a2a
+    app = FastAPI()
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/a2a/some-agent", json={})
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# test_well_known_returns_agent_card
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_well_known_returns_agent_card() -> None:
+    """GET /.well-known/agent-card.json returns 200 with an agent card when agents exist."""
+    registry: dict[str, Any] = {
+        "my_agent": {"file_path": "agent.py", "export_name": "graph"},
+    }
+    service = _make_service(registry)
+    app = _make_a2a_app(service)
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/.well-known/agent-card.json")
+
+    assert resp.status_code == 200
+    card = resp.json()
+    assert "name" in card
+    assert "url" in card
+    assert "my_agent" in card["url"]
+
+
+@pytest.mark.asyncio
+async def test_well_known_no_agents_returns_404() -> None:
+    """GET /.well-known/agent-card.json returns 404 when no agents are registered."""
+    service = _make_service({})
+    app = _make_a2a_app(service)
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/.well-known/agent-card.json")
+
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_well_known_with_assistant_id_query_param() -> None:
+    """GET /.well-known/agent-card.json?assistant_id=X returns card for that agent."""
+    registry: dict[str, Any] = {
+        "agent_a": {"file_path": "a.py", "export_name": "graph"},
+        "agent_b": {"file_path": "b.py", "export_name": "graph"},
+    }
+    service = _make_service(registry)
+    app = _make_a2a_app(service)
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/.well-known/agent-card.json", params={"assistant_id": "agent_b"})
+
+    assert resp.status_code == 200
+    card = resp.json()
+    assert "agent_b" in card["url"]
+
+
+@pytest.mark.asyncio
+async def test_well_known_unknown_assistant_id_returns_404() -> None:
+    """GET /.well-known/agent-card.json?assistant_id=unknown returns 404."""
+    registry: dict[str, Any] = {"agent_a": {}}
+    service = _make_service(registry)
+    app = _make_a2a_app(service)
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/.well-known/agent-card.json", params={"assistant_id": "no_such_agent"})
+
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# test_agent_cards_list_returns_array
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_agent_cards_list_returns_array() -> None:
+    """GET /a2a/agent-cards returns a JSON array of agent cards."""
+    registry: dict[str, Any] = {
+        "agent_a": {"file_path": "a.py", "export_name": "graph"},
+        "agent_b": {"file_path": "b.py", "export_name": "graph"},
+    }
+    service = _make_service(registry)
+    app = _make_a2a_app(service)
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/a2a/agent-cards")
+
+    assert resp.status_code == 200
+    cards = resp.json()
+    assert isinstance(cards, list)
+    assert len(cards) == 2
+    urls = {c["url"] for c in cards}
+    assert any("agent_a" in u for u in urls)
+    assert any("agent_b" in u for u in urls)
+
+
+@pytest.mark.asyncio
+async def test_agent_cards_list_empty_when_no_agents() -> None:
+    """GET /a2a/agent-cards returns an empty array when no agents are registered."""
+    service = _make_service({})
+    app = _make_a2a_app(service)
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/a2a/agent-cards")
+
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+# ---------------------------------------------------------------------------
+# test_unknown_method_returns_error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unknown_method_returns_error() -> None:
+    """POST /a2a/X with an unknown JSON-RPC method returns -32601 error."""
+    service = _make_service({"my_agent": {}})
+    app = _make_a2a_app(service)
+
+    payload = {"jsonrpc": "2.0", "id": 1, "method": "nonexistent/method", "params": {}}
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/a2a/my_agent", json=payload)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["error"]["code"] == -32601
+    assert body["id"] == 1
+
+
+# ---------------------------------------------------------------------------
+# test_invalid_json_returns_parse_error
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_invalid_json_returns_parse_error() -> None:
+    """POST /a2a/X with invalid JSON body returns -32700 parse error."""
+    service = _make_service({"my_agent": {}})
+    app = _make_a2a_app(service)
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post(
+            "/a2a/my_agent",
+            content=b"this is not json",
+            headers={"Content-Type": "application/json"},
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["error"]["code"] == -32700
+    assert body["id"] is None
+
+
+# ---------------------------------------------------------------------------
+# test_message_send_delegates_to_service
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_message_send_delegates_to_service() -> None:
+    """POST /a2a/X with method=message/send calls service.send_message."""
+    service = _make_service({"my_agent": {}})
+    fake_task: dict[str, Any] = {
+        "id": "run-1",
+        "contextId": "ctx-1",
+        "status": {"state": "completed"},
+        "artifacts": None,
+    }
+    service.send_message = AsyncMock(return_value=fake_task)  # type: ignore[method-assign]
+    app = _make_a2a_app(service)
+
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 42,
+        "method": "message/send",
+        "params": {
+            "message": {
+                "parts": [{"kind": "text", "text": "hello"}],
+            }
+        },
+    }
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/a2a/my_agent", json=payload)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "result" in body
+    assert body["id"] == 42
+    service.send_message.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# test_tasks_get_delegates_to_service
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tasks_get_delegates_to_service() -> None:
+    """POST /a2a/X with method=tasks/get calls service.get_task."""
+    service = _make_service({"my_agent": {}})
+    fake_task: dict[str, Any] = {
+        "id": "run-99",
+        "contextId": "ctx-99",
+        "status": {"state": "completed"},
+        "artifacts": None,
+    }
+    service.get_task = AsyncMock(return_value=fake_task)  # type: ignore[method-assign]
+    app = _make_a2a_app(service)
+
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 7,
+        "method": "tasks/get",
+        "params": {"id": "run-99"},
+    }
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/a2a/my_agent", json=payload)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["result"]["id"] == "run-99"
+    assert body["id"] == 7
+    service.get_task.assert_awaited_once_with("run-99")
+
+
+# ---------------------------------------------------------------------------
+# test_message_stream_returns_not_implemented
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_message_stream_returns_sse_response() -> None:
+    """POST /a2a/X with method=message/stream returns text/event-stream."""
+    service = _make_service({"my_agent": {}})
+
+    async def _fake_stream(**kwargs: Any) -> AsyncIterator[str]:
+        yield "data: {}\n\n"
+
+    service.stream_message = MagicMock(return_value=_fake_stream())  # type: ignore[method-assign]
+    app = _make_a2a_app(service)
+
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 3,
+        "method": "message/stream",
+        "params": {"message": {"parts": [{"kind": "text", "text": "hi"}]}},
+    }
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.post("/a2a/my_agent", json=payload)
+
+    assert resp.status_code == 200
+    assert "text/event-stream" in resp.headers.get("content-type", "")

--- a/libs/aegra-api/tests/integration/adapters/test_a2a_endpoint.py
+++ b/libs/aegra-api/tests/integration/adapters/test_a2a_endpoint.py
@@ -306,7 +306,7 @@ async def test_tasks_get_delegates_to_service() -> None:
     body = resp.json()
     assert body["result"]["id"] == "run-99"
     assert body["id"] == 7
-    service.get_task.assert_awaited_once_with("run-99")
+    service.get_task.assert_awaited_once_with("run-99", _TEST_USER)
 
 
 # ---------------------------------------------------------------------------

--- a/libs/aegra-api/tests/integration/adapters/test_adapter_auth.py
+++ b/libs/aegra-api/tests/integration/adapters/test_adapter_auth.py
@@ -1,0 +1,273 @@
+"""Integration tests for A2A and MCP adapter authentication.
+
+Verifies that:
+- MCP auth middleware rejects unauthenticated requests
+- MCP auth middleware passes authenticated user to tool handlers
+- A2A RPC endpoint rejects unauthenticated requests
+- A2A discovery endpoints (agent cards) don't require auth
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from starlette.authentication import AuthCredentials, AuthenticationError
+
+from aegra_api.adapters.a2a_adapter import mount_a2a
+from aegra_api.adapters.a2a_service import A2AService
+from aegra_api.adapters.mcp_adapter import _AuthMiddleware, _current_user, mount_mcp
+from aegra_api.adapters.mcp_service import MCPService
+from aegra_api.core.auth_middleware import LangGraphUser
+from aegra_api.models.auth import User
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_mcp_service(registry: dict[str, Any] | None = None) -> MCPService:
+    """Return an MCPService backed by a minimal mocked LangGraphService."""
+    svc = MCPService()
+    lg = MagicMock()
+    lg._graph_registry = registry or {}
+    lg._get_base_graph = AsyncMock(
+        return_value=MagicMock(get_input_jsonschema=lambda: {"type": "object"})
+    )
+    svc.set_langgraph_service(lg)
+    return svc
+
+
+def _make_a2a_service(registry: dict[str, Any] | None = None) -> A2AService:
+    """Return an A2AService backed by a minimal mocked LangGraphService."""
+    svc = A2AService()
+    lg = MagicMock()
+    lg._graph_registry = registry or {}
+    svc.set_langgraph_service(lg)
+    return svc
+
+
+def _make_auth_backend_that_rejects() -> MagicMock:
+    """Return a mock auth backend that raises AuthenticationError."""
+    backend = MagicMock()
+    backend.authenticate = AsyncMock(side_effect=AuthenticationError("Invalid token"))
+    return backend
+
+
+def _make_auth_backend_that_accepts(
+    identity: str = "test-user",
+) -> MagicMock:
+    """Return a mock auth backend that returns a valid user."""
+    user_data = {"identity": identity, "is_authenticated": True}
+    user = LangGraphUser(user_data)
+    backend = MagicMock()
+    backend.authenticate = AsyncMock(
+        return_value=(AuthCredentials([]), user)
+    )
+    return backend
+
+
+# ---------------------------------------------------------------------------
+# MCP auth middleware tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mcp_rejects_unauthenticated_request() -> None:
+    """MCP endpoint returns 401 when auth backend rejects the request."""
+    service = _make_mcp_service()
+
+    app = FastAPI()
+    with patch("aegra_api.adapters.mcp_adapter.get_mcp_service", return_value=service):
+        mount_mcp(app)
+
+    # Patch at request time so the auth rejection applies to the actual request
+    # (not just mount time)
+    with patch(
+        "aegra_api.adapters.mcp_adapter.get_auth_backend",
+        return_value=_make_auth_backend_that_rejects(),
+    ):
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="http://test",
+            follow_redirects=True,
+        ) as client:
+            resp = await client.post(
+                "/mcp",
+                json={"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+                headers={"Accept": "application/json, text/event-stream"},
+            )
+
+    assert resp.status_code == 401
+    body = resp.json()
+    assert "error" in body
+
+
+@pytest.mark.asyncio
+async def test_mcp_passes_authenticated_user_to_context_var() -> None:
+    """MCP auth middleware stores authenticated user in ContextVar."""
+    captured_users: list[User | None] = []
+
+    # Create a custom ASGI app that reads the ContextVar
+    async def _capture_app(scope: Any, receive: Any, send: Any) -> None:
+        captured_users.append(_current_user.get())
+        from starlette.responses import JSONResponse
+
+        response = JSONResponse({"ok": True})
+        await response(scope, receive, send)
+
+    middleware = _AuthMiddleware(_capture_app)
+
+    with patch(
+        "aegra_api.adapters.mcp_adapter.get_auth_backend",
+        return_value=_make_auth_backend_that_accepts("alice"),
+    ):
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=middleware),
+            base_url="http://test",
+        ) as client:
+            resp = await client.get("/anything")
+
+    assert resp.status_code == 200
+    assert len(captured_users) == 1
+    assert captured_users[0] is not None
+    assert captured_users[0].identity == "alice"
+
+
+@pytest.mark.asyncio
+async def test_mcp_context_var_cleared_after_request() -> None:
+    """MCP ContextVar is reset after the request completes."""
+    # Before any request, ContextVar should be None
+    assert _current_user.get() is None
+
+    async def _noop_app(scope: Any, receive: Any, send: Any) -> None:
+        from starlette.responses import JSONResponse
+
+        response = JSONResponse({"ok": True})
+        await response(scope, receive, send)
+
+    middleware = _AuthMiddleware(_noop_app)
+
+    with patch(
+        "aegra_api.adapters.mcp_adapter.get_auth_backend",
+        return_value=_make_auth_backend_that_accepts("bob"),
+    ):
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=middleware),
+            base_url="http://test",
+        ) as client:
+            await client.get("/anything")
+
+    # After request completes, ContextVar should be reset to None
+    assert _current_user.get() is None
+
+
+# ---------------------------------------------------------------------------
+# A2A auth tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a2a_rpc_rejects_unauthenticated_request() -> None:
+    """A2A JSON-RPC endpoint returns 401 when auth rejects the user."""
+    from fastapi import HTTPException
+
+    from aegra_api.core.auth_deps import get_current_user
+    from aegra_api.core.orm import get_session
+
+    service = _make_a2a_service({"agent": {}})
+
+    app = FastAPI()
+    with patch("aegra_api.adapters.a2a_adapter.get_a2a_service", return_value=service):
+        mount_a2a(app)
+
+    # Override get_current_user to raise 401 (simulates failed auth)
+    def _reject_user() -> None:
+        raise HTTPException(status_code=401, detail="Authentication required")
+
+    app.dependency_overrides[get_current_user] = _reject_user
+    app.dependency_overrides[get_session] = lambda: AsyncMock()
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        resp = await client.post(
+            "/a2a/agent",
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "message/send",
+                "params": {"message": {"parts": [{"kind": "text", "text": "hi"}]}},
+            },
+        )
+
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_a2a_discovery_endpoints_dont_require_auth() -> None:
+    """Agent card discovery endpoints work without authentication."""
+    service = _make_a2a_service({"agent": {}})
+
+    app = FastAPI()
+    with patch("aegra_api.adapters.a2a_adapter.get_a2a_service", return_value=service):
+        mount_a2a(app)
+
+    # Do NOT override auth — discovery should still work
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        card_resp = await client.get("/.well-known/agent-card.json")
+        cards_resp = await client.get("/a2a/agent-cards")
+
+    assert card_resp.status_code == 200
+    assert cards_resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_a2a_rpc_accepts_authenticated_user() -> None:
+    """A2A JSON-RPC endpoint works with authenticated user."""
+    from aegra_api.core.auth_deps import get_current_user
+    from aegra_api.core.orm import get_session
+
+    service = _make_a2a_service({"agent": {}})
+    service.send_message = AsyncMock(return_value={  # type: ignore[method-assign]
+        "id": "run-1",
+        "contextId": "thread-1",
+        "status": {"state": "completed"},
+        "artifacts": None,
+    })
+
+    app = FastAPI()
+    with patch("aegra_api.adapters.a2a_adapter.get_a2a_service", return_value=service):
+        mount_a2a(app)
+
+    test_user = User(identity="alice", is_authenticated=True, permissions=[])
+    app.dependency_overrides[get_current_user] = lambda: test_user
+    app.dependency_overrides[get_session] = lambda: AsyncMock()
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        resp = await client.post(
+            "/a2a/agent",
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "message/send",
+                "params": {"message": {"parts": [{"kind": "text", "text": "hello"}]}},
+            },
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "result" in body
+
+    # Verify the service received the authenticated user
+    service.send_message.assert_awaited_once()
+    call_kwargs = service.send_message.call_args.kwargs
+    assert call_kwargs["user"].identity == "alice"

--- a/libs/aegra-api/tests/integration/adapters/test_mcp_endpoint.py
+++ b/libs/aegra-api/tests/integration/adapters/test_mcp_endpoint.py
@@ -1,0 +1,186 @@
+"""Integration tests for the MCP adapter endpoint."""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from aegra_api.adapters.mcp_adapter import mount_mcp
+from aegra_api.adapters.mcp_service import MCPService
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_service(registry: dict[str, Any] | None = None) -> MCPService:
+    """Return an MCPService backed by a minimal mocked LangGraphService."""
+    svc = MCPService()
+    lg = MagicMock()
+    lg._graph_registry = registry or {}
+    lg._get_base_graph = AsyncMock(return_value=MagicMock(get_input_jsonschema=lambda: {"type": "object"}))
+    svc.set_langgraph_service(lg)
+    return svc
+
+
+def _make_mcp_app(service: MCPService) -> FastAPI:
+    """Build a minimal FastAPI app with the MCP adapter mounted."""
+    app = FastAPI()
+    with patch("aegra_api.adapters.mcp_adapter.get_mcp_service", return_value=service):
+        mount_mcp(app)
+    return app
+
+
+# ---------------------------------------------------------------------------
+# disable_mcp: /mcp should return 404
+# ---------------------------------------------------------------------------
+
+
+def test_mcp_disabled_returns_404() -> None:
+    """When disable_mcp is true, the /mcp path must not be mounted."""
+    app = FastAPI()
+    # Don't call mount_mcp — simulates disable_mcp=True
+    client = TestClient(app)
+    resp = client.post("/mcp", json={})
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# MCP enabled: /mcp endpoint exists and responds to JSON-RPC
+# ---------------------------------------------------------------------------
+
+
+def test_mcp_endpoint_responds_to_initialize() -> None:
+    """POST /mcp with an MCP initialize request returns a valid response."""
+    service = _make_service()
+    app = _make_mcp_app(service)
+    client = TestClient(app, raise_server_exceptions=False)
+
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {"name": "test", "version": "0.0.1"},
+        },
+    }
+    resp = client.post(
+        "/mcp",
+        json=payload,
+        headers={"Content-Type": "application/json", "Accept": "application/json, text/event-stream"},
+    )
+    # The MCP server should respond — 200 or 202, not 404/405
+    assert resp.status_code not in (404, 405), f"Unexpected status: {resp.status_code}"
+
+
+def test_mcp_endpoint_tools_list() -> None:
+    """POST /mcp tools/list returns one tool per registered graph."""
+    registry: dict[str, Any] = {
+        "my_agent": {"file_path": "agent.py", "export_name": "graph"},
+    }
+    service = _make_service(registry)
+    app = _make_mcp_app(service)
+    client = TestClient(app, raise_server_exceptions=False)
+
+    # First initialize the session
+    init_payload = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {"name": "test", "version": "0.0.1"},
+        },
+    }
+    init_resp = client.post(
+        "/mcp",
+        json=init_payload,
+        headers={"Content-Type": "application/json", "Accept": "application/json, text/event-stream"},
+    )
+    assert init_resp.status_code not in (404, 405)
+
+    # Send tools/list
+    tools_payload = {
+        "jsonrpc": "2.0",
+        "id": 2,
+        "method": "tools/list",
+        "params": {},
+    }
+    tools_resp = client.post(
+        "/mcp",
+        json=tools_payload,
+        headers={"Content-Type": "application/json", "Accept": "application/json, text/event-stream"},
+    )
+    assert tools_resp.status_code not in (404, 405)
+
+
+# ---------------------------------------------------------------------------
+# _AegraMCPServer unit-level behaviour
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_aegra_mcp_server_list_tools_delegates_to_service() -> None:
+    """_AegraMCPServer.list_tools returns one MCPTool per graph in registry."""
+    from aegra_api.adapters.mcp_adapter import _AegraMCPServer
+
+    registry: dict[str, Any] = {
+        "agent_a": {"file_path": "a.py", "export_name": "graph"},
+        "agent_b": {"file_path": "b.py", "export_name": "graph"},
+    }
+    service = _make_service(registry)
+    server = _AegraMCPServer(service)
+
+    tools = await server.list_tools()
+
+    assert len(tools) == 2
+    names = {t.name for t in tools}
+    assert names == {"agent_a", "agent_b"}
+
+
+@pytest.mark.asyncio
+async def test_aegra_mcp_server_call_tool_returns_text_content() -> None:
+    """_AegraMCPServer.call_tool wraps graph output as TextContent JSON."""
+    import json
+
+    from mcp.types import TextContent
+
+    from aegra_api.adapters.mcp_adapter import _AegraMCPServer, _current_user
+    from aegra_api.models.auth import User
+
+    service = MCPService()
+    service.call_tool = AsyncMock(return_value={"answer": 42})  # type: ignore[method-assign]
+
+    server = _AegraMCPServer(service)
+
+    # Set the ContextVar so call_tool can read the authenticated user
+    test_user = User(identity="test-user", is_authenticated=True, permissions=[])
+    token = _current_user.set(test_user)
+    try:
+        result = await server.call_tool("some_agent", {"q": "hello"})
+    finally:
+        _current_user.reset(token)
+
+    assert len(result) == 1
+    block = result[0]
+    assert isinstance(block, TextContent)
+    assert json.loads(block.text) == {"answer": 42}
+    service.call_tool.assert_awaited_once_with("some_agent", {"q": "hello"}, test_user)
+
+
+@pytest.mark.asyncio
+async def test_aegra_mcp_server_list_tools_empty_registry() -> None:
+    """_AegraMCPServer.list_tools returns empty list when no graphs are registered."""
+    from aegra_api.adapters.mcp_adapter import _AegraMCPServer
+
+    service = _make_service({})
+    server = _AegraMCPServer(service)
+
+    tools = await server.list_tools()
+
+    assert tools == []

--- a/libs/aegra-api/tests/unit/adapters/test_a2a_service.py
+++ b/libs/aegra-api/tests/unit/adapters/test_a2a_service.py
@@ -211,6 +211,16 @@ def test_card_url_uses_assistant_id() -> None:
 # ---------------------------------------------------------------------------
 
 
+def _make_null_session_maker() -> MagicMock:
+    """Return a mock session maker whose sessions return None from scalar."""
+    mock_session = AsyncMock()
+    mock_session.scalar = AsyncMock(return_value=None)
+    mock_maker = MagicMock()
+    mock_maker.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_maker.return_value.__aexit__ = AsyncMock(return_value=False)
+    return mock_maker
+
+
 @pytest.mark.asyncio
 async def test_send_message_delegates_to_wait_for_run() -> None:
     """send_message invokes wait_for_run and returns a Task dict."""
@@ -224,6 +234,9 @@ async def test_send_message_delegates_to_wait_for_run() -> None:
     with patch(
         "aegra_api.adapters.a2a_service.wait_for_run",
         new=AsyncMock(return_value=fake_output),
+    ), patch(
+        "aegra_api.adapters.a2a_service._get_session_maker",
+        return_value=_make_null_session_maker(),
     ):
         result = await service.send_message(
             assistant_id="my_graph",
@@ -253,6 +266,9 @@ async def test_send_message_generates_thread_id_when_none() -> None:
     with patch(
         "aegra_api.adapters.a2a_service.wait_for_run",
         side_effect=_capture_wait,
+    ), patch(
+        "aegra_api.adapters.a2a_service._get_session_maker",
+        return_value=_make_null_session_maker(),
     ):
         result = await service.send_message(
             assistant_id="agent",
@@ -289,6 +305,9 @@ async def test_send_message_returns_no_artifacts_when_empty_output() -> None:
     with patch(
         "aegra_api.adapters.a2a_service.wait_for_run",
         new=AsyncMock(return_value={}),
+    ), patch(
+        "aegra_api.adapters.a2a_service._get_session_maker",
+        return_value=_make_null_session_maker(),
     ):
         result = await service.send_message(
             assistant_id="graph",

--- a/libs/aegra-api/tests/unit/adapters/test_a2a_service.py
+++ b/libs/aegra-api/tests/unit/adapters/test_a2a_service.py
@@ -1,0 +1,299 @@
+"""Unit tests for the A2A service layer."""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain_core.messages import AIMessage
+
+from aegra_api.adapters.a2a_service import (
+    RUN_STATUS_TO_TASK_STATE,
+    A2AService,
+    convert_output_to_parts,
+    convert_parts_to_langchain,
+)
+from aegra_api.models.auth import User
+
+_TEST_USER = User(identity="test-user", is_authenticated=True, permissions=[])
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_service(registry: dict[str, Any]) -> A2AService:
+    """Create an A2AService with a minimal mocked LangGraphService."""
+    langgraph_service = MagicMock()
+    langgraph_service._graph_registry = registry
+    service = A2AService()
+    service.set_langgraph_service(langgraph_service)
+    return service
+
+
+# ---------------------------------------------------------------------------
+# convert_parts_to_langchain
+# ---------------------------------------------------------------------------
+
+
+def test_text_part_becomes_human_message() -> None:
+    """A text part dict is converted to a single HumanMessage."""
+    from langchain_core.messages import HumanMessage
+
+    parts = [{"kind": "text", "text": "hello world"}]
+    result = convert_parts_to_langchain(parts)
+
+    assert len(result) == 1
+    assert isinstance(result[0], HumanMessage)
+    assert result[0].content == "hello world"
+
+
+def test_non_text_part_raises_error() -> None:
+    """A non-text part raises ValueError."""
+    parts = [{"kind": "file", "data": "base64stuff"}]
+
+    with pytest.raises(ValueError, match="Unsupported part kind"):
+        convert_parts_to_langchain(parts)
+
+
+def test_multiple_text_parts_become_multiple_messages() -> None:
+    """Multiple text parts produce one HumanMessage each."""
+    from langchain_core.messages import HumanMessage
+
+    parts = [
+        {"kind": "text", "text": "first"},
+        {"kind": "text", "text": "second"},
+    ]
+    result = convert_parts_to_langchain(parts)
+
+    assert len(result) == 2
+    assert all(isinstance(m, HumanMessage) for m in result)
+    assert result[0].content == "first"
+    assert result[1].content == "second"
+
+
+def test_empty_parts_list_returns_empty_messages() -> None:
+    """An empty parts list produces an empty message list."""
+    result = convert_parts_to_langchain([])
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# convert_output_to_parts
+# ---------------------------------------------------------------------------
+
+
+def test_string_content_becomes_text_part() -> None:
+    """An AIMessage with string content becomes a single text part."""
+    output: dict[str, Any] = {"messages": [AIMessage(content="Response text")]}
+    result = convert_output_to_parts(output)
+
+    assert len(result) == 1
+    assert result[0]["kind"] == "text"
+    assert result[0]["text"] == "Response text"
+
+
+def test_empty_output_returns_empty_parts() -> None:
+    """An empty output dict produces an empty parts list."""
+    result = convert_output_to_parts({})
+    assert result == []
+
+
+def test_output_without_messages_key_returns_empty_parts() -> None:
+    """Output without a 'messages' key produces an empty parts list."""
+    result = convert_output_to_parts({"state": "done"})
+    assert result == []
+
+
+def test_non_ai_messages_are_skipped() -> None:
+    """HumanMessage and other non-AI messages are filtered out."""
+    from langchain_core.messages import HumanMessage
+
+    output: dict[str, Any] = {
+        "messages": [
+            HumanMessage(content="user input"),
+            AIMessage(content="ai response"),
+        ]
+    }
+    result = convert_output_to_parts(output)
+
+    assert len(result) == 1
+    assert result[0]["text"] == "ai response"
+
+
+def test_list_content_with_text_blocks_extracted() -> None:
+    """AIMessage with list content containing text blocks is converted correctly."""
+    output: dict[str, Any] = {
+        "messages": [
+            AIMessage(content=[{"type": "text", "text": "block text"}])
+        ]
+    }
+    result = convert_output_to_parts(output)
+
+    assert len(result) == 1
+    assert result[0]["text"] == "block text"
+
+
+def test_list_content_non_text_blocks_skipped() -> None:
+    """Non-text blocks in list content are silently skipped."""
+    output: dict[str, Any] = {
+        "messages": [
+            AIMessage(content=[{"type": "tool_use", "id": "123", "name": "foo"}])
+        ]
+    }
+    result = convert_output_to_parts(output)
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# RUN_STATUS_TO_TASK_STATE
+# ---------------------------------------------------------------------------
+
+
+def test_all_statuses_mapped() -> None:
+    """Every run status in RUN_STATUS_TO_TASK_STATE maps to a valid TaskState value."""
+    from a2a.types import TaskState
+
+    valid_states = {s.value for s in TaskState}
+
+    for run_status, task_state_value in RUN_STATUS_TO_TASK_STATE.items():
+        assert task_state_value in valid_states, (
+            f"Run status {run_status!r} maps to {task_state_value!r} "
+            f"which is not a valid TaskState"
+        )
+
+
+def test_status_mapping_covers_known_run_statuses() -> None:
+    """The expected run statuses are present in the mapping."""
+    expected = {"pending", "running", "success", "error", "interrupted"}
+    assert expected.issubset(set(RUN_STATUS_TO_TASK_STATE.keys()))
+
+
+# ---------------------------------------------------------------------------
+# A2AService.build_agent_card
+# ---------------------------------------------------------------------------
+
+
+def test_generates_card_with_correct_fields() -> None:
+    """build_agent_card returns an agent card with the expected structure."""
+    service = _make_service({})
+
+    card = service.build_agent_card(
+        assistant_id="my-agent",
+        name="My Agent",
+        description="Does stuff",
+        base_url="http://localhost:2026",
+    )
+
+    assert card["name"] == "My Agent"
+    assert card["description"] == "Does stuff"
+    assert card["url"] == "http://localhost:2026/a2a/my-agent"
+    assert "capabilities" in card
+    assert isinstance(card["skills"], list)
+    assert len(card["skills"]) >= 1
+
+
+def test_card_url_uses_assistant_id() -> None:
+    """build_agent_card embeds the assistant_id in the URL path."""
+    service = _make_service({})
+
+    card = service.build_agent_card(
+        assistant_id="special-graph",
+        name="Special",
+        description="Special graph",
+        base_url="https://example.com",
+    )
+
+    assert card["url"] == "https://example.com/a2a/special-graph"
+
+
+# ---------------------------------------------------------------------------
+# A2AService.send_message
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_message_delegates_to_wait_for_run() -> None:
+    """send_message invokes wait_for_run and returns a Task dict."""
+    registry: dict[str, Any] = {"my_graph": {"file_path": "g.py", "export_name": "graph"}}
+    service = _make_service(registry)
+
+    fake_output: dict[str, Any] = {
+        "messages": [AIMessage(content="Graph output")]
+    }
+
+    with patch(
+        "aegra_api.adapters.a2a_service.wait_for_run",
+        new=AsyncMock(return_value=fake_output),
+    ):
+        result = await service.send_message(
+            assistant_id="my_graph",
+            parts=[{"kind": "text", "text": "Hello"}],
+            user=_TEST_USER,
+            context_id="ctx-thread",
+        )
+
+    assert result["contextId"] == "ctx-thread"
+    assert result["status"]["state"].value == "completed"
+    assert len(result["artifacts"]) == 1
+    assert result["artifacts"][0]["parts"][0]["text"] == "Graph output"
+
+
+@pytest.mark.asyncio
+async def test_send_message_generates_thread_id_when_none() -> None:
+    """send_message generates a thread_id when context_id is not supplied."""
+    registry: dict[str, Any] = {"agent": {"file_path": "a.py", "export_name": "graph"}}
+    service = _make_service(registry)
+
+    captured_thread_ids: list[str] = []
+
+    async def _capture_wait(thread_id: str, request: Any, user: Any) -> dict[str, Any]:
+        captured_thread_ids.append(thread_id)
+        return {}
+
+    with patch(
+        "aegra_api.adapters.a2a_service.wait_for_run",
+        side_effect=_capture_wait,
+    ):
+        result = await service.send_message(
+            assistant_id="agent",
+            parts=[{"kind": "text", "text": "hi"}],
+            user=_TEST_USER,
+        )
+
+    assert len(captured_thread_ids) == 1
+    assert isinstance(captured_thread_ids[0], str)
+    assert len(captured_thread_ids[0]) > 0
+    assert result["contextId"] is not None
+
+
+@pytest.mark.asyncio
+async def test_send_message_raises_on_non_text_parts() -> None:
+    """send_message propagates ValueError from convert_parts_to_langchain."""
+    registry: dict[str, Any] = {"graph": {}}
+    service = _make_service(registry)
+
+    with pytest.raises(ValueError, match="Unsupported part kind"):
+        await service.send_message(
+            assistant_id="graph",
+            parts=[{"kind": "image", "url": "http://example.com/img.png"}],
+            user=_TEST_USER,
+        )
+
+
+@pytest.mark.asyncio
+async def test_send_message_returns_no_artifacts_when_empty_output() -> None:
+    """send_message returns None artifacts when the graph emits no AI messages."""
+    registry: dict[str, Any] = {"graph": {}}
+    service = _make_service(registry)
+
+    with patch(
+        "aegra_api.adapters.a2a_service.wait_for_run",
+        new=AsyncMock(return_value={}),
+    ):
+        result = await service.send_message(
+            assistant_id="graph",
+            parts=[{"kind": "text", "text": "hello"}],
+            user=_TEST_USER,
+        )
+
+    assert result["artifacts"] is None

--- a/libs/aegra-api/tests/unit/adapters/test_a2a_service.py
+++ b/libs/aegra-api/tests/unit/adapters/test_a2a_service.py
@@ -164,7 +164,7 @@ def test_all_statuses_mapped() -> None:
 
 def test_status_mapping_covers_known_run_statuses() -> None:
     """The expected run statuses are present in the mapping."""
-    expected = {"pending", "running", "success", "error", "interrupted"}
+    expected = {"pending", "running", "success", "error", "timeout", "interrupted"}
     assert expected.issubset(set(RUN_STATUS_TO_TASK_STATE.keys()))
 
 

--- a/libs/aegra-api/tests/unit/adapters/test_config.py
+++ b/libs/aegra-api/tests/unit/adapters/test_config.py
@@ -1,0 +1,52 @@
+"""Tests for A2A/MCP config fields in HttpConfig."""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+from aegra_api.config import HttpConfig, load_http_config
+
+
+def test_http_config_accepts_disable_a2a() -> None:
+    """HttpConfig TypedDict allows disable_a2a field."""
+    config: HttpConfig = {"disable_a2a": True}
+    assert config["disable_a2a"] is True
+
+
+def test_http_config_accepts_disable_mcp() -> None:
+    """HttpConfig TypedDict allows disable_mcp field."""
+    config: HttpConfig = {"disable_mcp": True}
+    assert config["disable_mcp"] is True
+
+
+def test_load_http_config_returns_disable_flags(tmp_path: Path) -> None:
+    """load_http_config returns disable_a2a and disable_mcp from aegra.json."""
+    config_file = tmp_path / "aegra.json"
+    config_file.write_text(
+        json.dumps(
+            {
+                "graphs": {},
+                "http": {"disable_a2a": True, "disable_mcp": False},
+            }
+        )
+    )
+    with patch("aegra_api.config._resolve_config_path", return_value=config_file):
+        result = load_http_config()
+
+    assert result is not None
+    assert result["disable_a2a"] is True
+    assert result["disable_mcp"] is False
+
+
+def test_load_http_config_defaults_when_flags_absent(tmp_path: Path) -> None:
+    """When disable_a2a/disable_mcp are absent, they default to False via .get()."""
+    config_file = tmp_path / "aegra.json"
+    config_file.write_text(
+        json.dumps({"graphs": {}, "http": {"enable_custom_route_auth": False}})
+    )
+    with patch("aegra_api.config._resolve_config_path", return_value=config_file):
+        result = load_http_config()
+
+    assert result is not None
+    assert result.get("disable_a2a", False) is False
+    assert result.get("disable_mcp", False) is False

--- a/libs/aegra-api/tests/unit/adapters/test_mcp_service.py
+++ b/libs/aegra-api/tests/unit/adapters/test_mcp_service.py
@@ -1,0 +1,197 @@
+"""Unit tests for the MCP service layer."""
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aegra_api.adapters.mcp_service import MCPService
+from aegra_api.models.auth import User
+
+_TEST_USER = User(identity="test-user", is_authenticated=True, permissions=[])
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_service(registry: dict[str, Any]) -> MCPService:
+    """Create an MCPService with a minimal mocked LangGraphService."""
+    langgraph_service = MagicMock()
+    langgraph_service._graph_registry = registry
+    service = MCPService()
+    service.set_langgraph_service(langgraph_service)
+    return service
+
+
+def _make_mock_graph(schema: dict[str, Any]) -> MagicMock:
+    """Create a mock compiled Pregel graph with a given input schema."""
+    graph = MagicMock()
+    graph.get_input_jsonschema.return_value = schema
+    return graph
+
+
+# ---------------------------------------------------------------------------
+# MCPService.list_tools
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_returns_tool_per_graph() -> None:
+    """list_tools returns exactly one tool for each registered graph."""
+    registry: dict[str, Any] = {
+        "graph_a": {"file_path": "a.py", "export_name": "graph"},
+        "graph_b": {"file_path": "b.py", "export_name": "graph"},
+    }
+    service = _make_service(registry)
+    service._langgraph_service._get_base_graph = AsyncMock(
+        return_value=_make_mock_graph({"type": "object"})
+    )
+
+    tools = await service.list_tools()
+
+    assert len(tools) == 2
+    names = {t["name"] for t in tools}
+    assert names == {"graph_a", "graph_b"}
+
+
+@pytest.mark.asyncio
+async def test_tool_has_input_schema_from_graph() -> None:
+    """list_tools embeds the graph's input JSON schema under inputSchema."""
+    expected_schema: dict[str, Any] = {
+        "type": "object",
+        "properties": {"messages": {"type": "array"}},
+    }
+    registry: dict[str, Any] = {"my_agent": {"file_path": "x.py", "export_name": "graph"}}
+    service = _make_service(registry)
+    service._langgraph_service._get_base_graph = AsyncMock(
+        return_value=_make_mock_graph(expected_schema)
+    )
+
+    tools = await service.list_tools()
+
+    assert len(tools) == 1
+    assert tools[0]["inputSchema"] == expected_schema
+
+
+@pytest.mark.asyncio
+async def test_tool_description_uses_graph_id() -> None:
+    """list_tools sets description to 'Run the {graph_id} agent'."""
+    registry: dict[str, Any] = {"cool_graph": {"file_path": "y.py", "export_name": "graph"}}
+    service = _make_service(registry)
+    service._langgraph_service._get_base_graph = AsyncMock(
+        return_value=_make_mock_graph({"type": "object"})
+    )
+
+    tools = await service.list_tools()
+
+    assert tools[0]["description"] == "Run the cool_graph agent"
+
+
+@pytest.mark.asyncio
+async def test_list_tools_skips_graph_that_fails_to_load() -> None:
+    """list_tools omits any graph whose _get_base_graph raises."""
+    registry: dict[str, Any] = {
+        "good": {"file_path": "g.py", "export_name": "graph"},
+        "bad": {"file_path": "b.py", "export_name": "graph"},
+    }
+    service = _make_service(registry)
+
+    async def _get_base_graph_side_effect(graph_id: str) -> MagicMock:
+        if graph_id == "bad":
+            raise ValueError("Cannot load graph")
+        return _make_mock_graph({"type": "object"})
+
+    service._langgraph_service._get_base_graph = AsyncMock(
+        side_effect=_get_base_graph_side_effect
+    )
+
+    tools = await service.list_tools()
+
+    assert len(tools) == 1
+    assert tools[0]["name"] == "good"
+
+
+# ---------------------------------------------------------------------------
+# MCPService.call_tool
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unknown_tool_raises_value_error() -> None:
+    """call_tool raises ValueError for an unregistered tool name."""
+    registry: dict[str, Any] = {"existing": {"file_path": "e.py", "export_name": "graph"}}
+    service = _make_service(registry)
+
+    with pytest.raises(ValueError, match="Unknown tool"):
+        await service.call_tool("nonexistent", {}, _TEST_USER)
+
+
+@pytest.mark.asyncio
+async def test_call_tool_delegates_to_wait_for_run() -> None:
+    """call_tool delegates execution to wait_for_run and returns its output."""
+    expected_output: dict[str, Any] = {"result": "hello"}
+    registry: dict[str, Any] = {"agent": {"file_path": "a.py", "export_name": "graph"}}
+    service = _make_service(registry)
+
+    with patch(
+        "aegra_api.adapters.mcp_service.stateless_wait_for_run",
+        new=AsyncMock(return_value=expected_output),
+    ):
+        result = await service.call_tool("agent", {"messages": []}, _TEST_USER)
+
+    assert result == expected_output
+
+
+@pytest.mark.asyncio
+async def test_call_tool_passes_graph_registry_to_resolve() -> None:
+    """call_tool forwards the full graph registry to resolve_assistant_id."""
+    registry: dict[str, Any] = {"my_graph": {"file_path": "m.py", "export_name": "graph"}}
+    service = _make_service(registry)
+
+    captured_calls: list[tuple[str, Any]] = []
+
+    def _capture_resolve(requested_id: str, available_graphs: Any) -> str:
+        captured_calls.append((requested_id, available_graphs))
+        return "resolved-assistant-id"
+
+    with (
+        patch(
+            "aegra_api.adapters.mcp_service.resolve_assistant_id",
+            side_effect=_capture_resolve,
+        ),
+        patch(
+            "aegra_api.adapters.mcp_service.stateless_wait_for_run",
+            new=AsyncMock(return_value={}),
+        ),
+    ):
+        await service.call_tool("my_graph", {}, _TEST_USER)
+
+    assert len(captured_calls) == 1
+    called_id, called_registry = captured_calls[0]
+    assert called_id == "my_graph"
+    assert called_registry is registry
+
+
+@pytest.mark.asyncio
+async def test_call_tool_creates_run_request_with_correct_fields() -> None:
+    """call_tool builds a RunCreate with the resolved assistant_id and input."""
+    registry: dict[str, Any] = {"agent": {"file_path": "a.py", "export_name": "graph"}}
+    service = _make_service(registry)
+
+    captured_request: list[Any] = []
+
+    async def _capture_wait_for_run(request: Any, user: Any) -> dict[str, Any]:
+        captured_request.append((request, user))
+        return {}
+
+    with patch(
+        "aegra_api.adapters.mcp_service.stateless_wait_for_run",
+        side_effect=_capture_wait_for_run,
+    ):
+        await service.call_tool("agent", {"messages": [{"role": "user", "content": "hi"}]}, _TEST_USER)
+
+    assert len(captured_request) == 1
+    req, user = captured_request[0]
+    assert req.input == {"messages": [{"role": "user", "content": "hi"}]}
+    assert user.identity == "test-user"

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.8.3"
+version = "0.8.4"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -14,10 +14,34 @@ members = [
 ]
 
 [[package]]
+name = "a2a-sdk"
+version = "0.3.25"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "protobuf" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/83/3c99b276d09656cce039464509f05bf385e5600d6dc046a131bbcf686930/a2a_sdk-0.3.25.tar.gz", hash = "sha256:afda85bab8d6af0c5d15e82f326c94190f6be8a901ce562d045a338b7127242f", size = 270638, upload-time = "2026-03-10T13:08:46.417Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/f9/6a62520b7ecb945188a6e1192275f4732ff9341cd4629bc975a6c146aeab/a2a_sdk-0.3.25-py3-none-any.whl", hash = "sha256:2fce38faea82eb0b6f9f9c2bcf761b0d78612c80ef0e599b50d566db1b2654b5", size = 149609, upload-time = "2026-03-10T13:08:44.7Z" },
+]
+
+[package.optional-dependencies]
+http-server = [
+    { name = "fastapi" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+]
+
+[[package]]
 name = "aegra-api"
-version = "0.8.3"
+version = "0.8.4"
 source = { editable = "libs/aegra-api" }
 dependencies = [
+    { name = "a2a-sdk", extra = ["http-server"] },
     { name = "alembic" },
     { name = "asgi-correlation-id" },
     { name = "asyncpg" },
@@ -26,6 +50,7 @@ dependencies = [
     { name = "langgraph" },
     { name = "langgraph-checkpoint-postgres" },
     { name = "langgraph-sdk" },
+    { name = "mcp" },
     { name = "openinference-instrumentation-langchain" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp" },
@@ -55,6 +80,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "a2a-sdk", extras = ["http-server"], specifier = ">=0.3.25" },
     { name = "alembic", specifier = ">=1.16.4" },
     { name = "asgi-correlation-id", specifier = ">=4.3.4" },
     { name = "asyncpg", specifier = ">=0.30.0" },
@@ -63,6 +89,7 @@ requires-dist = [
     { name = "langgraph", specifier = ">=1.0.3" },
     { name = "langgraph-checkpoint-postgres", specifier = ">=2.0.23" },
     { name = "langgraph-sdk", specifier = ">=0.3.5" },
+    { name = "mcp", specifier = ">=1.26.0" },
     { name = "openinference-instrumentation-langchain", specifier = ">=0.1.58" },
     { name = "opentelemetry-api", specifier = ">=1.39.1" },
     { name = "opentelemetry-exporter-otlp", specifier = ">=1.39.1" },
@@ -92,7 +119,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.8.3"
+version = "0.8.4"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },
@@ -595,6 +622,35 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1d/65/ce7f1b70157833bf3cb851b556a37d4547ceafc158aa9b34b36782f23696/filelock-3.20.3.tar.gz", hash = "sha256:18c57ee915c7ec61cff0ecf7f0f869936c7c30191bb0cf406f1341778d0834e1", size = 19485, upload-time = "2026-01-09T17:55:05.421Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b5/36/7fb70f04bf00bc646cd5bb45aa9eddb15e19437a28b8fb2b4a5249fac770/filelock-3.20.3-py3-none-any.whl", hash = "sha256:4b0dda527ee31078689fc205ec4f1c1bf7d56cf88b6dc9426c4f230e46c2dce1", size = 16701, upload-time = "2026-01-09T17:55:04.334Z" },
+]
+
+[[package]]
+name = "google-api-core"
+version = "2.30.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/98/586ec94553b569080caef635f98a3723db36a38eac0e3d7eb3ea9d2e4b9a/google_api_core-2.30.0.tar.gz", hash = "sha256:02edfa9fab31e17fc0befb5f161b3bf93c9096d99aed584625f38065c511ad9b", size = 176959, upload-time = "2026-02-18T20:28:11.926Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/27/09c33d67f7e0dcf06d7ac17d196594e66989299374bfb0d4331d1038e76b/google_api_core-2.30.0-py3-none-any.whl", hash = "sha256:80be49ee937ff9aba0fd79a6eddfde35fe658b9953ab9b79c57dd7061afa8df5", size = 173288, upload-time = "2026-02-18T20:28:10.367Z" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.49.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ea/80/6a696a07d3d3b0a92488933532f03dbefa4a24ab80fb231395b9a2a1be77/google_auth-2.49.1.tar.gz", hash = "sha256:16d40da1c3c5a0533f57d268fe72e0ebb0ae1cc3b567024122651c045d879b64", size = 333825, upload-time = "2026-03-12T19:30:58.135Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/eb/c6c2478d8a8d633460be40e2a8a6f8f429171997a35a96f81d3b680dec83/google_auth-2.49.1-py3-none-any.whl", hash = "sha256:195ebe3dca18eddd1b3db5edc5189b76c13e96f29e73043b923ebcf3f1a860f7", size = 240737, upload-time = "2026-03-12T19:30:53.159Z" },
 ]
 
 [[package]]
@@ -1512,6 +1568,18 @@ wheels = [
 ]
 
 [[package]]
+name = "proto-plus"
+version = "1.27.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/0d/94dfe80193e79d55258345901acd2917523d56e8381bc4dee7fd38e3868a/proto_plus-1.27.2.tar.gz", hash = "sha256:b2adde53adadf75737c44d3dcb0104fde65250dfc83ad59168b4aa3e574b6a24", size = 57204, upload-time = "2026-03-26T22:18:57.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/f3/1fba73eeffafc998a25d59703b63f8be4fe8a5cb12eaff7386a0ba0f7125/proto_plus-1.27.2-py3-none-any.whl", hash = "sha256:6432f75893d3b9e70b9c412f1d2f03f65b11fb164b793d14ae2ca01821d22718", size = 50450, upload-time = "2026-03-26T22:13:42.927Z" },
+]
+
+[[package]]
 name = "protobuf"
 version = "6.33.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1594,6 +1662,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/56/9a/9470d013d0d50af0da9c4251614aeb3c1823635cab3edc211e3839db0bcf/psycopg_pool-3.3.0.tar.gz", hash = "sha256:fa115eb2860bd88fce1717d75611f41490dec6135efb619611142b24da3f6db5", size = 31606, upload-time = "2025-12-01T11:34:33.11Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e7/c3/26b8a0908a9db249de3b4169692e1c7c19048a9bc41a4d3209cee7dbb758/psycopg_pool-3.3.0-py3-none-any.whl", hash = "sha256:2e44329155c410b5e8666372db44276a8b1ebd8c90f1c3026ebba40d4bc81063", size = 39995, upload-time = "2025-12-01T11:34:29.761Z" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description
Adds two new "adapters" to the server. 

- MCP
- A2A

Based on the implementation and functionality provided by LangSmith Platform today, the goal was to create a simple layer that reuses existing API methods and authentication. This allows adapters to follow any changes in how certain processes work under the hood.

This is paired with some tests that also evaluate them using MCP and A2A client libraries.

## Type of Change
<!-- Check the relevant option -->
- [x] `feat`: New feature
- [ ] `fix`: Bug fix
- [x] `docs`: Documentation changes
- [ ] `style`: Code style/formatting
- [ ] `refactor`: Code refactoring
- [ ] `perf`: Performance improvement
- [x] `test`: Tests added/updated
- [ ] `chore`: Maintenance (dependencies, build, etc.)
- [ ] `ci`: CI/CD changes

## Related Issues
https://github.com/ibbybuilds/aegra/issues/75


## Changes Made
<!-- List the main changes -->
- New adapter pattern (Adapter + Service) for adding interfaces for other common protocols, expandable to add more later.
- Main Updated to init and mount routes/services for MCP & A2A
- A2A Service and Adapter Added
- MCP Service and Adapter Added
- Docs added and updated where needed for it.

## Testing
<!-- Describe how you tested your changes -->
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] E2E tests added/updated
- [ ] Manual testing performed

## Checklist
<!-- Ensure all items are checked before requesting review -->
- [x] Code follows project style (Ruff formatting)
- [x] All linting checks pass (`make lint`)
- [ ] Type checking passes (`make type-check`) 
- [x] All tests pass (`make test`)
- [x] Documentation updated (if needed)
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] PR title follows Conventional Commits format

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Additional Notes

Type Check Failed but seems like many things are also failing that which are existing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * A2A agent-to-agent JSON-RPC endpoints, agent discovery, and streaming messaging; MCP endpoint exposing agents as tools (streamable HTTP). Adapters enabled by default and respect existing auth.

* **Configuration**
  * New http flags to enable/disable A2A and MCP adapters.

* **Documentation**
  * New A2A and MCP guides, README updates, and config examples with client snippets.

* **Tests**
  * Extensive unit, integration, and end-to-end tests covering A2A/MCP and auth.

* **Chores**
  * Package version bumps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->