### PR TITLE
feat(mcp): add Model Context Protocol adapter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,7 @@ aegra/
 │   ├── aegra-api/                    # Core API package
 │   │   ├── src/aegra_api/            # Main application code
 │   │   │   ├── api/                  # Agent Protocol endpoints
+│   │   │   ├── adapters/             # Protocol adapters (MCP)
 │   │   │   ├── services/             # Business logic layer
 │   │   │   ├── core/                 # Infrastructure (database, auth, orm, health, migrations)
 │   │   │   ├── models/               # Pydantic request/response schemas
@@ -70,7 +71,7 @@ aegra/
 │
 ├── examples/                         # Example agents and configs
 ├── docs/                             # Documentation
-├── aegra.json                        # Project configuration (graphs, auth, http, store)
+├── aegra.json                        # Project configuration (graphs, auth, http, mcp, store)
 └── docker-compose.yml                # Local development setup
 ```
 
@@ -253,6 +254,11 @@ Aegra runs against user-managed Postgres including multi-host HA (PR #299). DB c
 
 ## Architecture
 
+### Protocol Adapters
+The `adapters/` directory contains protocol bridge implementations that expose Aegra agents via additional protocols:
+
+- **MCP adapter** — Implements [Model Context Protocol](https://modelcontextprotocol.io/) at `/mcp` using Streamable HTTP transport via [FastMCP](https://gofastmcp.com). Exposes each configured graph as an MCP tool (one tool per graph, name = graph_id). Enabled by default; disable via `aegra.json` (`http.disable_mcp`). Configure response filtering via `mcp.final_response_only` in `aegra.json` to return only the last AI message instead of the full graph state. Uses the same auth stack as the Agent Protocol endpoints. Optional auth provider (`mcp.auth.path` in `aegra.json`) points to a Python file exporting a FastMCP auth provider for spec-compliant MCP OAuth flow, while Aegra's `@auth.authenticate` handler remains the final authority.
+
 ### Database Architecture
 The system uses two connection pools:
 1. **SQLAlchemy Pool** (asyncpg driver) - Metadata tables: assistants, threads, runs
@@ -261,7 +267,7 @@ The system uses two connection pools:
 **URL format:** LangGraph requires `postgresql://` while SQLAlchemy uses `postgresql+asyncpg://`
 
 ### Configuration
-**aegra.json** defines graphs, auth, HTTP config, and store settings. See `docs/configuration.md` for full reference.
+**aegra.json** defines graphs, auth, HTTP config, MCP behavior, and store settings. See `docs/configuration.md` for full reference.
 
 ### Graph Loading
 Agents are Python modules exporting a `graph` variable. This can be:

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ async for chunk in client.runs.stream(
 ## ✨ Features
 
 - **[Agent Protocol](https://github.com/langchain-ai/agent-protocol) compliant** - Works with Agent Chat UI, LangGraph Studio, CopilotKit
+- **[MCP support](https://modelcontextprotocol.io/)** - Use deployed agents as tools in Claude Desktop, Cursor, and any MCP client
 - **[Worker architecture](https://docs.aegra.dev/guides/worker-architecture)** - Redis job queue with 30 concurrent runs per instance, lease-based crash recovery, and horizontal scaling across multiple instances
 - **[Human-in-the-loop](https://docs.aegra.dev/guides/human-in-the-loop)** - Approval gates and user intervention points
 - **[Streaming](https://docs.aegra.dev/guides/streaming)** - Real-time SSE streaming with cross-instance pub/sub and automatic reconnection with event replay

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,198 @@
+# MCP (Model Context Protocol)
+
+Aegra exposes all configured graphs as MCP tools via the [Model Context Protocol](https://modelcontextprotocol.io/). This lets you use your deployed agents as tools in Claude Desktop, Cursor, and any other MCP-compatible client.
+
+## Overview
+
+When Aegra starts, it automatically creates one MCP tool per graph defined in `aegra.json`. The tool name matches the `graph_id`, and the input schema is auto-discovered from the graph's input schema.
+
+Each tool invocation runs the agent and returns its output. The transport is Streamable HTTP, which supports both request/response and streaming interactions.
+
+## Endpoint
+
+```text
+POST /mcp
+```
+
+Aegra exposes a single Streamable HTTP endpoint at `/mcp`. All MCP interactions go through this endpoint using the standard MCP JSON-RPC protocol over HTTP.
+
+## Connecting from Claude Desktop
+
+Add the following to your Claude Desktop configuration (`~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
+
+```json
+{
+  "mcpServers": {
+    "aegra": {
+      "url": "http://localhost:2026/mcp",
+      "transport": "streamable-http"
+    }
+  }
+}
+```
+
+After restarting Claude Desktop, your Aegra agents will appear as available tools.
+
+## Connecting from Python
+
+Using the FastMCP client:
+
+```python
+from fastmcp import Client
+
+async with Client("http://localhost:2026/mcp") as client:
+    tools = await client.list_tools()
+    print(tools)
+```
+
+Or using the lower-level MCP SDK:
+
+```python
+from mcp.client.streamable_http import streamable_http_client
+from mcp import ClientSession
+
+async with streamable_http_client(url="http://localhost:2026/mcp") as (read, write, _):
+    async with ClientSession(read, write) as session:
+        await session.initialize()
+        tools = await session.list_tools()
+        print(tools)
+```
+
+## Tool discovery
+
+Each graph becomes one MCP tool:
+
+- **Tool name**: the `graph_id` from `aegra.json` (e.g., `"agent"`, `"assistant"`)
+- **Input schema**: auto-derived from the graph's input schema
+- **Description**: the graph's `description` field if set in config, otherwise `"Run the {graph_id} agent"`
+
+For example, if `aegra.json` defines:
+
+```json
+{
+  "graphs": {
+    "agent": "./src/agent/graph.py:graph",
+    "researcher": "./src/researcher/graph.py:graph"
+  }
+}
+```
+
+Then two MCP tools are exposed: `agent` and `researcher`.
+
+## Authentication
+
+MCP uses the same authentication as the rest of Aegra. If you have an `auth` handler configured in `aegra.json`, all MCP requests go through it.
+
+For Claude Desktop and other clients that support HTTP headers, pass your token in the `Authorization` header:
+
+```json
+{
+  "mcpServers": {
+    "aegra": {
+      "url": "http://localhost:2026/mcp",
+      "transport": "streamable-http",
+      "headers": {
+        "Authorization": "Bearer <your-token>"
+      }
+    }
+  }
+}
+```
+
+If no auth is configured, all MCP requests are allowed.
+
+### MCP auth provider (spec-compliant OAuth)
+
+For MCP clients that support the [MCP OAuth flow](https://modelcontextprotocol.io/specification/2025-03-26/basic/authorization) (Dynamic Client Registration, authorization redirects, token exchange), Aegra can delegate authentication to any [FastMCP auth provider](https://gofastmcp.com/servers/auth).
+
+Create a Python file that exports a FastMCP auth provider, then point to it via `mcp.auth.path` in `aegra.json`:
+
+**aegra.json:**
+
+```json
+{
+  "graphs": {
+    "agent": "./src/agent/graph.py:graph"
+  },
+  "mcp": {
+    "auth": {
+      "path": "./mcp_auth.py:mcp_auth"
+    }
+  }
+}
+```
+
+**mcp_auth.py** (example using OIDCProxy):
+
+```python
+import os
+from fastmcp.server.auth.oidc_proxy import OIDCProxy
+
+mcp_auth = OIDCProxy(
+    config_url="https://your-idp.com/.well-known/openid-configuration",
+    client_id="your-client-id",
+    client_secret=os.environ["MCP_OIDC_CLIENT_SECRET"],
+    base_url="http://localhost:2026/mcp",
+)
+```
+
+Because the auth provider is a Python file, you can use any FastMCP auth provider -- `OIDCProxy`, a custom implementation, or anything that implements the FastMCP auth provider interface. You also have full control over constructor parameters, including objects that cannot be expressed in JSON config (custom token verifiers, storage backends, etc.).
+
+See [`examples/mcp_auth_example.py`](../examples/mcp_auth_example.py) for more configurations (PKCE clients, custom token verifiers, extra OAuth params).
+
+When an auth provider is configured:
+
+1. **FastMCP handles the OAuth flow** -- MCP clients authenticate through the standard OAuth dance.
+2. **Aegra's `@auth.authenticate` handler has the final say** -- the validated upstream token is forwarded to your auth handler as `Authorization: Bearer <upstream-token>`. Your handler decides identity, permissions, and whether to allow the request.
+
+This means the auth provider enables the token exchange flow, but never bypasses Aegra's auth. If no `mcp.auth.path` is configured, requests pass through as anonymous.
+
+The `path` format supports the same conventions as `auth.path`:
+- `./mcp_auth.py:mcp_auth` -- load from a file relative to `aegra.json`
+- `./src/auth/mcp.py:provider` -- nested path
+- `mypackage.mcp_auth:provider` -- load from an installed package
+
+## Stateless operation
+
+The MCP endpoint is stateless. Each tool call is an independent request — there are no persistent sessions. State between calls is not maintained at the MCP layer. If you need persistent conversation state, use the Agent Protocol (`/threads` and `/runs`) directly.
+
+## Configuration
+
+MCP is enabled by default. To disable it, set `disable_mcp` in the `http` section of `aegra.json`:
+
+```json
+{
+  "graphs": {
+    "agent": "./src/agent/graph.py:graph"
+  },
+  "http": {
+    "disable_mcp": true
+  }
+}
+```
+
+See the [configuration reference](/reference/configuration) for all `http` options.
+
+## Response filtering
+
+By default, MCP tool calls return the **full graph state** — including all intermediate messages (tool calls, tool responses, reasoning steps). For agents with a `messages` list in their state, this can be verbose.
+
+To return only the last AI message, enable `final_response_only` in the `mcp` section of `aegra.json`:
+
+```json
+{
+  "graphs": {
+    "agent": "./src/agent/graph.py:graph"
+  },
+  "mcp": {
+    "final_response_only": true
+  }
+}
+```
+
+When enabled, the MCP adapter extracts the last AI message from the output and returns it as a single JSON object. If no AI message is found (e.g., non-message-based graphs), the full output is returned as a fallback.
+
+| Setting | Default | Behavior |
+|---------|---------|----------|
+| `final_response_only: false` | Yes | Return full graph state (all messages, metadata) |
+| `final_response_only: true` | No | Return only the last AI message |

--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -3,7 +3,7 @@ title: "Configuration"
 description: "Complete reference for the aegra.json configuration file."
 ---
 
-Aegra uses a JSON configuration file (`aegra.json`) to define graphs, authentication, HTTP settings, and the semantic store.
+Aegra uses a JSON configuration file (`aegra.json`) to define graphs, authentication, HTTP settings, MCP behavior, and the semantic store.
 
 ## Config file resolution
 
@@ -40,6 +40,12 @@ aegra dev
     "cors": {
       "allow_origins": ["https://example.com"],
       "allow_credentials": true
+    }
+  },
+  "mcp": {
+    "final_response_only": false,
+    "auth": {
+      "path": "./mcp_auth.py:mcp_auth"
     }
   },
   "store": {
@@ -227,6 +233,7 @@ Configure custom routes and CORS.
   "http": {
     "app": "./custom_routes.py:app",
     "enable_custom_route_auth": false,
+    "disable_mcp": false,
     "cors": {
       "allow_origins": ["https://example.com"],
       "allow_credentials": true
@@ -239,10 +246,52 @@ Configure custom routes and CORS.
 |-------|------|---------|-------------|
 | `app` | `string` | `None` | Import path to custom FastAPI app |
 | `enable_custom_route_auth` | `bool` | `false` | Apply Aegra auth to all custom routes |
+| `disable_mcp` | `bool` | `false` | Disable the MCP (Model Context Protocol) endpoint at `/mcp` |
 | `cors.allow_origins` | `list[str]` | `["*"]` | Allowed CORS origins |
 | `cors.allow_credentials` | `bool` | `false` when origins is `["*"]`, `true` otherwise | Allow credentials in CORS requests |
 
 See [custom routes guide](/guides/custom-routes) for details.
+
+### `disable_mcp`
+- **Type:** `boolean`
+- **Default:** `false`
+- Disable the MCP (Model Context Protocol) endpoint at `/mcp`.
+
+## `mcp`
+
+Configure MCP (Model Context Protocol) behavior.
+
+```json
+{
+  "mcp": {
+    "final_response_only": true,
+    "auth": {
+      "path": "./mcp_auth.py:mcp_auth"
+    }
+  }
+}
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `final_response_only` | `bool` | `false` | Return only the last AI message from tool calls instead of the full graph state |
+| `auth` | `object` | — | Auth provider config for spec-compliant MCP OAuth |
+| `auth.path` | `string` | — | Import path to a Python file exporting a [FastMCP auth provider](https://gofastmcp.com/servers/auth) |
+
+### `final_response_only`
+- **Type:** `boolean`
+- **Default:** `false`
+- When `true`, MCP tool call responses contain only the last AI message (as a JSON object) instead of the full graph state. Useful when MCP clients don't need intermediate reasoning, tool calls, and tool responses.
+
+### `auth`
+
+Enables spec-compliant MCP OAuth authentication by pointing to a Python file that exports a [FastMCP auth provider](https://gofastmcp.com/servers/auth).
+
+The `path` format is the same as `auth.path`: `./file.py:variable` or `module:variable`. Relative paths are resolved from the `aegra.json` directory.
+
+Because the provider is constructed in Python, you can use any FastMCP auth provider and have full control over all constructor parameters.
+
+See [MCP guide](/mcp) for details and examples.
 
 ## `store`
 

--- a/examples/mcp_auth_example.py
+++ b/examples/mcp_auth_example.py
@@ -1,0 +1,65 @@
+"""Example MCP auth provider configurations.
+
+Export one of these as ``mcp.auth.path`` in aegra.json:
+
+    {
+      "mcp": {
+        "auth": {
+          "path": "./examples/mcp_auth_example.py:mcp_auth"
+        }
+      }
+    }
+
+The auth provider can be any object that implements the FastMCP auth
+provider interface.  Below are three common configurations using
+FastMCP's built-in OIDCProxy.  Uncomment the one that matches your
+setup and fill in the values.
+"""
+
+import os
+
+from fastmcp.server.auth.oidc_proxy import OIDCProxy
+
+# ---------------------------------------------------------------------------
+# Option 1: Confidential client (most common)
+# ---------------------------------------------------------------------------
+mcp_auth = OIDCProxy(
+    config_url="https://your-idp.com/.well-known/openid-configuration",
+    client_id=os.environ.get("MCP_OIDC_CLIENT_ID", "your-client-id"),
+    client_secret=os.environ.get("MCP_OIDC_CLIENT_SECRET", "your-client-secret"),
+    audience="https://api.example.com",
+    required_scopes=["openid", "profile", "email"],
+    base_url=os.environ.get("SERVER_URL", "http://localhost:2026") + "/mcp",
+)
+
+# ---------------------------------------------------------------------------
+# Option 2: Public PKCE client (no client_secret, e.g. SPA or CLI)
+# ---------------------------------------------------------------------------
+# mcp_auth = OIDCProxy(
+#     config_url="https://your-idp.com/.well-known/openid-configuration",
+#     client_id=os.environ.get("MCP_OIDC_CLIENT_ID", "your-public-client-id"),
+#     jwt_signing_key=os.environ["MCP_OIDC_JWT_SIGNING_KEY"],
+#     token_endpoint_auth_method="none",
+#     base_url=os.environ.get("SERVER_URL", "http://localhost:2026") + "/mcp",
+# )
+
+# ---------------------------------------------------------------------------
+# Option 3: Advanced — custom token verifier, extra OAuth params
+# ---------------------------------------------------------------------------
+# from fastmcp.server.auth.providers.introspection import IntrospectionTokenVerifier
+#
+# verifier = IntrospectionTokenVerifier(
+#     introspection_endpoint="https://your-idp.com/oauth2/introspect",
+#     client_id="your-client-id",
+#     client_secret=os.environ["MCP_OIDC_CLIENT_SECRET"],
+# )
+#
+# mcp_auth = OIDCProxy(
+#     config_url="https://your-idp.com/.well-known/openid-configuration",
+#     client_id="your-client-id",
+#     client_secret=os.environ["MCP_OIDC_CLIENT_SECRET"],
+#     base_url=os.environ.get("SERVER_URL", "http://localhost:2026") + "/mcp",
+#     token_verifier=verifier,
+#     extra_authorize_params={"prompt": "consent", "access_type": "offline"},
+#     allowed_client_redirect_uris=["http://localhost:*", "https://*.example.com/*"],
+# )

--- a/libs/aegra-api/README.md
+++ b/libs/aegra-api/README.md
@@ -7,6 +7,7 @@ Aegra is an open-source, self-hosted alternative to LangSmith Deployments. This 
 ## Features
 
 - **Agent Protocol Compliant**: Works with Agent Chat UI, LangGraph Studio, CopilotKit
+- **MCP Support**: Exposes agents as MCP tools for Claude Desktop, Cursor, and other MCP clients
 - **Drop-in Replacement**: Compatible with the LangGraph SDK
 - **Self-Hosted**: Run on your own PostgreSQL database
 - **Streaming Support**: Real-time streaming of agent responses
@@ -121,6 +122,7 @@ OTEL_TARGETS=LANGFUSE,PHOENIX
 | `/store/items/search` | POST | Semantic search |
 | `/store/namespaces` | POST | List store namespaces |
 | `/health` | GET | Health check |
+| `/mcp` | POST | MCP (Model Context Protocol) Streamable HTTP endpoint |
 
 ## Creating Graphs
 

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.9.16"
+version = "0.9.17"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -51,6 +51,9 @@ dependencies = [
 
     # Redis (optional broker backend for multi-instance streaming)
     "redis[hiredis]>=5.0.0",
+
+    # Protocol adapters
+    "fastmcp>=3.2.0,<4.0.0",
 ]
 
 [project.urls]

--- a/libs/aegra-api/src/aegra_api/adapters/__init__.py
+++ b/libs/aegra-api/src/aegra_api/adapters/__init__.py
@@ -1,0 +1,1 @@
+"""Protocol adapters (MCP) that expose Aegra graphs via additional protocols."""

--- a/libs/aegra-api/src/aegra_api/adapters/mcp_adapter.py
+++ b/libs/aegra-api/src/aegra_api/adapters/mcp_adapter.py
@@ -1,0 +1,297 @@
+"""MCP adapter — exposes configured graphs as MCP tools at /mcp."""
+
+import contextvars
+import importlib
+import importlib.util
+import json
+import sys
+from collections.abc import AsyncIterator, Callable
+from contextlib import AbstractAsyncContextManager, asynccontextmanager
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+import mcp.types as mcp_types
+import structlog
+from fastapi import FastAPI, HTTPException
+from fastmcp import FastMCP
+from fastmcp.exceptions import ToolError
+from fastmcp.tools.base import Tool, ToolResult
+from mcp.server.auth.middleware.bearer_auth import AuthenticatedUser
+from pydantic import SkipValidation
+from sqlalchemy import select
+from starlette.middleware import Middleware
+from starlette.requests import Request as StarletteRequest
+from starlette.responses import JSONResponse as StarletteJSONResponse
+from starlette.routing import Route
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+from aegra_api.api.stateless_runs import _delete_thread_by_id
+from aegra_api.config import get_config_dir, load_mcp_config
+from aegra_api.core.auth_deps import _to_user_model
+from aegra_api.core.auth_middleware import get_auth_backend
+from aegra_api.core.orm import Run as RunORM
+from aegra_api.core.orm import _get_session_maker
+from aegra_api.models.auth import User
+from aegra_api.models.runs import RunCreate
+from aegra_api.services.executor import executor
+from aegra_api.services.langgraph_service import LangGraphService
+from aegra_api.services.run_preparation import _prepare_run
+from aegra_api.settings import settings
+from aegra_api.utils.assistants import resolve_assistant_id
+
+logger = structlog.get_logger(__name__)
+
+_current_user: contextvars.ContextVar[User | None] = contextvars.ContextVar("_mcp_current_user", default=None)
+_final_response_only: bool | None = None
+mcp_server = FastMCP("aegra")
+
+
+def _is_final_response_only() -> bool:
+    global _final_response_only
+    if _final_response_only is None:
+        mcp_cfg = load_mcp_config()
+        _final_response_only = bool(mcp_cfg.get("final_response_only", False)) if mcp_cfg else False
+    return _final_response_only
+
+
+def _extract_final_response(output: dict[str, Any]) -> str:
+    messages = output.get("messages", [])
+    if not messages:
+        return json.dumps(output)
+    for msg in reversed(messages):
+        if isinstance(msg, dict) and msg.get("type") == "ai":
+            return json.dumps(msg)
+    return json.dumps(output)
+
+
+async def _read_run_result(run_id: str, thread_id: str, user_id: str) -> tuple[str, dict[str, Any], str | None]:
+    maker = _get_session_maker()
+    async with maker() as session:
+        run_orm = await session.scalar(
+            select(RunORM).where(
+                RunORM.run_id == run_id,
+                RunORM.thread_id == thread_id,
+                RunORM.user_id == user_id,
+            )
+        )
+    if not run_orm:
+        return "error", {}, "Run not found"
+    return run_orm.status, run_orm.output or {}, run_orm.error_message
+
+
+_OAUTH_FLOW_SUFFIXES = ("/register", "/authorize", "/token", "/consent", "/auth/callback")
+_mcp_oauth_enabled: bool = False
+
+
+class _AuthMiddleware:
+    """Bridges MCP requests to Aegra's auth backend, swapping upstream OAuth tokens when present."""
+
+    def __init__(self, app: ASGIApp, **_kwargs: Any) -> None:
+        self._app = app
+
+    @staticmethod
+    def _is_oauth_path(path: str) -> bool:
+        stripped = path.rstrip("/")
+        return stripped.endswith(_OAUTH_FLOW_SUFFIXES)
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] == "lifespan":
+            await self._app(scope, receive, send)
+            return
+        if scope["type"] != "http":
+            response = StarletteJSONResponse(status_code=400, content={"error": "Unsupported scope type"})
+            await response(scope, receive, send)
+            return
+
+        path = scope.get("path", "")
+        if self._is_oauth_path(path):
+            await self._app(scope, receive, send)
+            return
+
+        auth_user = scope.get("user")
+        if isinstance(auth_user, AuthenticatedUser):
+            upstream = f"Bearer {auth_user.access_token.token}".encode()
+            scope["headers"] = [(k, upstream if k == b"authorization" else v) for k, v in scope["headers"]]
+
+        request = StarletteRequest(scope, receive)
+        backend = get_auth_backend()
+
+        try:
+            result = await backend.authenticate(request)
+        except Exception as exc:
+            if _mcp_oauth_enabled:
+                await self._app(scope, receive, send)
+                return
+            logger.warning("mcp_auth_failed", error=str(exc))
+            response = StarletteJSONResponse(status_code=401, content={"error": "Authentication failed"})
+            await response(scope, receive, send)
+            return
+
+        if result is None:
+            anonymous = User(identity="anonymous", is_authenticated=True, permissions=[])
+            token = _current_user.set(anonymous)
+            try:
+                await self._app(scope, receive, send)
+            finally:
+                _current_user.reset(token)
+            return
+
+        _credentials, user_obj = result
+        token = _current_user.set(_to_user_model(user_obj))
+        try:
+            await self._app(scope, receive, send)
+        finally:
+            _current_user.reset(token)
+
+
+class _GraphTool(Tool):
+    graph_id: str
+    langgraph_service: SkipValidation[LangGraphService]
+
+    model_config = {"arbitrary_types_allowed": True}
+
+    async def run(self, arguments: dict[str, Any]) -> ToolResult:
+        user = _current_user.get()
+        if user is None:
+            raise RuntimeError("No authenticated user in MCP context")
+
+        registry = self.langgraph_service._graph_registry
+        assistant_id = resolve_assistant_id(self.graph_id, registry)
+        thread_id = str(uuid4())
+        request = RunCreate(assistant_id=assistant_id, input=arguments)
+
+        maker = _get_session_maker()
+        try:
+            try:
+                async with maker() as session:
+                    run_id, _run, _job = await _prepare_run(session, thread_id, request, user, initial_status="pending")
+            except HTTPException as exc:
+                raise ToolError(exc.detail) from exc
+
+            try:
+                await executor.wait_for_completion(run_id, timeout=settings.worker.BG_JOB_TIMEOUT_SECS)
+            except TimeoutError as exc:
+                raise ToolError("Graph execution timed out") from exc
+
+            status, output, error_msg = await _read_run_result(run_id, thread_id, user.identity)
+        finally:
+            try:
+                await _delete_thread_by_id(thread_id, user.identity)
+            except Exception:
+                logger.exception("mcp_thread_cleanup_failed", thread_id=thread_id)
+
+        if status == "error":
+            raise ToolError(error_msg or "Graph execution failed")
+
+        text = _extract_final_response(output) if _is_final_response_only() else json.dumps(output)
+        return ToolResult(content=[mcp_types.TextContent(type="text", text=text)])
+
+
+async def register_mcp_tools(service: LangGraphService) -> None:
+    for graph_id, graph_meta in service._graph_registry.items():
+        try:
+            graph = await service._get_base_graph(graph_id)
+            input_schema = graph.get_input_jsonschema()
+        except Exception:
+            logger.exception("mcp_register_tool_failed", graph_id=graph_id)
+            continue
+
+        description = (
+            graph_meta.get("description", f"Run the {graph_id} agent")
+            if isinstance(graph_meta, dict)
+            else f"Run the {graph_id} agent"
+        )
+
+        tool = _GraphTool(
+            name=graph_id,
+            description=description,
+            parameters=input_schema,
+            graph_id=graph_id,
+            langgraph_service=service,
+        )
+        mcp_server.add_tool(tool)
+        logger.info("mcp_tool_registered", graph_id=graph_id)
+
+
+_mcp_app_lifespan: Callable[..., AbstractAsyncContextManager[Any]] | None = None
+
+
+def _load_mcp_auth_provider(path: str) -> Any:
+    """Load auth provider from ``./file.py:var`` or ``module:var`` path."""
+    if ":" not in path:
+        raise ValueError(f"Invalid MCP auth path format (missing ':'): {path}")
+
+    module_path, var_name = path.rsplit(":", 1)
+
+    is_file_path = module_path.endswith(".py") or module_path.startswith("./") or module_path.startswith("../")
+    if is_file_path:
+        file_path = Path(module_path)
+        if not file_path.is_absolute():
+            config_dir = get_config_dir()
+            file_path = ((config_dir / file_path) if config_dir else (Path.cwd() / file_path)).resolve()
+
+        if not file_path.exists():
+            raise FileNotFoundError(f"MCP auth file not found: {file_path}")
+        if not file_path.is_file():
+            raise ValueError(f"MCP auth path is not a file: {file_path}")
+
+        module_name = f"mcp_auth_module_{file_path.stem}"
+        spec = importlib.util.spec_from_file_location(module_name, str(file_path))
+        if spec is None or spec.loader is None:
+            raise ImportError(f"Could not create module spec from {file_path}")
+
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+        spec.loader.exec_module(module)
+    else:
+        module = importlib.import_module(module_path)
+
+    provider = getattr(module, var_name, None)
+    if provider is None:
+        raise AttributeError(f"Variable '{var_name}' not found in {module_path}")
+
+    logger.info("mcp_auth_provider_loaded", path=path)
+    return provider
+
+
+def mount_mcp(app: FastAPI) -> None:
+    """Mount the MCP Streamable HTTP endpoint at ``/mcp``."""
+    global _mcp_app_lifespan, _mcp_oauth_enabled
+
+    mcp_cfg = load_mcp_config()
+    auth_cfg = (mcp_cfg or {}).get("auth")
+
+    auth_provider: Any = None
+    if auth_cfg and "path" in auth_cfg:
+        auth_provider = _load_mcp_auth_provider(auth_cfg["path"])
+        mcp_server.auth = auth_provider
+        _mcp_oauth_enabled = True
+
+    mcp_app = mcp_server.http_app(
+        path="/",
+        stateless_http=True,
+        middleware=[Middleware(_AuthMiddleware)],
+    )
+
+    if auth_provider is not None and hasattr(auth_provider, "get_well_known_routes"):
+        # Provider's base_url already includes mount path; passing mcp_path would double it.
+        well_known_routes: list[Route] = auth_provider.get_well_known_routes()
+        for route in well_known_routes:
+            app.routes.insert(0, route)
+        logger.info("mcp_mounted", auth_provider=True, well_known_routes=[r.path for r in well_known_routes])
+    else:
+        logger.info("mcp_mounted")
+
+    _mcp_app_lifespan = mcp_app.lifespan
+    app.mount("/mcp", mcp_app)
+
+
+@asynccontextmanager
+async def mcp_lifespan() -> AsyncIterator[None]:
+    """FastAPI doesn't propagate lifespan to mounted apps."""
+    if _mcp_app_lifespan is None:
+        yield
+        return
+    async with _mcp_app_lifespan(None):
+        yield

--- a/libs/aegra-api/src/aegra_api/adapters/mcp_adapter.py
+++ b/libs/aegra-api/src/aegra_api/adapters/mcp_adapter.py
@@ -168,6 +168,8 @@ class _GraphTool(Tool):
                     run_id, _run, _job = await _prepare_run(session, thread_id, request, user, initial_status="pending")
             except HTTPException as exc:
                 raise ToolError(exc.detail) from exc
+            except Exception as exc:
+                raise ToolError(f"Run preparation failed: {exc}") from exc
 
             try:
                 await executor.wait_for_completion(run_id, timeout=settings.worker.BG_JOB_TIMEOUT_SECS)

--- a/libs/aegra-api/src/aegra_api/adapters/mcp_adapter.py
+++ b/libs/aegra-api/src/aegra_api/adapters/mcp_adapter.py
@@ -20,6 +20,7 @@ from fastmcp.tools.base import Tool, ToolResult
 from mcp.server.auth.middleware.bearer_auth import AuthenticatedUser
 from pydantic import SkipValidation
 from sqlalchemy import select
+from starlette.authentication import AuthenticationError
 from starlette.middleware import Middleware
 from starlette.requests import Request as StarletteRequest
 from starlette.responses import JSONResponse as StarletteJSONResponse
@@ -119,7 +120,7 @@ class _AuthMiddleware:
 
         try:
             result = await backend.authenticate(request)
-        except Exception as exc:
+        except (AuthenticationError, HTTPException) as exc:
             if _mcp_oauth_enabled:
                 await self._app(scope, receive, send)
                 return

--- a/libs/aegra-api/src/aegra_api/config.py
+++ b/libs/aegra-api/src/aegra_api/config.py
@@ -1,8 +1,8 @@
-"""Configuration management for Aegra HTTP settings"""
+"""Configuration management for Aegra settings (HTTP, auth, store, MCP)"""
 
 import json
 from pathlib import Path
-from typing import TypedDict
+from typing import Any, TypedDict
 
 import structlog
 
@@ -23,7 +23,7 @@ class CorsConfig(TypedDict, total=False):
 
 
 class HttpConfig(TypedDict, total=False):
-    """HTTP configuration options for custom routes"""
+    """HTTP configuration options for custom routes and protocol adapters"""
 
     app: str
     """Import path for custom Starlette/FastAPI app to mount"""
@@ -31,6 +31,8 @@ class HttpConfig(TypedDict, total=False):
     """Apply Aegra authentication dependency to custom routes (uses FastAPI dependencies, not middleware)"""
     cors: CorsConfig | None
     """Custom CORS configuration"""
+    disable_mcp: bool
+    """Disable MCP (Model Context Protocol) endpoint. Default: False (enabled)."""
 
 
 class StoreIndexConfig(TypedDict, total=False):
@@ -80,6 +82,31 @@ class AuthConfig(TypedDict, total=False):
     """Disable authentication for LangGraph Studio connections"""
 
 
+class McpAuthConfig(TypedDict, total=False):
+    """MCP auth provider configuration.
+
+    Points to a Python file exporting a FastMCP auth provider.
+    """
+
+    path: str
+    """Import path for MCP auth provider in format './file.py:variable' or 'module:variable'.
+    Examples:
+    - './mcp_auth.py:mcp_auth' - Load from mcp_auth.py
+    - './src/auth/mcp.py:provider' - Load from nested path
+    - 'mypackage.mcp_auth:provider' - Load from installed package
+    """
+
+
+class McpConfig(TypedDict, total=False):
+    """MCP (Model Context Protocol) behavior configuration."""
+
+    final_response_only: bool
+    """Return only the last AI message instead of the full graph state. Default: False."""
+    auth: McpAuthConfig | None
+    """Auth provider config for spec-compliant MCP OAuth. Points to a Python file
+    exporting a FastMCP auth provider."""
+
+
 def _resolve_config_path() -> Path | None:
     """Resolve config file path using standard resolution order.
 
@@ -111,7 +138,7 @@ def _resolve_config_path() -> Path | None:
     return None
 
 
-def load_config() -> dict | None:
+def load_config() -> dict[str, Any] | None:
     """Load full config file using standard resolution order.
 
     Returns:
@@ -192,6 +219,27 @@ def load_auth_config() -> AuthConfig | None:
         config_path = _resolve_config_path()
         logger.info(f"Loaded auth config from {config_path}")
         return auth_config
+
+    return None
+
+
+def load_mcp_config() -> McpConfig | None:
+    """Load MCP config from aegra.json or langgraph.json.
+
+    Uses standard config resolution order.
+
+    Returns:
+        MCP configuration dict or None if not found
+    """
+    config = load_config()
+    if config is None:
+        return None
+
+    mcp_config = config.get("mcp")
+    if mcp_config:
+        config_path = _resolve_config_path()
+        logger.info(f"Loaded MCP config from {config_path}")
+        return mcp_config
 
     return None
 

--- a/libs/aegra-api/src/aegra_api/main.py
+++ b/libs/aegra-api/src/aegra_api/main.py
@@ -12,6 +12,7 @@ from fastapi.responses import JSONResponse
 from fastapi.routing import APIRoute, APIRouter
 
 from aegra_api import __version__
+from aegra_api.adapters.mcp_adapter import mcp_lifespan, mount_mcp, register_mcp_tools
 from aegra_api.api.assistants import router as assistants_router
 from aegra_api.api.runs import router as runs_router
 from aegra_api.api.stateless_runs import router as stateless_runs_router
@@ -99,6 +100,10 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     langgraph_service = get_langgraph_service()
     await langgraph_service.initialize()
 
+    # Register graph tools in MCP adapter (skip when MCP is disabled)
+    if not (load_http_config() or {}).get("disable_mcp", False):
+        await register_mcp_tools(langgraph_service)
+
     # Initialize Redis broker (if enabled)
     if settings.redis.REDIS_BROKER_ENABLED:
         try:
@@ -129,7 +134,8 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     if settings.redis.REDIS_BROKER_ENABLED:
         await lease_reaper.start()
 
-    yield
+    async with mcp_lifespan():
+        yield
 
     # Shutdown order: reaper → executor (drains jobs) → broker → Redis → DB
     if settings.redis.REDIS_BROKER_ENABLED:
@@ -197,7 +203,7 @@ def _apply_auth_to_routes(app: FastAPI, auth_deps: list[Any]) -> None:
         auth_deps: List of dependencies to apply (e.g., [Depends(require_auth)])
     """
 
-    def process_routes(routes: list) -> None:
+    def process_routes(routes: list[Any]) -> None:
         """Recursively process routes and nested routers."""
         for route in routes:
             if isinstance(route, APIRoute):
@@ -360,6 +366,10 @@ def create_app() -> FastAPI:
             application.exception_handler(exc_type)(handler)
 
         application.get("/")(root_handler)
+
+    # Mount MCP adapter unless disabled
+    if not (http_config or {}).get("disable_mcp", False):
+        mount_mcp(application)
 
     setup_prometheus_metrics(application)
 

--- a/libs/aegra-api/src/aegra_api/services/langgraph_service.py
+++ b/libs/aegra-api/src/aegra_api/services/langgraph_service.py
@@ -140,16 +140,27 @@ class LangGraphService:
                 )
             seen_modules[mod_name] = graph_id
 
-        for graph_id, graph_path in graphs_config.items():
-            # Parse path format: "./graphs/weather_agent.py:graph"
+        for graph_id, graph_value in graphs_config.items():
+            # Support both string format ("./path.py:export") and dict format
+            # ({"path": "./path.py:export", "description": "..."})
+            if isinstance(graph_value, dict):
+                graph_path = graph_value.get("path", "")
+                description = graph_value.get("description")
+            else:
+                graph_path = graph_value
+                description = None
+
             if ":" not in graph_path:
                 raise ValueError(f"Invalid graph path format: {graph_path}")
 
             file_path, export_name = graph_path.split(":", 1)
-            self._graph_registry[graph_id] = {
+            registry_entry: dict[str, Any] = {
                 "file_path": file_path,
                 "export_name": export_name,
             }
+            if description:
+                registry_entry["description"] = description
+            self._graph_registry[graph_id] = registry_entry
 
     async def _load_all_graph_modules(self) -> None:
         """Eagerly load all graph modules, classifying factories without calling them.

--- a/libs/aegra-api/tests/e2e/test_mcp.py
+++ b/libs/aegra-api/tests/e2e/test_mcp.py
@@ -1,0 +1,89 @@
+"""E2E tests for the MCP adapter endpoint.
+
+Requires a running server with MCP enabled (default).
+"""
+
+import httpx
+import pytest
+
+from aegra_api.settings import settings
+
+MCP_HEADERS: dict[str, str] = {
+    "Content-Type": "application/json",
+    "Accept": "application/json, text/event-stream",
+}
+
+
+def _server_url() -> str:
+    return settings.app.SERVER_URL or f"http://localhost:{settings.app.PORT}"
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_mcp_initialize_returns_server_info() -> None:
+    """POST /mcp with initialize returns a valid JSON-RPC result with serverInfo."""
+    async with httpx.AsyncClient(base_url=_server_url(), timeout=10.0) as client:
+        payload = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "e2e-test", "version": "0.0.1"},
+            },
+        }
+        resp = await client.post("/mcp", json=payload, headers=MCP_HEADERS)
+
+    assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
+    data = resp.json()
+    assert data.get("jsonrpc") == "2.0"
+    assert data.get("id") == 1
+    assert "result" in data, f"Missing 'result' key: {data}"
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_mcp_tools_list_returns_registered_tools() -> None:
+    """POST /mcp with tools/list returns at least one registered tool."""
+    async with httpx.AsyncClient(base_url=_server_url(), timeout=10.0) as client:
+        init_resp = await client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {},
+                    "clientInfo": {"name": "e2e-test", "version": "0.0.1"},
+                },
+            },
+            headers=MCP_HEADERS,
+        )
+        assert init_resp.status_code == 200
+
+        tools_resp = await client.post(
+            "/mcp",
+            json={"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}},
+            headers=MCP_HEADERS,
+        )
+
+    assert tools_resp.status_code == 200, f"Expected 200, got {tools_resp.status_code}: {tools_resp.text}"
+    data = tools_resp.json()
+    assert "result" in data
+    tools = data["result"].get("tools", [])
+    assert len(tools) >= 1, f"Expected at least 1 tool, got {len(tools)}"
+    assert all("name" in t for t in tools), "All tools must have a 'name' field"
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_mcp_endpoint_rejects_invalid_jsonrpc() -> None:
+    """POST /mcp with a malformed JSON-RPC request returns an error response."""
+    async with httpx.AsyncClient(base_url=_server_url(), timeout=10.0) as client:
+        resp = await client.post("/mcp", json={"invalid": "payload"}, headers=MCP_HEADERS)
+
+    assert resp.status_code in (200, 400), f"Unexpected status: {resp.status_code}"
+    data = resp.json()
+    assert "error" in data, "Expected JSON-RPC error for invalid request"

--- a/libs/aegra-api/tests/integration/test_mcp_endpoint.py
+++ b/libs/aegra-api/tests/integration/test_mcp_endpoint.py
@@ -1,0 +1,260 @@
+"""Integration tests for the MCP adapter endpoint."""
+
+import json
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from aegra_api.adapters.mcp_adapter import mcp_lifespan, mount_mcp, register_mcp_tools
+
+
+async def _make_mcp_app(registry: dict[str, Any] | None = None) -> FastAPI:
+    """Build a minimal FastAPI app with MCP mounted and its lifespan wired."""
+
+    @asynccontextmanager
+    async def _lifespan(app: FastAPI) -> AsyncIterator[None]:
+        async with mcp_lifespan():
+            yield
+
+    app = FastAPI(lifespan=_lifespan)
+
+    svc = MagicMock()
+    svc._graph_registry = registry or {}
+    mock_graph = MagicMock()
+    mock_graph.get_input_jsonschema.return_value = {"type": "object"}
+    svc._get_base_graph = AsyncMock(return_value=mock_graph)
+
+    await register_mcp_tools(svc)
+    mount_mcp(app)
+    return app
+
+
+def _parse_sse_json(text: str) -> dict[str, Any]:
+    """Extract the first JSON-RPC payload from an SSE response body."""
+    for line in text.strip().split("\n"):
+        if line.startswith("data: "):
+            return json.loads(line[6:])
+    raise ValueError(f"No SSE data line found in response: {text!r}")
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> None:
+    """Reset module-level state between tests."""
+    from aegra_api.adapters import mcp_adapter
+
+    mcp_adapter._final_response_only = None
+    mcp_adapter._mcp_app_lifespan = None
+    mcp_adapter.mcp_server._local_provider._components.clear()
+
+
+def test_unmounted_mcp_returns_404() -> None:
+    """When MCP is not mounted (e.g. disable_mcp=true), /mcp returns 404."""
+    app = FastAPI()
+    client = TestClient(app)
+    resp = client.post("/mcp", json={})
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_mcp_endpoint_responds_to_initialize() -> None:
+    """POST /mcp with an MCP initialize request returns a valid JSON-RPC response."""
+    app = await _make_mcp_app()
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        payload = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "test", "version": "0.0.1"},
+            },
+        }
+        resp = client.post(
+            "/mcp",
+            json=payload,
+            headers={"Content-Type": "application/json", "Accept": "application/json, text/event-stream"},
+        )
+
+    assert resp.status_code == 200, f"Expected 200, got {resp.status_code}: {resp.text}"
+    data = _parse_sse_json(resp.text)
+    assert data.get("jsonrpc") == "2.0"
+    assert data.get("id") == 1
+    assert "result" in data
+
+
+@pytest.mark.asyncio
+async def test_mcp_endpoint_tools_list() -> None:
+    """POST /mcp tools/list returns one tool per registered graph."""
+    registry: dict[str, Any] = {
+        "my_agent": {"file_path": "agent.py", "export_name": "graph"},
+    }
+    app = await _make_mcp_app(registry)
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        init_payload = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "test", "version": "0.0.1"},
+            },
+        }
+        init_resp = client.post(
+            "/mcp",
+            json=init_payload,
+            headers={"Content-Type": "application/json", "Accept": "application/json, text/event-stream"},
+        )
+        assert init_resp.status_code == 200
+
+        tools_payload = {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/list",
+            "params": {},
+        }
+        tools_resp = client.post(
+            "/mcp",
+            json=tools_payload,
+            headers={"Content-Type": "application/json", "Accept": "application/json, text/event-stream"},
+        )
+
+    assert tools_resp.status_code == 200
+    tools_data = _parse_sse_json(tools_resp.text)
+    assert "result" in tools_data
+    tools = tools_data["result"].get("tools", [])
+    assert len(tools) == 1
+    assert tools[0]["name"] == "my_agent"
+
+
+@pytest.mark.asyncio
+async def test_mcp_auth_rejects_unauthenticated() -> None:
+    """MCP endpoint returns 401 when auth backend rejects."""
+    from starlette.authentication import AuthenticationError
+
+    app = await _make_mcp_app({"agent": {}})
+
+    mock_backend = MagicMock()
+    mock_backend.authenticate = AsyncMock(side_effect=AuthenticationError("Invalid token"))
+
+    with patch("aegra_api.adapters.mcp_adapter.get_auth_backend", return_value=mock_backend):
+        client = TestClient(app, raise_server_exceptions=False)
+        resp = client.post(
+            "/mcp",
+            json={"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+            headers={"Accept": "application/json, text/event-stream"},
+        )
+
+    assert resp.status_code == 401
+
+
+def test_mcp_final_response_only_loads_from_config(tmp_path: Any, monkeypatch: Any) -> None:
+    """_is_final_response_only reads the mcp section from aegra.json."""
+    from aegra_api.adapters import mcp_adapter
+    from aegra_api.adapters.mcp_adapter import _is_final_response_only
+
+    monkeypatch.chdir(tmp_path)
+    mcp_adapter._final_response_only = None
+
+    config_file = tmp_path / "aegra.json"
+    config_file.write_text(
+        json.dumps(
+            {
+                "graphs": {"test": "./test.py:graph"},
+                "mcp": {"final_response_only": True},
+            }
+        )
+    )
+
+    assert _is_final_response_only() is True
+
+    mcp_adapter._final_response_only = None
+    config_file.write_text(
+        json.dumps(
+            {
+                "graphs": {"test": "./test.py:graph"},
+            }
+        )
+    )
+
+    assert _is_final_response_only() is False
+
+
+# ============================================================================
+# Auth provider integration tests
+# ============================================================================
+
+
+def test_mount_mcp_with_auth_provider() -> None:
+    """When mcp.auth.path is configured, mount_mcp loads the provider and sets mcp_server.auth."""
+    from aegra_api.adapters import mcp_adapter
+
+    mcp_config: dict[str, Any] = {"final_response_only": False, "auth": {"path": "./mcp_auth.py:provider"}}
+
+    app = FastAPI()
+    mock_provider = MagicMock()
+    mock_provider.get_well_known_routes.return_value = []
+    mock_starlette_app = MagicMock()
+    mock_starlette_app.lifespan = None
+
+    with (
+        patch("aegra_api.adapters.mcp_adapter.load_mcp_config", return_value=mcp_config),
+        patch("aegra_api.adapters.mcp_adapter._load_mcp_auth_provider", return_value=mock_provider) as mock_load,
+        patch.object(mcp_adapter.mcp_server, "http_app", return_value=mock_starlette_app),
+    ):
+        mount_mcp(app)
+
+    mock_load.assert_called_once_with("./mcp_auth.py:provider")
+    assert mcp_adapter.mcp_server.auth is mock_provider
+
+
+def test_mount_mcp_without_auth_config() -> None:
+    """When no mcp.auth config, mount_mcp uses _AuthMiddleware only (auth stays None)."""
+    from aegra_api.adapters import mcp_adapter
+
+    mcp_adapter.mcp_server.auth = None
+
+    app = FastAPI()
+
+    with patch("aegra_api.adapters.mcp_adapter.load_mcp_config", return_value=None):
+        mount_mcp(app)
+
+    assert mcp_adapter.mcp_server.auth is None
+
+
+def test_mcp_auth_config_loads_from_aegra_json(tmp_path: Any, monkeypatch: Any) -> None:
+    """load_mcp_config correctly parses mcp.auth from aegra.json."""
+    from aegra_api.config import load_mcp_config
+
+    monkeypatch.chdir(tmp_path)
+
+    config_file = tmp_path / "aegra.json"
+    config_file.write_text(
+        json.dumps(
+            {
+                "graphs": {"test": "./test.py:graph"},
+                "mcp": {
+                    "final_response_only": False,
+                    "auth": {
+                        "path": "./mcp_auth.py:provider",
+                    },
+                },
+            }
+        )
+    )
+
+    mcp_cfg = load_mcp_config()
+    assert mcp_cfg is not None
+    assert mcp_cfg.get("final_response_only") is False
+
+    auth = mcp_cfg.get("auth")
+    assert auth is not None
+    assert auth["path"] == "./mcp_auth.py:provider"

--- a/libs/aegra-api/tests/integration/test_mcp_endpoint.py
+++ b/libs/aegra-api/tests/integration/test_mcp_endpoint.py
@@ -49,6 +49,7 @@ def _reset_module_state() -> None:
 
     mcp_adapter._final_response_only = None
     mcp_adapter._mcp_app_lifespan = None
+    mcp_adapter._mcp_oauth_enabled = False
     mcp_adapter.mcp_server._local_provider._components.clear()
 
 

--- a/libs/aegra-api/tests/integration/test_mcp_endpoint.py
+++ b/libs/aegra-api/tests/integration/test_mcp_endpoint.py
@@ -50,6 +50,7 @@ def _reset_module_state() -> None:
     mcp_adapter._final_response_only = None
     mcp_adapter._mcp_app_lifespan = None
     mcp_adapter._mcp_oauth_enabled = False
+    mcp_adapter.mcp_server.auth = None
     mcp_adapter.mcp_server._local_provider._components.clear()
 
 
@@ -220,8 +221,6 @@ def test_mount_mcp_with_auth_provider() -> None:
 def test_mount_mcp_without_auth_config() -> None:
     """When no mcp.auth config, mount_mcp uses _AuthMiddleware only (auth stays None)."""
     from aegra_api.adapters import mcp_adapter
-
-    mcp_adapter.mcp_server.auth = None
 
     app = FastAPI()
 

--- a/libs/aegra-api/tests/integration/test_services/test_langgraph_service_integration.py
+++ b/libs/aegra-api/tests/integration/test_services/test_langgraph_service_integration.py
@@ -134,6 +134,156 @@ class TestLangGraphServiceRealFiles:
                 await service.initialize()
 
 
+class TestLoadGraphRegistryDictFormatIntegration:
+    """Integration tests for dict-format graph config with real files."""
+
+    @pytest.mark.asyncio
+    async def test_initialize_with_dict_format_graphs(self) -> None:
+        """Full initialize with a mix of string and dict format graph entries."""
+        config_data = {
+            "graphs": {
+                "string_graph": "./graphs/test.py:graph",
+                "dict_graph": {
+                    "path": "./graphs/dict.py:agent",
+                    "description": "A described agent",
+                },
+            }
+        }
+
+        with TemporaryDirectory() as temp_dir:
+            config_path = Path(temp_dir) / "aegra.json"
+            config_path.write_text(json.dumps(config_data))
+
+            with (
+                patch("aegra_api.services.langgraph_service.LangGraphService._ensure_default_assistants"),
+                patch("aegra_api.services.langgraph_service.LangGraphService._load_all_graph_modules"),
+            ):
+                service = LangGraphService(str(config_path))
+                await service.initialize()
+
+                assert service.config == config_data
+
+                string_entry = service._graph_registry["string_graph"]
+                assert string_entry["file_path"] == "./graphs/test.py"
+                assert string_entry["export_name"] == "graph"
+                assert "description" not in string_entry
+
+                dict_entry = service._graph_registry["dict_graph"]
+                assert dict_entry["file_path"] == "./graphs/dict.py"
+                assert dict_entry["export_name"] == "agent"
+                assert dict_entry["description"] == "A described agent"
+
+    @pytest.mark.asyncio
+    async def test_initialize_dict_format_invalid_path_raises(self) -> None:
+        """Dict-format entry with missing colon in path raises during initialize."""
+        config_data = {
+            "graphs": {
+                "broken": {
+                    "path": "./graphs/no_export_separator.py",
+                    "description": "Missing colon",
+                }
+            }
+        }
+
+        with TemporaryDirectory() as temp_dir:
+            config_path = Path(temp_dir) / "aegra.json"
+            config_path.write_text(json.dumps(config_data))
+
+            with (
+                patch("aegra_api.services.langgraph_service.LangGraphService._ensure_default_assistants"),
+                patch("aegra_api.services.langgraph_service.LangGraphService._load_all_graph_modules"),
+            ):
+                service = LangGraphService(str(config_path))
+
+                with pytest.raises(ValueError, match="Invalid graph path format"):
+                    await service.initialize()
+
+    @pytest.mark.asyncio
+    async def test_list_graphs_with_dict_format(self) -> None:
+        """list_graphs returns file_path for both string and dict format entries."""
+        config_data = {
+            "graphs": {
+                "str_agent": "./graphs/str.py:graph",
+                "dict_agent": {
+                    "path": "./graphs/dict.py:agent",
+                    "description": "Described agent",
+                },
+            }
+        }
+
+        with TemporaryDirectory() as temp_dir:
+            config_path = Path(temp_dir) / "aegra.json"
+            config_path.write_text(json.dumps(config_data))
+
+            with (
+                patch("aegra_api.services.langgraph_service.LangGraphService._ensure_default_assistants"),
+                patch("aegra_api.services.langgraph_service.LangGraphService._load_all_graph_modules"),
+            ):
+                service = LangGraphService(str(config_path))
+                await service.initialize()
+
+                graphs = service.list_graphs()
+                assert graphs == {
+                    "str_agent": "./graphs/str.py",
+                    "dict_agent": "./graphs/dict.py",
+                }
+
+    @pytest.mark.asyncio
+    async def test_dict_format_description_accessible_from_registry(self) -> None:
+        """Description is stored in registry and accessible for downstream consumers."""
+        config_data = {
+            "graphs": {
+                "my_graph": {
+                    "path": "./graphs/my.py:graph",
+                    "description": "Does important things",
+                }
+            }
+        }
+
+        with TemporaryDirectory() as temp_dir:
+            config_path = Path(temp_dir) / "aegra.json"
+            config_path.write_text(json.dumps(config_data))
+
+            with (
+                patch("aegra_api.services.langgraph_service.LangGraphService._ensure_default_assistants"),
+                patch("aegra_api.services.langgraph_service.LangGraphService._load_all_graph_modules"),
+            ):
+                service = LangGraphService(str(config_path))
+                await service.initialize()
+
+                entry = service._graph_registry["my_graph"]
+                assert entry.get("description") == "Does important things"
+
+    @pytest.mark.asyncio
+    async def test_get_graph_with_dict_format_entry(self) -> None:
+        """get_graph works correctly when the graph was registered via dict format."""
+        service = LangGraphService()
+        service._graph_registry = {
+            "dict_graph": {
+                "file_path": "./graphs/dict.py",
+                "export_name": "agent",
+                "description": "A test agent",
+            }
+        }
+
+        mock_graph = DummyStateGraph()
+        mock_compiled = Mock()
+        mock_compiled.copy = Mock(return_value=mock_compiled)
+        mock_graph.compile = Mock(return_value=mock_compiled)
+
+        with (
+            patch.object(service, "_load_graph_from_file", return_value=mock_graph),
+            patch("aegra_api.core.database.db_manager") as mock_db_manager,
+        ):
+            mock_db_manager.get_checkpointer = Mock(return_value="checkpointer")
+            mock_db_manager.get_store = Mock(return_value="store")
+
+            async with service.get_graph("dict_graph") as graph:
+                assert graph == mock_compiled
+                mock_graph.compile.assert_called_once()
+                mock_compiled.copy.assert_called_once()
+
+
 class TestLangGraphServiceDatabase:
     """Test LangGraphService database integration"""
 

--- a/libs/aegra-api/tests/unit/test_adapters/test_mcp_adapter.py
+++ b/libs/aegra-api/tests/unit/test_adapters/test_mcp_adapter.py
@@ -1,0 +1,723 @@
+"""Unit tests for the MCP adapter."""
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastmcp.exceptions import ToolError
+from fastmcp.server.auth.auth import AccessToken
+from mcp.server.auth.middleware.bearer_auth import AuthenticatedUser
+
+from aegra_api.adapters.mcp_adapter import (
+    _AuthMiddleware,
+    _current_user,
+    _extract_final_response,
+    _GraphTool,
+    _load_mcp_auth_provider,
+    mcp_server,
+    register_mcp_tools,
+)
+from aegra_api.models.auth import User
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state() -> None:
+    """Reset module-level state between tests."""
+    from aegra_api.adapters import mcp_adapter
+
+    mcp_adapter._final_response_only = None
+    mcp_adapter._mcp_oauth_enabled = False
+    mcp_adapter.mcp_server._local_provider._components.clear()
+
+
+def _mock_langgraph_service(registry: dict[str, Any] | None = None) -> MagicMock:
+    """Build a mocked LangGraphService with a fake graph registry."""
+    svc = MagicMock()
+    svc._graph_registry = registry or {}
+    mock_graph = MagicMock()
+    mock_graph.get_input_jsonschema.return_value = {
+        "type": "object",
+        "properties": {"messages": {"type": "array"}},
+    }
+    svc._get_base_graph = AsyncMock(return_value=mock_graph)
+    return svc
+
+
+def _make_graph_tool(*, graph_id: str = "agent", service: MagicMock | None = None) -> _GraphTool:
+    """Create a _GraphTool with a mocked LangGraphService."""
+    if service is None:
+        service = _mock_langgraph_service({"agent": {"file_path": "agent.py", "export_name": "graph"}})
+    return _GraphTool(
+        name=graph_id,
+        description=f"Run the {graph_id} agent",
+        parameters={"type": "object", "properties": {"messages": {"type": "array"}}},
+        graph_id=graph_id,
+        langgraph_service=service,
+    )
+
+
+def _make_access_token(*, client_id: str = "test-client", token: str = "upstream-jwt") -> AccessToken:
+    """Create a minimal AccessToken for testing."""
+    return AccessToken(
+        token=token,
+        client_id=client_id,
+        scopes=["openid"],
+        claims={"sub": "user-123", "email": "alice@example.com"},
+    )
+
+
+def _make_authenticated_scope(access_token: AccessToken) -> dict[str, Any]:
+    """Build an ASGI scope with an AuthenticatedUser (simulating FastMCP auth)."""
+    return {
+        "type": "http",
+        "method": "POST",
+        "path": "/mcp",
+        "query_string": b"",
+        "root_path": "",
+        "headers": [(b"authorization", b"Bearer fastmcp-internal-jwt")],
+        "user": AuthenticatedUser(access_token),
+    }
+
+
+# ---------------------------------------------------------------------------
+# register_mcp_tools
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_register_mcp_tools_registers_one_tool_per_graph() -> None:
+    """One _GraphTool per graph in the registry."""
+    registry: dict[str, Any] = {
+        "agent": {"file_path": "agent.py", "export_name": "graph"},
+        "researcher": {"file_path": "researcher.py", "export_name": "graph"},
+    }
+    svc = _mock_langgraph_service(registry)
+
+    await register_mcp_tools(svc)
+
+    tools = await mcp_server._local_provider.list_tools()
+    assert len(tools) == 2
+    names = {t.name for t in tools}
+    assert names == {"agent", "researcher"}
+
+
+@pytest.mark.asyncio
+async def test_register_mcp_tools_skips_graphs_that_fail_to_load() -> None:
+    """Graphs whose _get_base_graph raises are skipped."""
+    registry: dict[str, Any] = {"broken": {"file_path": "broken.py", "export_name": "graph"}}
+    svc = _mock_langgraph_service(registry)
+    svc._get_base_graph = AsyncMock(side_effect=RuntimeError("load failed"))
+
+    await register_mcp_tools(svc)
+
+    tools = await mcp_server._local_provider.list_tools()
+    assert len(tools) == 0
+
+
+@pytest.mark.asyncio
+async def test_register_mcp_tools_includes_input_schema() -> None:
+    """Registered tools include the graph's input JSON schema."""
+    registry: dict[str, Any] = {"agent": {"file_path": "agent.py", "export_name": "graph"}}
+    svc = _mock_langgraph_service(registry)
+
+    await register_mcp_tools(svc)
+
+    tool = await mcp_server._local_provider.get_tool("agent")
+    assert tool.parameters == {
+        "type": "object",
+        "properties": {"messages": {"type": "array"}},
+    }
+
+
+@pytest.mark.asyncio
+async def test_register_mcp_tools_uses_description_from_config() -> None:
+    """Uses description from graph config when available."""
+    registry: dict[str, Any] = {
+        "agent": {"file_path": "agent.py", "export_name": "graph", "description": "My custom agent"},
+    }
+    svc = _mock_langgraph_service(registry)
+
+    await register_mcp_tools(svc)
+
+    tool = await mcp_server._local_provider.get_tool("agent")
+    assert tool.description == "My custom agent"
+
+
+@pytest.mark.asyncio
+async def test_register_mcp_tools_uses_default_description() -> None:
+    """Falls back to a default description."""
+    registry: dict[str, Any] = {"agent": {"file_path": "agent.py", "export_name": "graph"}}
+    svc = _mock_langgraph_service(registry)
+
+    await register_mcp_tools(svc)
+
+    tool = await mcp_server._local_provider.get_tool("agent")
+    assert tool.description == "Run the agent agent"
+
+
+# ---------------------------------------------------------------------------
+# _GraphTool.run
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_graph_tool_run_raises_when_no_user() -> None:
+    """Raises RuntimeError when no user is in the ContextVar."""
+    tool = _make_graph_tool()
+    with pytest.raises(RuntimeError, match="No authenticated user"):
+        await tool.run({"messages": []})
+
+
+@pytest.mark.asyncio
+async def test_graph_tool_run_executes_graph_and_returns_output() -> None:
+    """Prepares a run, waits, reads output, and returns ToolResult."""
+    svc = _mock_langgraph_service({"agent": {"file_path": "agent.py", "export_name": "graph"}})
+    tool = _make_graph_tool(service=svc)
+
+    user = User(identity="alice", is_authenticated=True, permissions=[])
+    token = _current_user.set(user)
+
+    try:
+        fake_output: dict[str, Any] = {"messages": [{"role": "assistant", "content": "Hello!"}]}
+
+        with (
+            patch("aegra_api.adapters.mcp_adapter._get_session_maker") as mock_maker,
+            patch("aegra_api.adapters.mcp_adapter._prepare_run") as mock_prepare,
+            patch("aegra_api.adapters.mcp_adapter.executor") as mock_executor,
+            patch("aegra_api.adapters.mcp_adapter._read_run_result", new_callable=AsyncMock) as mock_read,
+            patch("aegra_api.adapters.mcp_adapter._delete_thread_by_id", new_callable=AsyncMock),
+        ):
+            mock_session = AsyncMock()
+            mock_maker.return_value = MagicMock(
+                __aenter__=AsyncMock(return_value=mock_session), __aexit__=AsyncMock(return_value=False)
+            )
+            mock_prepare.return_value = ("run-123", MagicMock(), MagicMock())
+            mock_executor.wait_for_completion = AsyncMock()
+            mock_read.return_value = ("success", fake_output, None)
+
+            result = await tool.run({"messages": [{"role": "user", "content": "hi"}]})
+
+        assert len(result.content) == 1
+        assert result.content[0].type == "text"
+        assert '"Hello!"' in result.content[0].text
+    finally:
+        _current_user.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_graph_tool_run_returns_filtered_output_when_final_response_only() -> None:
+    """Returns only the last AI message when final_response_only is enabled."""
+    from aegra_api.adapters import mcp_adapter
+
+    svc = _mock_langgraph_service({"agent": {"file_path": "agent.py", "export_name": "graph"}})
+    tool = _make_graph_tool(service=svc)
+
+    user = User(identity="alice", is_authenticated=True, permissions=[])
+    token = _current_user.set(user)
+
+    try:
+        fake_output: dict[str, Any] = {
+            "messages": [
+                {"type": "human", "content": "Hi"},
+                {"type": "ai", "content": "Thinking..."},
+                {"type": "tool", "content": "Tool result"},
+                {"type": "ai", "content": "Final answer"},
+            ]
+        }
+
+        mcp_adapter._final_response_only = True
+
+        with (
+            patch("aegra_api.adapters.mcp_adapter._get_session_maker") as mock_maker,
+            patch("aegra_api.adapters.mcp_adapter._prepare_run") as mock_prepare,
+            patch("aegra_api.adapters.mcp_adapter.executor") as mock_executor,
+            patch("aegra_api.adapters.mcp_adapter._read_run_result", new_callable=AsyncMock) as mock_read,
+            patch("aegra_api.adapters.mcp_adapter._delete_thread_by_id", new_callable=AsyncMock),
+        ):
+            mock_session = AsyncMock()
+            mock_maker.return_value = MagicMock(
+                __aenter__=AsyncMock(return_value=mock_session), __aexit__=AsyncMock(return_value=False)
+            )
+            mock_prepare.return_value = ("run-123", MagicMock(), MagicMock())
+            mock_executor.wait_for_completion = AsyncMock()
+            mock_read.return_value = ("success", fake_output, None)
+
+            result = await tool.run({"messages": [{"role": "user", "content": "hi"}]})
+
+        assert len(result.content) == 1
+        parsed = json.loads(result.content[0].text)
+        assert parsed["type"] == "ai"
+        assert parsed["content"] == "Final answer"
+    finally:
+        _current_user.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_graph_tool_run_returns_full_output_when_final_response_only_disabled() -> None:
+    """Returns full output when final_response_only is disabled (default)."""
+    from aegra_api.adapters import mcp_adapter
+
+    svc = _mock_langgraph_service({"agent": {"file_path": "agent.py", "export_name": "graph"}})
+    tool = _make_graph_tool(service=svc)
+
+    user = User(identity="alice", is_authenticated=True, permissions=[])
+    token = _current_user.set(user)
+
+    try:
+        fake_output: dict[str, Any] = {
+            "messages": [
+                {"type": "human", "content": "Hi"},
+                {"type": "ai", "content": "Final answer"},
+            ]
+        }
+
+        mcp_adapter._final_response_only = False
+
+        with (
+            patch("aegra_api.adapters.mcp_adapter._get_session_maker") as mock_maker,
+            patch("aegra_api.adapters.mcp_adapter._prepare_run") as mock_prepare,
+            patch("aegra_api.adapters.mcp_adapter.executor") as mock_executor,
+            patch("aegra_api.adapters.mcp_adapter._read_run_result", new_callable=AsyncMock) as mock_read,
+            patch("aegra_api.adapters.mcp_adapter._delete_thread_by_id", new_callable=AsyncMock),
+        ):
+            mock_session = AsyncMock()
+            mock_maker.return_value = MagicMock(
+                __aenter__=AsyncMock(return_value=mock_session), __aexit__=AsyncMock(return_value=False)
+            )
+            mock_prepare.return_value = ("run-123", MagicMock(), MagicMock())
+            mock_executor.wait_for_completion = AsyncMock()
+            mock_read.return_value = ("success", fake_output, None)
+
+            result = await tool.run({"messages": [{"role": "user", "content": "hi"}]})
+
+        assert len(result.content) == 1
+        parsed = json.loads(result.content[0].text)
+        assert parsed == fake_output
+    finally:
+        _current_user.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_graph_tool_run_returns_error_when_run_fails() -> None:
+    """Raises ToolError when the graph run fails."""
+    svc = _mock_langgraph_service({"agent": {"file_path": "agent.py", "export_name": "graph"}})
+    tool = _make_graph_tool(service=svc)
+
+    user = User(identity="alice", is_authenticated=True, permissions=[])
+    token = _current_user.set(user)
+
+    try:
+        with (
+            patch("aegra_api.adapters.mcp_adapter._get_session_maker") as mock_maker,
+            patch("aegra_api.adapters.mcp_adapter._prepare_run") as mock_prepare,
+            patch("aegra_api.adapters.mcp_adapter.executor") as mock_executor,
+            patch("aegra_api.adapters.mcp_adapter._read_run_result", new_callable=AsyncMock) as mock_read,
+            patch("aegra_api.adapters.mcp_adapter._delete_thread_by_id", new_callable=AsyncMock),
+        ):
+            mock_session = AsyncMock()
+            mock_maker.return_value = MagicMock(
+                __aenter__=AsyncMock(return_value=mock_session), __aexit__=AsyncMock(return_value=False)
+            )
+            mock_prepare.return_value = ("run-123", MagicMock(), MagicMock())
+            mock_executor.wait_for_completion = AsyncMock()
+            mock_read.return_value = ("error", {}, "ValueError: bad input")
+
+            with pytest.raises(ToolError, match="ValueError: bad input"):
+                await tool.run({"messages": [{"role": "user", "content": "hi"}]})
+    finally:
+        _current_user.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_graph_tool_run_raises_tool_error_on_timeout() -> None:
+    """Converts TimeoutError into ToolError."""
+    svc = _mock_langgraph_service({"agent": {"file_path": "agent.py", "export_name": "graph"}})
+    tool = _make_graph_tool(service=svc)
+
+    user = User(identity="alice", is_authenticated=True, permissions=[])
+    token = _current_user.set(user)
+
+    try:
+        with (
+            patch("aegra_api.adapters.mcp_adapter._get_session_maker") as mock_maker,
+            patch("aegra_api.adapters.mcp_adapter._prepare_run") as mock_prepare,
+            patch("aegra_api.adapters.mcp_adapter.executor") as mock_executor,
+            patch("aegra_api.adapters.mcp_adapter._delete_thread_by_id", new_callable=AsyncMock) as mock_delete,
+        ):
+            mock_session = AsyncMock()
+            mock_maker.return_value = MagicMock(
+                __aenter__=AsyncMock(return_value=mock_session), __aexit__=AsyncMock(return_value=False)
+            )
+            mock_prepare.return_value = ("run-123", MagicMock(), MagicMock())
+            mock_executor.wait_for_completion = AsyncMock(side_effect=TimeoutError("deadline exceeded"))
+
+            with pytest.raises(ToolError, match="timed out"):
+                await tool.run({"messages": [{"role": "user", "content": "hi"}]})
+
+            mock_delete.assert_awaited_once()
+    finally:
+        _current_user.reset(token)
+
+
+# ---------------------------------------------------------------------------
+# _AuthMiddleware
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_auth_middleware_sets_anonymous_when_backend_returns_none() -> None:
+    """When auth backend returns None, middleware sets anonymous user."""
+    captured_users: list[User | None] = []
+
+    async def _capture_app(scope: Any, receive: Any, send: Any) -> None:
+        captured_users.append(_current_user.get())
+        from starlette.responses import JSONResponse
+
+        response = JSONResponse({"ok": True})
+        await response(scope, receive, send)
+
+    middleware = _AuthMiddleware(_capture_app)
+
+    mock_backend = MagicMock()
+    mock_backend.authenticate = AsyncMock(return_value=None)
+
+    with patch("aegra_api.adapters.mcp_adapter.get_auth_backend", return_value=mock_backend):
+        import httpx
+
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=middleware),
+            base_url="http://test",
+        ) as client:
+            resp = await client.get("/anything")
+
+    assert resp.status_code == 200
+    assert len(captured_users) == 1
+    assert captured_users[0] is not None
+    assert captured_users[0].identity == "anonymous"
+
+
+@pytest.mark.asyncio
+async def test_auth_middleware_rejects_non_http_non_lifespan_scopes() -> None:
+    """Non-http, non-lifespan scopes get 400."""
+
+    async def _noop_app(scope: Any, receive: Any, send: Any) -> None:
+        pass
+
+    middleware = _AuthMiddleware(_noop_app)
+
+    scope: dict[str, Any] = {"type": "websocket", "asgi": {"version": "3.0"}}
+    responses: list[dict[str, Any]] = []
+
+    async def receive() -> dict[str, Any]:
+        return {}
+
+    async def send(msg: dict[str, Any]) -> None:
+        responses.append(msg)
+
+    await middleware(scope, receive, send)
+    assert any(r.get("status") == 400 for r in responses)
+
+
+@pytest.mark.asyncio
+async def test_auth_middleware_passes_through_when_oauth_enabled() -> None:
+    """When MCP OAuth is enabled, auth failures pass through to FastMCP."""
+    from starlette.authentication import AuthenticationError
+
+    from aegra_api.adapters import mcp_adapter
+
+    mcp_adapter._mcp_oauth_enabled = True
+
+    inner_called = False
+
+    async def _inner_app(scope: Any, receive: Any, send: Any) -> None:
+        nonlocal inner_called
+        inner_called = True
+        from starlette.responses import JSONResponse
+
+        response = JSONResponse({"ok": True})
+        await response(scope, receive, send)
+
+    middleware = _AuthMiddleware(_inner_app)
+
+    mock_backend = MagicMock()
+    mock_backend.authenticate = AsyncMock(side_effect=AuthenticationError("Missing token"))
+
+    with patch("aegra_api.adapters.mcp_adapter.get_auth_backend", return_value=mock_backend):
+        import httpx
+
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=middleware),
+            base_url="http://test",
+        ) as client:
+            resp = await client.post("/mcp")
+
+    assert inner_called, "Inner app should be called so FastMCP can return proper 401"
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_auth_middleware_rejects_when_oauth_disabled() -> None:
+    """Without MCP OAuth, auth failures return 401 directly."""
+    from starlette.authentication import AuthenticationError
+
+    from aegra_api.adapters import mcp_adapter
+
+    mcp_adapter._mcp_oauth_enabled = False
+
+    async def _inner_app(scope: Any, receive: Any, send: Any) -> None:
+        pytest.fail("Inner app should NOT be called when OAuth is disabled")
+
+    middleware = _AuthMiddleware(_inner_app)
+
+    mock_backend = MagicMock()
+    mock_backend.authenticate = AsyncMock(side_effect=AuthenticationError("Missing token"))
+
+    with patch("aegra_api.adapters.mcp_adapter.get_auth_backend", return_value=mock_backend):
+        import httpx
+
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=middleware),
+            base_url="http://test",
+        ) as client:
+            resp = await client.post("/mcp")
+
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_auth_middleware_swaps_upstream_token() -> None:
+    """When scope has AuthenticatedUser, swaps the upstream token into headers."""
+    access_token = _make_access_token()
+    captured_headers: list[dict[str, str]] = []
+
+    mock_backend = MagicMock()
+
+    async def _capture_authenticate(conn: Any) -> tuple[Any, Any]:
+        captured_headers.append(dict(conn.headers))
+        user_data = MagicMock()
+        user_data.identity = "alice"
+        user_data.is_authenticated = True
+        user_data.display_name = "Alice"
+        user_data.permissions = []
+        user_data._user_data = {"identity": "alice", "is_authenticated": True}
+        user_data.to_dict.return_value = {"identity": "alice", "is_authenticated": True}
+        return MagicMock(), user_data
+
+    mock_backend.authenticate = AsyncMock(side_effect=_capture_authenticate)
+
+    responses: list[dict[str, Any]] = []
+
+    async def _inner_app(scope: Any, receive: Any, send: Any) -> None:
+        from starlette.responses import JSONResponse
+
+        response = JSONResponse({"ok": True})
+        await response(scope, receive, send)
+
+    middleware = _AuthMiddleware(_inner_app)
+
+    async def receive() -> dict[str, Any]:
+        return {"type": "http.request", "body": b""}
+
+    async def send(msg: dict[str, Any]) -> None:
+        responses.append(msg)
+
+    scope = _make_authenticated_scope(access_token)
+    with patch("aegra_api.adapters.mcp_adapter.get_auth_backend", return_value=mock_backend):
+        await middleware(scope, receive, send)
+
+    assert len(captured_headers) == 1
+    assert captured_headers[0]["authorization"] == "Bearer upstream-jwt"
+
+
+@pytest.mark.asyncio
+async def test_auth_middleware_no_swap_without_authenticated_user() -> None:
+    """Without AuthenticatedUser in scope, passes headers as-is."""
+    captured_headers: list[dict[str, str]] = []
+
+    mock_backend = MagicMock()
+
+    async def _capture_authenticate(conn: Any) -> None:
+        captured_headers.append(dict(conn.headers))
+        return None
+
+    mock_backend.authenticate = AsyncMock(side_effect=_capture_authenticate)
+
+    async def _inner_app(scope: Any, receive: Any, send: Any) -> None:
+        from starlette.responses import JSONResponse
+
+        response = JSONResponse({"ok": True})
+        await response(scope, receive, send)
+
+    middleware = _AuthMiddleware(_inner_app)
+    scope: dict[str, Any] = {
+        "type": "http",
+        "method": "POST",
+        "path": "/mcp",
+        "query_string": b"",
+        "root_path": "",
+        "headers": [(b"authorization", b"Bearer direct-token")],
+    }
+
+    async def receive() -> dict[str, Any]:
+        return {"type": "http.request", "body": b""}
+
+    async def send(msg: dict[str, Any]) -> None:
+        pass
+
+    with patch("aegra_api.adapters.mcp_adapter.get_auth_backend", return_value=mock_backend):
+        await middleware(scope, receive, send)
+
+    assert len(captured_headers) == 1
+    assert captured_headers[0]["authorization"] == "Bearer direct-token"
+
+
+# ---------------------------------------------------------------------------
+# _extract_final_response
+# ---------------------------------------------------------------------------
+
+
+def test_extract_final_response_returns_last_ai_message() -> None:
+    """Extracts the last AI message from a multi-type messages list."""
+    output: dict[str, Any] = {
+        "messages": [
+            {"type": "human", "content": "Hello"},
+            {"type": "ai", "content": "Let me search for that.", "tool_calls": [{"name": "search"}]},
+            {"type": "tool", "content": "Search result: ..."},
+            {"type": "ai", "content": "Here is your answer."},
+        ]
+    }
+    result = _extract_final_response(output)
+    parsed = json.loads(result)
+    assert parsed["type"] == "ai"
+    assert parsed["content"] == "Here is your answer."
+
+
+def test_extract_final_response_returns_full_ai_message_dict() -> None:
+    """Returns the entire AI message dict, not just content."""
+    ai_msg: dict[str, Any] = {
+        "type": "ai",
+        "content": "Done!",
+        "id": "msg-123",
+        "response_metadata": {"model": "gpt-4o"},
+    }
+    output: dict[str, Any] = {"messages": [{"type": "human", "content": "Hi"}, ai_msg]}
+    result = _extract_final_response(output)
+    parsed = json.loads(result)
+    assert parsed == ai_msg
+
+
+def test_extract_final_response_with_list_content() -> None:
+    """AI messages with list content blocks are returned as-is."""
+    output: dict[str, Any] = {
+        "messages": [
+            {"type": "human", "content": "Hi"},
+            {"type": "ai", "content": [{"type": "text", "text": "Hello!"}, {"type": "image_url", "url": "..."}]},
+        ]
+    }
+    result = _extract_final_response(output)
+    parsed = json.loads(result)
+    assert parsed["type"] == "ai"
+    assert isinstance(parsed["content"], list)
+    assert len(parsed["content"]) == 2
+
+
+def test_extract_final_response_no_messages_key() -> None:
+    """Falls back to full output when there is no messages key."""
+    output: dict[str, Any] = {"result": "42"}
+    result = _extract_final_response(output)
+    assert json.loads(result) == output
+
+
+def test_extract_final_response_empty_messages() -> None:
+    """Falls back to full output when messages list is empty."""
+    output: dict[str, Any] = {"messages": []}
+    result = _extract_final_response(output)
+    assert json.loads(result) == output
+
+
+def test_extract_final_response_no_ai_message() -> None:
+    """Falls back to full output when no AI message exists."""
+    output: dict[str, Any] = {
+        "messages": [
+            {"type": "human", "content": "Hello"},
+            {"type": "tool", "content": "Result"},
+        ]
+    }
+    result = _extract_final_response(output)
+    assert json.loads(result) == output
+
+
+# ---------------------------------------------------------------------------
+# _load_mcp_auth_provider
+# ---------------------------------------------------------------------------
+
+
+def test_load_mcp_auth_provider_raises_on_missing_colon() -> None:
+    """Raises ValueError when path has no ':' separator."""
+    with pytest.raises(ValueError, match="missing ':'"):
+        _load_mcp_auth_provider("./mcp_auth.py")
+
+
+def test_load_mcp_auth_provider_raises_on_missing_file() -> None:
+    """Raises FileNotFoundError for non-existent file."""
+    with pytest.raises(FileNotFoundError, match="not found"):
+        _load_mcp_auth_provider("./nonexistent_mcp_auth.py:provider")
+
+
+def test_load_mcp_auth_provider_loads_from_file(tmp_path: Any) -> None:
+    """Loads a variable from a Python file."""
+    auth_file = tmp_path / "mcp_auth.py"
+    auth_file.write_text("my_provider = {'type': 'test_provider'}\n")
+
+    with patch("aegra_api.adapters.mcp_adapter.get_config_dir", return_value=tmp_path):
+        provider = _load_mcp_auth_provider("./mcp_auth.py:my_provider")
+
+    assert provider == {"type": "test_provider"}
+
+
+def test_load_mcp_auth_provider_loads_from_module() -> None:
+    """Loads a variable from an installed module."""
+    provider = _load_mcp_auth_provider("json:dumps")
+    assert provider is json.dumps
+
+
+def test_load_mcp_auth_provider_raises_on_missing_variable(tmp_path: Any) -> None:
+    """Raises AttributeError when variable doesn't exist."""
+    auth_file = tmp_path / "mcp_auth.py"
+    auth_file.write_text("other_var = 42\n")
+
+    with (
+        patch("aegra_api.adapters.mcp_adapter.get_config_dir", return_value=tmp_path),
+        pytest.raises(AttributeError, match="not found"),
+    ):
+        _load_mcp_auth_provider("./mcp_auth.py:missing_var")
+
+
+def test_load_mcp_auth_provider_resolves_relative_to_config_dir(tmp_path: Any) -> None:
+    """Resolves relative paths from config directory."""
+    sub_dir = tmp_path / "src" / "auth"
+    sub_dir.mkdir(parents=True)
+    auth_file = sub_dir / "mcp.py"
+    auth_file.write_text("provider = 'loaded_from_subdir'\n")
+
+    with patch("aegra_api.adapters.mcp_adapter.get_config_dir", return_value=tmp_path):
+        provider = _load_mcp_auth_provider("./src/auth/mcp.py:provider")
+
+    assert provider == "loaded_from_subdir"
+
+
+def test_load_mcp_auth_provider_raises_on_directory(tmp_path: Any) -> None:
+    """Raises ValueError when path points to a directory."""
+    dir_path = tmp_path / "mcp_auth.py"
+    dir_path.mkdir()
+
+    with (
+        patch("aegra_api.adapters.mcp_adapter.get_config_dir", return_value=tmp_path),
+        pytest.raises(ValueError, match="not a file"),
+    ):
+        _load_mcp_auth_provider("./mcp_auth.py:provider")

--- a/libs/aegra-api/tests/unit/test_adapters/test_mcp_adapter.py
+++ b/libs/aegra-api/tests/unit/test_adapters/test_mcp_adapter.py
@@ -4,10 +4,12 @@ import json
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
 import pytest
 from fastmcp.exceptions import ToolError
 from fastmcp.server.auth.auth import AccessToken
 from mcp.server.auth.middleware.bearer_auth import AuthenticatedUser
+from starlette.responses import JSONResponse
 
 from aegra_api.adapters.mcp_adapter import (
     _AuthMiddleware,
@@ -32,6 +34,7 @@ def _reset_module_state() -> None:
 
     mcp_adapter._final_response_only = None
     mcp_adapter._mcp_oauth_enabled = False
+    mcp_adapter.mcp_server.auth = None
     mcp_adapter.mcp_server._local_provider._components.clear()
 
 
@@ -376,8 +379,6 @@ async def test_auth_middleware_sets_anonymous_when_backend_returns_none() -> Non
 
     async def _capture_app(scope: Any, receive: Any, send: Any) -> None:
         captured_users.append(_current_user.get())
-        from starlette.responses import JSONResponse
-
         response = JSONResponse({"ok": True})
         await response(scope, receive, send)
 
@@ -387,8 +388,6 @@ async def test_auth_middleware_sets_anonymous_when_backend_returns_none() -> Non
     mock_backend.authenticate = AsyncMock(return_value=None)
 
     with patch("aegra_api.adapters.mcp_adapter.get_auth_backend", return_value=mock_backend):
-        import httpx
-
         async with httpx.AsyncClient(
             transport=httpx.ASGITransport(app=middleware),
             base_url="http://test",
@@ -437,8 +436,6 @@ async def test_auth_middleware_passes_through_when_oauth_enabled() -> None:
     async def _inner_app(scope: Any, receive: Any, send: Any) -> None:
         nonlocal inner_called
         inner_called = True
-        from starlette.responses import JSONResponse
-
         response = JSONResponse({"ok": True})
         await response(scope, receive, send)
 
@@ -448,8 +445,6 @@ async def test_auth_middleware_passes_through_when_oauth_enabled() -> None:
     mock_backend.authenticate = AsyncMock(side_effect=AuthenticationError("Missing token"))
 
     with patch("aegra_api.adapters.mcp_adapter.get_auth_backend", return_value=mock_backend):
-        import httpx
-
         async with httpx.AsyncClient(
             transport=httpx.ASGITransport(app=middleware),
             base_url="http://test",
@@ -478,8 +473,6 @@ async def test_auth_middleware_rejects_when_oauth_disabled() -> None:
     mock_backend.authenticate = AsyncMock(side_effect=AuthenticationError("Missing token"))
 
     with patch("aegra_api.adapters.mcp_adapter.get_auth_backend", return_value=mock_backend):
-        import httpx
-
         async with httpx.AsyncClient(
             transport=httpx.ASGITransport(app=middleware),
             base_url="http://test",
@@ -513,8 +506,6 @@ async def test_auth_middleware_swaps_upstream_token() -> None:
     responses: list[dict[str, Any]] = []
 
     async def _inner_app(scope: Any, receive: Any, send: Any) -> None:
-        from starlette.responses import JSONResponse
-
         response = JSONResponse({"ok": True})
         await response(scope, receive, send)
 
@@ -548,8 +539,6 @@ async def test_auth_middleware_no_swap_without_authenticated_user() -> None:
     mock_backend.authenticate = AsyncMock(side_effect=_capture_authenticate)
 
     async def _inner_app(scope: Any, receive: Any, send: Any) -> None:
-        from starlette.responses import JSONResponse
-
         response = JSONResponse({"ok": True})
         await response(scope, receive, send)
 

--- a/libs/aegra-api/tests/unit/test_core/test_config.py
+++ b/libs/aegra-api/tests/unit/test_core/test_config.py
@@ -1,13 +1,15 @@
-"""Unit tests for HTTP and store configuration loading"""
+"""Unit tests for HTTP, store, and MCP configuration loading"""
 
 import json
+from pathlib import Path
 
-from aegra_api.config import load_http_config, load_store_config
+import pytest
+
+from aegra_api.config import load_http_config, load_mcp_config, load_store_config
 
 
-def test_load_http_config_from_aegra_json(tmp_path, monkeypatch):
+def test_load_http_config_from_aegra_json(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Test loading HTTP config from aegra.json"""
-    # Change to temp directory
     monkeypatch.chdir(tmp_path)
 
     # Create aegra.json with http config
@@ -31,9 +33,8 @@ def test_load_http_config_from_aegra_json(tmp_path, monkeypatch):
     assert config["enable_custom_route_auth"] is True
 
 
-def test_load_http_config_from_langgraph_json(tmp_path, monkeypatch):
+def test_load_http_config_from_langgraph_json(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Test loading HTTP config from langgraph.json fallback"""
-    # Change to temp directory
     monkeypatch.chdir(tmp_path)
 
     # Create langgraph.json with http config (no aegra.json)
@@ -55,9 +56,8 @@ def test_load_http_config_from_langgraph_json(tmp_path, monkeypatch):
     assert config["app"] == "./custom.py:app"
 
 
-def test_load_http_config_prefers_aegra_json(tmp_path, monkeypatch):
+def test_load_http_config_prefers_aegra_json(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Test that aegra.json takes precedence over langgraph.json"""
-    # Change to temp directory
     monkeypatch.chdir(tmp_path)
 
     # Create both config files
@@ -87,9 +87,8 @@ def test_load_http_config_prefers_aegra_json(tmp_path, monkeypatch):
     assert config["app"] == "./aegra_custom.py:app"
 
 
-def test_load_http_config_no_config(tmp_path, monkeypatch):
+def test_load_http_config_no_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Test loading when no config file exists"""
-    # Change to temp directory
     monkeypatch.chdir(tmp_path)
 
     config = load_http_config()
@@ -97,9 +96,8 @@ def test_load_http_config_no_config(tmp_path, monkeypatch):
     assert config is None
 
 
-def test_load_http_config_no_http_section(tmp_path, monkeypatch):
+def test_load_http_config_no_http_section(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Test loading when config exists but no http section"""
-    # Change to temp directory
     monkeypatch.chdir(tmp_path)
 
     config_file = tmp_path / "aegra.json"
@@ -110,9 +108,8 @@ def test_load_http_config_no_http_section(tmp_path, monkeypatch):
     assert config is None
 
 
-def test_load_http_config_invalid_json(tmp_path, monkeypatch):
+def test_load_http_config_invalid_json(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Test loading when config file has invalid JSON"""
-    # Change to temp directory
     monkeypatch.chdir(tmp_path)
 
     config_file = tmp_path / "aegra.json"
@@ -129,7 +126,7 @@ def test_load_http_config_invalid_json(tmp_path, monkeypatch):
 # ============================================================================
 
 
-def test_load_store_config_with_index(tmp_path, monkeypatch):
+def test_load_store_config_with_index(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Test loading store config with index configuration"""
     monkeypatch.chdir(tmp_path)
 
@@ -155,7 +152,7 @@ def test_load_store_config_with_index(tmp_path, monkeypatch):
     assert config["index"]["embed"] == "openai:text-embedding-3-small"
 
 
-def test_load_store_config_no_config(tmp_path, monkeypatch):
+def test_load_store_config_no_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Test loading when no config file exists"""
     monkeypatch.chdir(tmp_path)
 
@@ -164,7 +161,7 @@ def test_load_store_config_no_config(tmp_path, monkeypatch):
     assert config is None
 
 
-def test_load_store_config_no_store_section(tmp_path, monkeypatch):
+def test_load_store_config_no_store_section(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Test loading when config exists but no store section"""
     monkeypatch.chdir(tmp_path)
 
@@ -176,7 +173,7 @@ def test_load_store_config_no_store_section(tmp_path, monkeypatch):
     assert config is None
 
 
-def test_load_store_config_from_langgraph_json(tmp_path, monkeypatch):
+def test_load_store_config_from_langgraph_json(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Test loading store config from langgraph.json fallback"""
     monkeypatch.chdir(tmp_path)
 
@@ -200,3 +197,69 @@ def test_load_store_config_from_langgraph_json(tmp_path, monkeypatch):
     assert config is not None
     assert config["index"]["dims"] == 768
     assert config["index"]["embed"] == "cohere:embed-english-v3.0"
+
+
+# ============================================================================
+# MCP Config Tests
+# ============================================================================
+
+
+def test_load_mcp_config_with_final_response_only(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test loading MCP config with final_response_only set."""
+    monkeypatch.chdir(tmp_path)
+
+    config_file = tmp_path / "aegra.json"
+    config_file.write_text(
+        json.dumps(
+            {
+                "graphs": {"test": "./test.py:graph"},
+                "mcp": {"final_response_only": True},
+            }
+        )
+    )
+
+    config = load_mcp_config()
+
+    assert config is not None
+    assert config["final_response_only"] is True
+
+
+def test_load_mcp_config_no_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test loading when no config file exists."""
+    monkeypatch.chdir(tmp_path)
+
+    config = load_mcp_config()
+
+    assert config is None
+
+
+def test_load_mcp_config_no_mcp_section(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test loading when config exists but no mcp section."""
+    monkeypatch.chdir(tmp_path)
+
+    config_file = tmp_path / "aegra.json"
+    config_file.write_text(json.dumps({"graphs": {"test": "./test.py:graph"}}))
+
+    config = load_mcp_config()
+
+    assert config is None
+
+
+def test_load_mcp_config_from_langgraph_json(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test loading MCP config from langgraph.json fallback."""
+    monkeypatch.chdir(tmp_path)
+
+    config_file = tmp_path / "langgraph.json"
+    config_file.write_text(
+        json.dumps(
+            {
+                "graphs": {"test": "./test.py:graph"},
+                "mcp": {"final_response_only": True},
+            }
+        )
+    )
+
+    config = load_mcp_config()
+
+    assert config is not None
+    assert config["final_response_only"] is True

--- a/libs/aegra-api/tests/unit/test_services/test_langgraph_service.py
+++ b/libs/aegra-api/tests/unit/test_services/test_langgraph_service.py
@@ -189,6 +189,220 @@ class TestLangGraphServiceConfig:
         assert service.get_dependencies() == []
 
 
+class TestLoadGraphRegistryDictFormat:
+    """Test _load_graph_registry support for dict-format graph entries.
+
+    The graph config accepts both string format ("./path.py:export") and
+    dict format ({"path": "./path.py:export", "description": "..."}).
+    """
+
+    def test_string_format_produces_registry_without_description(self) -> None:
+        """String-format entries should NOT have a 'description' key."""
+        service = LangGraphService()
+        service.config = {"graphs": {"agent": "./graphs/agent.py:graph"}}
+        service._load_graph_registry()
+
+        entry = service._graph_registry["agent"]
+        assert entry["file_path"] == "./graphs/agent.py"
+        assert entry["export_name"] == "graph"
+        assert "description" not in entry
+
+    def test_dict_format_with_path_and_description(self) -> None:
+        """Dict-format entry with path and description stores both."""
+        service = LangGraphService()
+        service.config = {
+            "graphs": {
+                "weather": {
+                    "path": "./graphs/weather.py:graph",
+                    "description": "A weather lookup agent",
+                }
+            }
+        }
+        service._load_graph_registry()
+
+        entry = service._graph_registry["weather"]
+        assert entry["file_path"] == "./graphs/weather.py"
+        assert entry["export_name"] == "graph"
+        assert entry["description"] == "A weather lookup agent"
+
+    def test_dict_format_without_description(self) -> None:
+        """Dict-format entry without description omits it from registry."""
+        service = LangGraphService()
+        service.config = {
+            "graphs": {
+                "chatbot": {
+                    "path": "./graphs/chatbot.py:bot",
+                }
+            }
+        }
+        service._load_graph_registry()
+
+        entry = service._graph_registry["chatbot"]
+        assert entry["file_path"] == "./graphs/chatbot.py"
+        assert entry["export_name"] == "bot"
+        assert "description" not in entry
+
+    def test_dict_format_with_empty_description(self) -> None:
+        """Dict-format entry with empty string description omits it (falsy)."""
+        service = LangGraphService()
+        service.config = {
+            "graphs": {
+                "agent": {
+                    "path": "./graphs/agent.py:graph",
+                    "description": "",
+                }
+            }
+        }
+        service._load_graph_registry()
+
+        entry = service._graph_registry["agent"]
+        assert "description" not in entry
+
+    def test_dict_format_missing_path_raises_value_error(self) -> None:
+        """Dict-format entry without 'path' key defaults to '' which fails the ':' check."""
+        service = LangGraphService()
+        service.config = {
+            "graphs": {
+                "broken": {
+                    "description": "Missing path key",
+                }
+            }
+        }
+
+        with pytest.raises(ValueError, match="Invalid graph path format"):
+            service._load_graph_registry()
+
+    def test_dict_format_path_without_colon_raises_value_error(self) -> None:
+        """Dict-format entry with invalid path format (no ':') raises ValueError."""
+        service = LangGraphService()
+        service.config = {
+            "graphs": {
+                "bad": {
+                    "path": "./graphs/agent.py",
+                    "description": "No export separator",
+                }
+            }
+        }
+
+        with pytest.raises(ValueError, match="Invalid graph path format"):
+            service._load_graph_registry()
+
+    def test_mixed_string_and_dict_formats(self) -> None:
+        """Registry can contain a mix of string and dict format entries."""
+        service = LangGraphService()
+        service.config = {
+            "graphs": {
+                "string_agent": "./graphs/string_agent.py:graph",
+                "dict_agent": {
+                    "path": "./graphs/dict_agent.py:agent",
+                    "description": "Dict-based agent",
+                },
+                "dict_no_desc": {
+                    "path": "./graphs/no_desc.py:run",
+                },
+            }
+        }
+        service._load_graph_registry()
+
+        assert len(service._graph_registry) == 3
+
+        string_entry = service._graph_registry["string_agent"]
+        assert string_entry["file_path"] == "./graphs/string_agent.py"
+        assert string_entry["export_name"] == "graph"
+        assert "description" not in string_entry
+
+        dict_entry = service._graph_registry["dict_agent"]
+        assert dict_entry["file_path"] == "./graphs/dict_agent.py"
+        assert dict_entry["export_name"] == "agent"
+        assert dict_entry["description"] == "Dict-based agent"
+
+        no_desc_entry = service._graph_registry["dict_no_desc"]
+        assert no_desc_entry["file_path"] == "./graphs/no_desc.py"
+        assert no_desc_entry["export_name"] == "run"
+        assert "description" not in no_desc_entry
+
+    def test_dict_format_path_with_multiple_colons(self) -> None:
+        """Path with multiple colons splits on the first one only."""
+        service = LangGraphService()
+        service.config = {
+            "graphs": {
+                "multi_colon": {
+                    "path": "./graphs/agent.py:some:nested:export",
+                    "description": "Unusual export name",
+                }
+            }
+        }
+        service._load_graph_registry()
+
+        entry = service._graph_registry["multi_colon"]
+        assert entry["file_path"] == "./graphs/agent.py"
+        assert entry["export_name"] == "some:nested:export"
+        assert entry["description"] == "Unusual export name"
+
+    def test_no_config_loaded_raises_value_error(self) -> None:
+        """_load_graph_registry raises when config is None."""
+        service = LangGraphService()
+        service.config = None
+
+        with pytest.raises(ValueError, match="Configuration not loaded"):
+            service._load_graph_registry()
+
+    def test_empty_graphs_config(self) -> None:
+        """Empty graphs section produces empty registry."""
+        service = LangGraphService()
+        service.config = {"graphs": {}}
+        service._load_graph_registry()
+
+        assert service._graph_registry == {}
+
+    def test_missing_graphs_key(self) -> None:
+        """Missing 'graphs' key produces empty registry."""
+        service = LangGraphService()
+        service.config = {}
+        service._load_graph_registry()
+
+        assert service._graph_registry == {}
+
+    @pytest.mark.asyncio
+    async def test_dict_format_description_preserved_through_initialize(self) -> None:
+        """Description from dict-format config survives the full initialize flow."""
+        config_data = {
+            "graphs": {
+                "my_agent": {
+                    "path": "./graphs/my_agent.py:graph",
+                    "description": "My cool agent",
+                }
+            }
+        }
+
+        with (
+            patch("pathlib.Path.exists", return_value=True),
+            patch("pathlib.Path.open", mock_open(read_data=json.dumps(config_data))),
+            patch("aegra_api.services.langgraph_service.LangGraphService._ensure_default_assistants"),
+            patch("aegra_api.services.langgraph_service.LangGraphService._load_all_graph_modules"),
+        ):
+            service = LangGraphService()
+            await service.initialize()
+
+        entry = service._graph_registry["my_agent"]
+        assert entry["description"] == "My cool agent"
+        assert entry["file_path"] == "./graphs/my_agent.py"
+        assert entry["export_name"] == "graph"
+
+    def test_colliding_graph_ids_raises_for_dict_format(self) -> None:
+        """Sanitisation collision detection works for dict-format entries too."""
+        service = LangGraphService()
+        service.config = {
+            "graphs": {
+                "a.b": {"path": "./graphs/ab.py:graph", "description": "first"},
+                "a_b": {"path": "./graphs/ab2.py:graph", "description": "second"},
+            }
+        }
+
+        with pytest.raises(ValueError, match="collide after sanitisation"):
+            service._load_graph_registry()
+
+
 class TestLangGraphServiceGraphs:
     """Test graph management"""
 

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.9.16"
+version = "0.9.17"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -15,13 +15,14 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.9.16"
+version = "0.9.17"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
     { name = "asgi-correlation-id" },
     { name = "asyncpg" },
     { name = "fastapi" },
+    { name = "fastmcp" },
     { name = "greenlet" },
     { name = "langgraph" },
     { name = "langgraph-checkpoint-postgres" },
@@ -62,6 +63,7 @@ requires-dist = [
     { name = "asgi-correlation-id", specifier = ">=4.3.4" },
     { name = "asyncpg", specifier = ">=0.30.0" },
     { name = "fastapi", specifier = ">=0.110.1" },
+    { name = "fastmcp", specifier = ">=3.2.0,<4.0.0" },
     { name = "greenlet", specifier = ">=3.1.0" },
     { name = "langgraph", specifier = ">=1.0.3" },
     { name = "langgraph-checkpoint-postgres", specifier = ">=2.0.23" },
@@ -98,7 +100,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.9.16"
+version = "0.9.17"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },
@@ -154,6 +156,18 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [{ name = "pre-commit", specifier = ">=4.0.1" }]
+
+[[package]]
+name = "aiofile"
+version = "3.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "caio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/e2/d7cb819de8df6b5c1968a2756c3cb4122d4fa2b8fc768b53b7c9e5edb646/aiofile-3.9.0.tar.gz", hash = "sha256:e5ad718bb148b265b6df1b3752c4d1d83024b93da9bd599df74b9d9ffcf7919b", size = 17943, upload-time = "2024-10-08T10:39:35.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/25/da1f0b4dd970e52bf5a36c204c107e11a0c6d3ed195eba0bfbc664c312b2/aiofile-3.9.0-py3-none-any.whl", hash = "sha256:ce2f6c1571538cbdfa0143b04e16b208ecb0e9cb4148e528af8a640ed51cc8aa", size = 19539, upload-time = "2024-10-08T10:39:32.955Z" },
+]
 
 [[package]]
 name = "alembic"
@@ -263,6 +277,19 @@ wheels = [
 ]
 
 [[package]]
+name = "authlib"
+version = "1.7.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "joserfc" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/98/7d93f30d029643c0275dbc0bd6d5a6f670661ee6c9a94d93af7ab4887600/authlib-1.7.2.tar.gz", hash = "sha256:2cea25fefcd4e7173bdf1372c0afc265c8034b23a8cd5dcb6a9164b826c64231", size = 176511, upload-time = "2026-05-06T08:10:23.116Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/95/adcb68e20c34162e9135f370d6e31737719c2b6f94bc953fe7ed1f10fe21/authlib-1.7.2-py2.py3-none-any.whl", hash = "sha256:3e1faedc9d87e7d56a164eca3ccb6ace0d61b94abe83e92242f8dc8bba9b4a9f", size = 259548, upload-time = "2026-05-06T08:10:21.436Z" },
+]
+
+[[package]]
 name = "bandit"
 version = "1.9.3"
 source = { registry = "https://pypi.org/simple" }
@@ -275,6 +302,45 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/89/76/a7f3e639b78601118aaa4a394db2c66ae2597fbd8c39644c32874ed11e0c/bandit-1.9.3.tar.gz", hash = "sha256:ade4b9b7786f89ef6fc7344a52b34558caec5da74cb90373aed01de88472f774", size = 4242154, upload-time = "2026-01-19T04:05:22.802Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/0b/8bdc52111c83e2dc2f97403dc87c0830b8989d9ae45732b34b686326fb2c/bandit-1.9.3-py3-none-any.whl", hash = "sha256:4745917c88d2246def79748bde5e08b9d5e9b92f877863d43fab70cd8814ce6a", size = 134451, upload-time = "2026-01-19T04:05:20.938Z" },
+]
+
+[[package]]
+name = "beartype"
+version = "0.22.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/94/1009e248bbfbab11397abca7193bea6626806be9a327d399810d523a07cb/beartype-0.22.9.tar.gz", hash = "sha256:8f82b54aa723a2848a56008d18875f91c1db02c32ef6a62319a002e3e25a975f", size = 1608866, upload-time = "2025-12-13T06:50:30.72Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/cc/18245721fa7747065ab478316c7fea7c74777d07f37ae60db2e84f8172e8/beartype-0.22.9-py3-none-any.whl", hash = "sha256:d16c9bbc61ea14637596c5f6fbff2ee99cbe3573e46a716401734ef50c3060c2", size = 1333658, upload-time = "2025-12-13T06:50:28.266Z" },
+]
+
+[[package]]
+name = "cachetools"
+version = "7.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/e2/85f227594656000ff4d8adadae91a21f536d4a84c6c716a86bd6685874be/cachetools-7.1.1.tar.gz", hash = "sha256:27bdf856d68fd3c71c26c01b5edc312124ed427524d1ddb31aa2b7746fe20d4b", size = 40202, upload-time = "2026-05-03T20:00:29.391Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/0f/f897abe4ea0a8c408ae65c8c83bffab4936ad65d6032d4fb4cd35bbdc3ee/cachetools-7.1.1-py3-none-any.whl", hash = "sha256:0335cd7a0952d2b22327441fb0628139e234c565559eeb91a8a4ac7551c5353d", size = 16775, upload-time = "2026-05-03T20:00:27.857Z" },
+]
+
+[[package]]
+name = "caio"
+version = "0.9.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/88/b8527e1b00c1811db339a1df8bd1ae49d146fcea9d6a5c40e3a80aaeb38d/caio-0.9.25.tar.gz", hash = "sha256:16498e7f81d1d0f5a4c0ad3f2540e65fe25691376e0a5bd367f558067113ed10", size = 26781, upload-time = "2025-12-26T15:21:36.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/25/79c98ebe12df31548ba4eaf44db11b7cad6b3e7b4203718335620939083c/caio-0.9.25-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fb7ff95af4c31ad3f03179149aab61097a71fd85e05f89b4786de0359dffd044", size = 36983, upload-time = "2025-12-26T15:21:36.075Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/2b/21288691f16d479945968a0a4f2856818c1c5be56881d51d4dac9b255d26/caio-0.9.25-cp312-cp312-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:97084e4e30dfa598449d874c4d8e0c8d5ea17d2f752ef5e48e150ff9d240cd64", size = 82012, upload-time = "2025-12-26T15:22:20.983Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c4/8a1b580875303500a9c12b9e0af58cb82e47f5bcf888c2457742a138273c/caio-0.9.25-cp312-cp312-manylinux_2_34_aarch64.whl", hash = "sha256:4fa69eba47e0f041b9d4f336e2ad40740681c43e686b18b191b6c5f4c5544bfb", size = 81502, upload-time = "2026-03-04T22:08:22.381Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/1c/0fe770b8ffc8362c48134d1592d653a81a3d8748d764bec33864db36319d/caio-0.9.25-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:6bebf6f079f1341d19f7386db9b8b1f07e8cc15ae13bfdaff573371ba0575d69", size = 80200, upload-time = "2026-03-04T22:08:23.382Z" },
+    { url = "https://files.pythonhosted.org/packages/31/57/5e6ff127e6f62c9f15d989560435c642144aa4210882f9494204bc892305/caio-0.9.25-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d6c2a3411af97762a2b03840c3cec2f7f728921ff8adda53d7ea2315a8563451", size = 36979, upload-time = "2025-12-26T15:21:35.484Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/9f/f21af50e72117eb528c422d4276cbac11fb941b1b812b182e0a9c70d19c5/caio-0.9.25-cp313-cp313-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0998210a4d5cd5cb565b32ccfe4e53d67303f868a76f212e002a8554692870e6", size = 81900, upload-time = "2025-12-26T15:22:21.919Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/12/c39ae2a4037cb10ad5eb3578eb4d5f8c1a2575c62bba675f3406b7ef0824/caio-0.9.25-cp313-cp313-manylinux_2_34_aarch64.whl", hash = "sha256:1a177d4777141b96f175fe2c37a3d96dec7911ed9ad5f02bac38aaa1c936611f", size = 81523, upload-time = "2026-03-04T22:08:25.187Z" },
+    { url = "https://files.pythonhosted.org/packages/22/59/f8f2e950eb4f1a5a3883e198dca514b9d475415cb6cd7b78b9213a0dd45a/caio-0.9.25-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:9ed3cfb28c0e99fec5e208c934e5c157d0866aa9c32aa4dc5e9b6034af6286b7", size = 80243, upload-time = "2026-03-04T22:08:26.449Z" },
+    { url = "https://files.pythonhosted.org/packages/69/ca/a08fdc7efdcc24e6a6131a93c85be1f204d41c58f474c42b0670af8c016b/caio-0.9.25-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:fab6078b9348e883c80a5e14b382e6ad6aabbc4429ca034e76e730cf464269db", size = 36978, upload-time = "2025-12-26T15:21:41.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/6c/d4d24f65e690213c097174d26eda6831f45f4734d9d036d81790a27e7b78/caio-0.9.25-cp314-cp314-manylinux2010_x86_64.manylinux2014_x86_64.manylinux_2_12_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:44a6b58e52d488c75cfaa5ecaa404b2b41cc965e6c417e03251e868ecd5b6d77", size = 81832, upload-time = "2025-12-26T15:22:22.757Z" },
+    { url = "https://files.pythonhosted.org/packages/87/a4/e534cf7d2d0e8d880e25dd61e8d921ffcfe15bd696734589826f5a2df727/caio-0.9.25-cp314-cp314-manylinux_2_34_aarch64.whl", hash = "sha256:628a630eb7fb22381dd8e3c8ab7f59e854b9c806639811fc3f4310c6bd711d79", size = 81565, upload-time = "2026-03-04T22:08:27.483Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ed/bf81aeac1d290017e5e5ac3e880fd56ee15e50a6d0353986799d1bc5cfd5/caio-0.9.25-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:0ba16aa605ccb174665357fc729cf500679c2d94d5f1458a6f0d5ca48f2060a7", size = 80071, upload-time = "2026-03-04T22:08:28.751Z" },
+    { url = "https://files.pythonhosted.org/packages/86/93/1f76c8d1bafe3b0614e06b2195784a3765bbf7b0a067661af9e2dd47fc33/caio-0.9.25-py3-none-any.whl", hash = "sha256:06c0bb02d6b929119b1cfbe1ca403c768b2013a369e2db46bfa2a5761cf82e40", size = 19087, upload-time = "2025-12-26T15:22:00.221Z" },
 ]
 
 [[package]]
@@ -568,6 +634,21 @@ wheels = [
 ]
 
 [[package]]
+name = "cyclopts"
+version = "4.11.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "docstring-parser" },
+    { name = "rich" },
+    { name = "rich-rst" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/f7/3ee212c1bc314551094fc8fda7b4b63c647ac5c32d06daa285d04d33edfc/cyclopts-4.11.2.tar.gz", hash = "sha256:8c9b77921660fa1ee52c150e2217ced672323efb3434e9b338077de1bc551ff4", size = 175935, upload-time = "2026-05-04T00:11:57.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/18/4cedda786e7da429e7489549a9e5461530d4133130e541f25fb94f015776/cyclopts-4.11.2-py3-none-any.whl", hash = "sha256:838020120b939549ff7c8423aca29c86764b5dd1d8a5d7f3753a6327861f537b", size = 213537, upload-time = "2026-05-04T00:11:56.103Z" },
+]
+
+[[package]]
 name = "debugpy"
 version = "1.8.20"
 source = { registry = "https://pypi.org/simple" }
@@ -607,6 +688,58 @@ wheels = [
 ]
 
 [[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
+name = "docutils"
+version = "0.22.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/b6/03bb70946330e88ffec97aefd3ea75ba575cb2e762061e0e62a213befee8/docutils-0.22.4.tar.gz", hash = "sha256:4db53b1fde9abecbb74d91230d32ab626d94f6badfc575d6db9194a49df29968", size = 2291750, upload-time = "2025-12-18T19:00:26.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/10/5da547df7a391dcde17f59520a231527b8571e6f46fc8efb02ccb370ab12/docutils-0.22.4-py3-none-any.whl", hash = "sha256:d0013f540772d1420576855455d050a2180186c91c15779301ac2ccb3eeb68de", size = 633196, upload-time = "2025-12-18T19:00:18.077Z" },
+]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.128.6"
 source = { registry = "https://pypi.org/simple" }
@@ -620,6 +753,39 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/83/d1/195005b5e45b443e305136df47ee7df4493d782e0c039dd0d97065580324/fastapi-0.128.6.tar.gz", hash = "sha256:0cb3946557e792d731b26a42b04912f16367e3c3135ea8290f620e234f2b604f", size = 374757, upload-time = "2026-02-09T17:27:03.541Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/24/58/a2c4f6b240eeb148fb88cdac48f50a194aba760c1ca4988c6031c66a20ee/fastapi-0.128.6-py3-none-any.whl", hash = "sha256:bb1c1ef87d6086a7132d0ab60869d6f1ee67283b20fbf84ec0003bd335099509", size = 103674, upload-time = "2026-02-09T17:27:02.355Z" },
+]
+
+[[package]]
+name = "fastmcp"
+version = "3.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "authlib" },
+    { name = "cyclopts" },
+    { name = "exceptiongroup" },
+    { name = "griffelib" },
+    { name = "httpx" },
+    { name = "jsonref" },
+    { name = "jsonschema-path" },
+    { name = "mcp" },
+    { name = "openapi-pydantic" },
+    { name = "opentelemetry-api" },
+    { name = "packaging" },
+    { name = "platformdirs" },
+    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+    { name = "pydantic", extra = ["email"] },
+    { name = "pyperclip" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "uncalled-for" },
+    { name = "uvicorn" },
+    { name = "watchfiles" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9c/13/29544fbc6dfe45ea38046af0067311e0bad7acc7d1f2ad38bb08f2409fe2/fastmcp-3.2.4.tar.gz", hash = "sha256:083ecb75b44a4169e7fc0f632f94b781bdb0ff877c6b35b9877cbb566fd4d4d1", size = 28746127, upload-time = "2026-04-14T01:42:24.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/76/b310d52fa0e30d39bd937eb58ec2c1f1ea1b5f519f0575e9dd9612f01deb/fastmcp-3.2.4-py3-none-any.whl", hash = "sha256:e6c9c429171041455e47ab94bb3f83c4657622a0ec28922f6940053959bd58a9", size = 728599, upload-time = "2026-04-14T01:42:26.85Z" },
 ]
 
 [[package]]
@@ -684,6 +850,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/97/43/8bf0ffa3d498eeee4c58c212a3905dd6146c01c8dc0b0a046481ca29b18c/greenlet-3.3.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ed6b402bc74d6557a705e197d47f9063733091ed6357b3de33619d8a8d93ac53", size = 1614917, upload-time = "2026-01-23T16:04:26.276Z" },
     { url = "https://files.pythonhosted.org/packages/89/90/a3be7a5f378fc6e84abe4dcfb2ba32b07786861172e502388b4c90000d1b/greenlet-3.3.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:59913f1e5ada20fde795ba906916aea25d442abcc0593fba7e26c92b7ad76249", size = 1676092, upload-time = "2026-01-23T15:33:52.176Z" },
     { url = "https://files.pythonhosted.org/packages/e1/2b/98c7f93e6db9977aaee07eb1e51ca63bd5f779b900d362791d3252e60558/greenlet-3.3.1-cp314-cp314t-win_amd64.whl", hash = "sha256:301860987846c24cb8964bdec0e31a96ad4a2a801b41b4ef40963c1b44f33451", size = 233181, upload-time = "2026-01-23T15:33:00.29Z" },
+]
+
+[[package]]
+name = "griffelib"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/82/74f4a3310cdabfbb10da554c3a672847f1ed33c6f61dd472681ce7f1fe67/griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e", size = 166461, upload-time = "2026-03-27T11:34:51.091Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/8c/c9138d881c79aa0ea9ed83cbd58d5ca75624378b38cee225dcf5c42cc91f/griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1", size = 142357, upload-time = "2026-03-27T11:34:46.275Z" },
 ]
 
 [[package]]
@@ -873,6 +1048,48 @@ wheels = [
 ]
 
 [[package]]
+name = "jaraco-classes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777, upload-time = "2024-03-31T07:27:34.792Z" },
+]
+
+[[package]]
+name = "jaraco-context"
+version = "6.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/50/4763cd07e722bb6285316d390a164bc7e479db9d90daa769f22578f698b4/jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3", size = 16801, upload-time = "2026-03-20T22:13:33.922Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/58/bc8954bda5fcda97bd7c19be11b85f91973d67a706ed4a3aec33e7de22db/jaraco_context-6.1.2-py3-none-any.whl", hash = "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535", size = 7871, upload-time = "2026-03-20T22:13:32.808Z" },
+]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0f/27/056e0638a86749374d6f57d0b0db39f29509cce9313cf91bdc0ac4d91084/jaraco_functools-4.4.0.tar.gz", hash = "sha256:da21933b0417b89515562656547a77b4931f98176eb173644c0d35032a33d6bb", size = 19943, upload-time = "2025-12-21T09:29:43.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/c4/813bb09f0985cb21e959f21f2464169eca882656849adf727ac7bb7e1767/jaraco_functools-4.4.0-py3-none-any.whl", hash = "sha256:9eec1e36f45c818d9bf307c8948eb03b2b56cd44087b3cdc989abca1f20b9176", size = 10481, upload-time = "2025-12-21T09:29:42.27Z" },
+]
+
+[[package]]
+name = "jeepney"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
+]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 source = { registry = "https://pypi.org/simple" }
@@ -953,6 +1170,18 @@ wheels = [
 ]
 
 [[package]]
+name = "joserfc"
+version = "1.6.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/dc/5f768c2e391e9afabe5d18e3221346deb5fb6338565f1ccc9e7c6d7befdd/joserfc-1.6.5.tar.gz", hash = "sha256:1482a7db78fb4602e44ed89e51b599d052e091288c7c532c5b694e20149dec48", size = 231881, upload-time = "2026-05-06T04:58:13.408Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/3b/ad1cb22e75c963b1f07c8a2329bf47227ce7e4361df5eb2fb101b2ce33ef/joserfc-1.6.5-py3-none-any.whl", hash = "sha256:e9878a0f8243fe7b95e11fdda81374ca9f7a689e302751579d3dfdeec559675e", size = 70464, upload-time = "2026-05-06T04:58:11.668Z" },
+]
+
+[[package]]
 name = "jsonpatch"
 version = "1.33"
 source = { registry = "https://pypi.org/simple" }
@@ -974,6 +1203,15 @@ wheels = [
 ]
 
 [[package]]
+name = "jsonref"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/0d/c1f3277e90ccdb50d33ed5ba1ec5b3f0a242ed8c1b1a85d3afeb68464dca/jsonref-1.1.0.tar.gz", hash = "sha256:32fe8e1d85af0fdefbebce950af85590b22b60f9e95443176adbde4e1ecea552", size = 8814, upload-time = "2023-01-16T16:10:04.455Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/ec/e1db9922bceb168197a558a2b8c03a7963f1afe93517ddd3cf99f202f996/jsonref-1.1.0-py3-none-any.whl", hash = "sha256:590dc7773df6c21cbf948b5dac07a72a251db28b0238ceecce0a2abfa8ec30a9", size = 9425, upload-time = "2023-01-16T16:10:02.255Z" },
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -989,6 +1227,20 @@ wheels = [
 ]
 
 [[package]]
+name = "jsonschema-path"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pathable" },
+    { name = "pyyaml" },
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/01/86/cfee6dd25843bec0760f456599a4f7e7e40221a934b9229fda0662c859bc/jsonschema_path-0.4.6.tar.gz", hash = "sha256:c89eb635f4d497c9ac328eeff359c489755838806a7d033510a692e9576f5c4b", size = 15302, upload-time = "2026-04-27T18:57:08.412Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6c/43/3d3065c05a04bb550c143bfbb8e4fd7022cd327e1082bf257bac74923783/jsonschema_path-0.4.6-py3-none-any.whl", hash = "sha256:451354b5311fa955c3144e6e4e255388c751c0121c5570ec5bb9291dd42d08c9", size = 19565, upload-time = "2026-04-27T18:57:06.792Z" },
+]
+
+[[package]]
 name = "jsonschema-specifications"
 version = "2025.9.1"
 source = { registry = "https://pypi.org/simple" }
@@ -998,6 +1250,23 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "keyring"
+version = "25.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jaraco-classes" },
+    { name = "jaraco-context" },
+    { name = "jaraco-functools" },
+    { name = "jeepney", marker = "sys_platform == 'linux'" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "secretstorage", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
 ]
 
 [[package]]
@@ -1274,6 +1543,15 @@ wheels = [
 ]
 
 [[package]]
+name = "more-itertools"
+version = "11.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/f7/139d22fef48ac78127d18e01d80cf1be40236ae489769d17f35c3d425293/more_itertools-11.0.2.tar.gz", hash = "sha256:392a9e1e362cbc106a2457d37cabf9b36e5e12efd4ebff1654630e76597df804", size = 144659, upload-time = "2026-04-09T15:01:33.297Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/98/6af411189d9413534c3eb691182bff1f5c6d44ed2f93f2edfe52a1bbceb8/more_itertools-11.0.2-py3-none-any.whl", hash = "sha256:6e35b35f818b01f691643c6c611bc0902f2e92b46c18fffa77ae1e7c46e912e4", size = 71939, upload-time = "2026-04-09T15:01:32.21Z" },
+]
+
+[[package]]
 name = "nodeenv"
 version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1299,6 +1577,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9e/cb/f2c9f988a06d1fcdd18ddc010f43ac384219a399eb01765493d6b34b1461/openai-2.18.0.tar.gz", hash = "sha256:5018d3bcb6651c5aac90e6d0bf9da5cde1bdd23749f67b45b37c522b6e6353af", size = 632124, upload-time = "2026-02-09T21:42:18.017Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/5f/8940e0641c223eaf972732b3154f2178a968290f8cb99e8c88582cde60ed/openai-2.18.0-py3-none-any.whl", hash = "sha256:538f97e1c77a00e3a99507688c878cda7e9e63031807ba425c68478854d48b30", size = 1069897, upload-time = "2026-02-09T21:42:16.4Z" },
+]
+
+[[package]]
+name = "openapi-pydantic"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/2e/58d83848dd1a79cb92ed8e63f6ba901ca282c5f09d04af9423ec26c56fd7/openapi_pydantic-0.5.1.tar.gz", hash = "sha256:ff6835af6bde7a459fb93eb93bb92b8749b754fc6e51b2f1590a19dc3005ee0d", size = 60892, upload-time = "2025-01-08T19:29:27.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/cf/03675d8bd8ecbf4445504d8071adab19f5f993676795708e36402ab38263/openapi_pydantic-0.5.1-py3-none-any.whl", hash = "sha256:a3a09ef4586f5bd760a8df7f43028b60cafb6d9f61de2acba9574766255ab146", size = 96381, upload-time = "2025-01-08T19:29:25.275Z" },
 ]
 
 [[package]]
@@ -1572,6 +1862,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pathable"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/55/b748445cb4ea6b125626f15379be7c96d1035d4fa3e8fee362fa92298abf/pathable-0.5.0.tar.gz", hash = "sha256:d81938348a1cacb525e7c75166270644782c0fb9c8cecc16be033e71427e0ef1", size = 16655, upload-time = "2026-02-20T08:47:00.748Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/96/5a770e5c461462575474468e5af931cff9de036e7c2b4fea23c1c58d2cbe/pathable-0.5.0-py3-none-any.whl", hash = "sha256:646e3d09491a6351a0c82632a09c02cdf70a252e73196b36d8a15ba0a114f0a6", size = 16867, upload-time = "2026-02-20T08:46:59.536Z" },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1713,6 +2012,31 @@ wheels = [
 ]
 
 [[package]]
+name = "py-key-value-aio"
+version = "0.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beartype" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/3c/0397c072a38d4bc580994b42e0c90c5f44f679303489e4376289534735e5/py_key_value_aio-0.4.4.tar.gz", hash = "sha256:e3012e6243ed7cc09bb05457bd4d03b1ba5c2b1ca8700096b3927db79ffbbe55", size = 92300, upload-time = "2026-02-16T21:21:43.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/69/f1b537ee70b7def42d63124a539ed3026a11a3ffc3086947a1ca6e861868/py_key_value_aio-0.4.4-py3-none-any.whl", hash = "sha256:18e17564ecae61b987f909fc2cd41ee2012c84b4b1dcb8c055cf8b4bc1bf3f5d", size = 152291, upload-time = "2026-02-16T21:21:44.241Z" },
+]
+
+[package.optional-dependencies]
+filetree = [
+    { name = "aiofile" },
+    { name = "anyio" },
+]
+keyring = [
+    { name = "keyring" },
+]
+memory = [
+    { name = "cachetools" },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1734,6 +2058,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
+]
+
+[package.optional-dependencies]
+email = [
+    { name = "email-validator" },
 ]
 
 [[package]]
@@ -1845,6 +2174,15 @@ crypto = [
 ]
 
 [[package]]
+name = "pyperclip"
+version = "1.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/52/d87eba7cb129b81563019d1679026e7a112ef76855d6159d24754dbd2a51/pyperclip-1.11.0.tar.gz", hash = "sha256:244035963e4428530d9e3a6101a1ef97209c6825edab1567beac148ccc1db1b6", size = 12185, upload-time = "2025-09-26T14:40:37.245Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/80/fc9d01d5ed37ba4c42ca2b55b4339ae6e200b456be3a1aaddf4a9fa99b8c/pyperclip-1.11.0-py3-none-any.whl", hash = "sha256:299403e9ff44581cb9ba2ffeed69c7aa96a008622ad0c46cb575ca75b5b84273", size = 11063, upload-time = "2025-09-26T14:40:36.069Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1931,6 +2269,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
     { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
     { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
+]
+
+[[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
 ]
 
 [[package]]
@@ -2136,6 +2483,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich-rst"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docutils" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/6d/a506aaa4a9eaa945ed8ab2b7347859f53593864289853c5d6d62b77246e0/rich_rst-1.3.2.tar.gz", hash = "sha256:a1196fdddf1e364b02ec68a05e8ff8f6914fee10fbca2e6b6735f166bb0da8d4", size = 14936, upload-time = "2025-10-14T16:49:45.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/2f/b4530fbf948867702d0a3f27de4a6aab1d156f406d72852ab902c4d04de9/rich_rst-1.3.2-py3-none-any.whl", hash = "sha256:a99b4907cbe118cf9d18b0b44de272efa61f15117c61e39ebdc431baf5df722a", size = 12567, upload-time = "2025-10-14T16:49:42.953Z" },
+]
+
+[[package]]
 name = "rpds-py"
 version = "0.30.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2239,6 +2599,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/6f/b0/69adf22f4e24f3677208adb715c578266842e6e6a3cc77483f48dd999ede/ruff-0.15.0-py3-none-win32.whl", hash = "sha256:238a717ef803e501b6d51e0bdd0d2c6e8513fe9eec14002445134d3907cd46c3", size = 10465945, upload-time = "2026-02-03T17:53:12.591Z" },
     { url = "https://files.pythonhosted.org/packages/51/ad/f813b6e2c97e9b4598be25e94a9147b9af7e60523b0cb5d94d307c15229d/ruff-0.15.0-py3-none-win_amd64.whl", hash = "sha256:dd5e4d3301dc01de614da3cdffc33d4b1b96fb89e45721f1598e5532ccf78b18", size = 11564657, upload-time = "2026-02-03T17:52:51.893Z" },
     { url = "https://files.pythonhosted.org/packages/f6/b0/2d823f6e77ebe560f4e397d078487e8d52c1516b331e3521bc75db4272ca/ruff-0.15.0-py3-none-win_arm64.whl", hash = "sha256:c480d632cc0ca3f0727acac8b7d053542d9e114a462a145d0b00e7cd658c515a", size = 10865753, upload-time = "2026-02-03T17:53:03.014Z" },
+]
+
+[[package]]
+name = "secretstorage"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "jeepney" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
 ]
 
 [[package]]
@@ -2459,6 +2832,15 @@ wheels = [
 ]
 
 [[package]]
+name = "uncalled-for"
+version = "0.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/82/345cc927f7fbdae6065e7768759932fcc827fc20b29b45dfbafa2f1f7da4/uncalled_for-0.3.2.tar.gz", hash = "sha256:89f5dbcd71e2b8f47c030b1fa302e6cce2ec795d1ac565eeb6525c5fe55cb8a2", size = 50032, upload-time = "2026-05-06T13:38:25.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/25/2c87754f3a9e692315f7b811244090e68f362979fc8886b3fbd2985a1d8c/uncalled_for-0.3.2-py3-none-any.whl", hash = "sha256:0ff60b142c7d1f8070bde9d42afaa70aedc77dcc10998c227687e9c15713418e", size = 11444, upload-time = "2026-05-06T13:38:24.025Z" },
+]
+
+[[package]]
 name = "urllib3"
 version = "2.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2514,6 +2896,121 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/aa/a3/4d310fa5f00863544e1d0f4de93bddec248499ccf97d4791bc3122c9d4f3/virtualenv-20.36.1.tar.gz", hash = "sha256:8befb5c81842c641f8ee658481e42641c68b5eab3521d8e092d18320902466ba", size = 6032239, upload-time = "2026-01-09T18:21:01.296Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6a/2a/dc2228b2888f51192c7dc766106cd475f1b768c10caaf9727659726f7391/virtualenv-20.36.1-py3-none-any.whl", hash = "sha256:575a8d6b124ef88f6f51d56d656132389f961062a9177016a50e4f507bbcc19f", size = 6008258, upload-time = "2026-01-09T18:20:59.425Z" },
+]
+
+[[package]]
+name = "watchfiles"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c2/c9/8869df9b2a2d6c59d79220a4db37679e74f807c559ffe5265e08b227a210/watchfiles-1.1.1.tar.gz", hash = "sha256:a173cb5c16c4f40ab19cecf48a534c409f7ea983ab8fed0741304a1c0a31b3f2", size = 94440, upload-time = "2025-10-14T15:06:21.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/d5/f039e7e3c639d9b1d09b07ea412a6806d38123f0508e5f9b48a87b0a76cc/watchfiles-1.1.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:8c89f9f2f740a6b7dcc753140dd5e1ab9215966f7a3530d0c0705c83b401bd7d", size = 404745, upload-time = "2025-10-14T15:04:46.731Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/96/a881a13aa1349827490dab2d363c8039527060cfcc2c92cc6d13d1b1049e/watchfiles-1.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:bd404be08018c37350f0d6e34676bd1e2889990117a2b90070b3007f172d0610", size = 391769, upload-time = "2025-10-14T15:04:48.003Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/5b/d3b460364aeb8da471c1989238ea0e56bec24b6042a68046adf3d9ddb01c/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8526e8f916bb5b9a0a777c8317c23ce65de259422bba5b31325a6fa6029d33af", size = 449374, upload-time = "2025-10-14T15:04:49.179Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/44/5769cb62d4ed055cb17417c0a109a92f007114a4e07f30812a73a4efdb11/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2edc3553362b1c38d9f06242416a5d8e9fe235c204a4072e988ce2e5bb1f69f6", size = 459485, upload-time = "2025-10-14T15:04:50.155Z" },
+    { url = "https://files.pythonhosted.org/packages/19/0c/286b6301ded2eccd4ffd0041a1b726afda999926cf720aab63adb68a1e36/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:30f7da3fb3f2844259cba4720c3fc7138eb0f7b659c38f3bfa65084c7fc7abce", size = 488813, upload-time = "2025-10-14T15:04:51.059Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/2b/8530ed41112dd4a22f4dcfdb5ccf6a1baad1ff6eed8dc5a5f09e7e8c41c7/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8979280bdafff686ba5e4d8f97840f929a87ed9cdf133cbbd42f7766774d2aa", size = 594816, upload-time = "2025-10-14T15:04:52.031Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/d2/f5f9fb49489f184f18470d4f99f4e862a4b3e9ac2865688eb2099e3d837a/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dcc5c24523771db3a294c77d94771abcfcb82a0e0ee8efd910c37c59ec1b31bb", size = 475186, upload-time = "2025-10-14T15:04:53.064Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/68/5707da262a119fb06fbe214d82dd1fe4a6f4af32d2d14de368d0349eb52a/watchfiles-1.1.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1db5d7ae38ff20153d542460752ff397fcf5c96090c1230803713cf3147a6803", size = 456812, upload-time = "2025-10-14T15:04:55.174Z" },
+    { url = "https://files.pythonhosted.org/packages/66/ab/3cbb8756323e8f9b6f9acb9ef4ec26d42b2109bce830cc1f3468df20511d/watchfiles-1.1.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:28475ddbde92df1874b6c5c8aaeb24ad5be47a11f87cde5a28ef3835932e3e94", size = 630196, upload-time = "2025-10-14T15:04:56.22Z" },
+    { url = "https://files.pythonhosted.org/packages/78/46/7152ec29b8335f80167928944a94955015a345440f524d2dfe63fc2f437b/watchfiles-1.1.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:36193ed342f5b9842edd3532729a2ad55c4160ffcfa3700e0d54be496b70dd43", size = 622657, upload-time = "2025-10-14T15:04:57.521Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/bf/95895e78dd75efe9a7f31733607f384b42eb5feb54bd2eb6ed57cc2e94f4/watchfiles-1.1.1-cp312-cp312-win32.whl", hash = "sha256:859e43a1951717cc8de7f4c77674a6d389b106361585951d9e69572823f311d9", size = 272042, upload-time = "2025-10-14T15:04:59.046Z" },
+    { url = "https://files.pythonhosted.org/packages/87/0a/90eb755f568de2688cb220171c4191df932232c20946966c27a59c400850/watchfiles-1.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:91d4c9a823a8c987cce8fa2690923b069966dabb196dd8d137ea2cede885fde9", size = 288410, upload-time = "2025-10-14T15:05:00.081Z" },
+    { url = "https://files.pythonhosted.org/packages/36/76/f322701530586922fbd6723c4f91ace21364924822a8772c549483abed13/watchfiles-1.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:a625815d4a2bdca61953dbba5a39d60164451ef34c88d751f6c368c3ea73d404", size = 278209, upload-time = "2025-10-14T15:05:01.168Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/f750b29225fe77139f7ae5de89d4949f5a99f934c65a1f1c0b248f26f747/watchfiles-1.1.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:130e4876309e8686a5e37dba7d5e9bc77e6ed908266996ca26572437a5271e18", size = 404321, upload-time = "2025-10-14T15:05:02.063Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f9/f07a295cde762644aa4c4bb0f88921d2d141af45e735b965fb2e87858328/watchfiles-1.1.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5f3bde70f157f84ece3765b42b4a52c6ac1a50334903c6eaf765362f6ccca88a", size = 391783, upload-time = "2025-10-14T15:05:03.052Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/11/fc2502457e0bea39a5c958d86d2cb69e407a4d00b85735ca724bfa6e0d1a/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:14e0b1fe858430fc0251737ef3824c54027bedb8c37c38114488b8e131cf8219", size = 449279, upload-time = "2025-10-14T15:05:04.004Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/1f/d66bc15ea0b728df3ed96a539c777acfcad0eb78555ad9efcaa1274688f0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f27db948078f3823a6bb3b465180db8ebecf26dd5dae6f6180bd87383b6b4428", size = 459405, upload-time = "2025-10-14T15:05:04.942Z" },
+    { url = "https://files.pythonhosted.org/packages/be/90/9f4a65c0aec3ccf032703e6db02d89a157462fbb2cf20dd415128251cac0/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:059098c3a429f62fc98e8ec62b982230ef2c8df68c79e826e37b895bc359a9c0", size = 488976, upload-time = "2025-10-14T15:05:05.905Z" },
+    { url = "https://files.pythonhosted.org/packages/37/57/ee347af605d867f712be7029bb94c8c071732a4b44792e3176fa3c612d39/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bfb5862016acc9b869bb57284e6cb35fdf8e22fe59f7548858e2f971d045f150", size = 595506, upload-time = "2025-10-14T15:05:06.906Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/78/cc5ab0b86c122047f75e8fc471c67a04dee395daf847d3e59381996c8707/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:319b27255aacd9923b8a276bb14d21a5f7ff82564c744235fc5eae58d95422ae", size = 474936, upload-time = "2025-10-14T15:05:07.906Z" },
+    { url = "https://files.pythonhosted.org/packages/62/da/def65b170a3815af7bd40a3e7010bf6ab53089ef1b75d05dd5385b87cf08/watchfiles-1.1.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c755367e51db90e75b19454b680903631d41f9e3607fbd941d296a020c2d752d", size = 456147, upload-time = "2025-10-14T15:05:09.138Z" },
+    { url = "https://files.pythonhosted.org/packages/57/99/da6573ba71166e82d288d4df0839128004c67d2778d3b566c138695f5c0b/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:c22c776292a23bfc7237a98f791b9ad3144b02116ff10d820829ce62dff46d0b", size = 630007, upload-time = "2025-10-14T15:05:10.117Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/51/7439c4dd39511368849eb1e53279cd3454b4a4dbace80bab88feeb83c6b5/watchfiles-1.1.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:3a476189be23c3686bc2f4321dd501cb329c0a0469e77b7b534ee10129ae6374", size = 622280, upload-time = "2025-10-14T15:05:11.146Z" },
+    { url = "https://files.pythonhosted.org/packages/95/9c/8ed97d4bba5db6fdcdb2b298d3898f2dd5c20f6b73aee04eabe56c59677e/watchfiles-1.1.1-cp313-cp313-win32.whl", hash = "sha256:bf0a91bfb5574a2f7fc223cf95eeea79abfefa404bf1ea5e339c0c1560ae99a0", size = 272056, upload-time = "2025-10-14T15:05:12.156Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f3/c14e28429f744a260d8ceae18bf58c1d5fa56b50d006a7a9f80e1882cb0d/watchfiles-1.1.1-cp313-cp313-win_amd64.whl", hash = "sha256:52e06553899e11e8074503c8e716d574adeeb7e68913115c4b3653c53f9bae42", size = 288162, upload-time = "2025-10-14T15:05:13.208Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/61/fe0e56c40d5cd29523e398d31153218718c5786b5e636d9ae8ae79453d27/watchfiles-1.1.1-cp313-cp313-win_arm64.whl", hash = "sha256:ac3cc5759570cd02662b15fbcd9d917f7ecd47efe0d6b40474eafd246f91ea18", size = 277909, upload-time = "2025-10-14T15:05:14.49Z" },
+    { url = "https://files.pythonhosted.org/packages/79/42/e0a7d749626f1e28c7108a99fb9bf524b501bbbeb9b261ceecde644d5a07/watchfiles-1.1.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:563b116874a9a7ce6f96f87cd0b94f7faf92d08d0021e837796f0a14318ef8da", size = 403389, upload-time = "2025-10-14T15:05:15.777Z" },
+    { url = "https://files.pythonhosted.org/packages/15/49/08732f90ce0fbbc13913f9f215c689cfc9ced345fb1bcd8829a50007cc8d/watchfiles-1.1.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3ad9fe1dae4ab4212d8c91e80b832425e24f421703b5a42ef2e4a1e215aff051", size = 389964, upload-time = "2025-10-14T15:05:16.85Z" },
+    { url = "https://files.pythonhosted.org/packages/27/0d/7c315d4bd5f2538910491a0393c56bf70d333d51bc5b34bee8e68e8cea19/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce70f96a46b894b36eba678f153f052967a0d06d5b5a19b336ab0dbbd029f73e", size = 448114, upload-time = "2025-10-14T15:05:17.876Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/24/9e096de47a4d11bc4df41e9d1e61776393eac4cb6eb11b3e23315b78b2cc/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cb467c999c2eff23a6417e58d75e5828716f42ed8289fe6b77a7e5a91036ca70", size = 460264, upload-time = "2025-10-14T15:05:18.962Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/0f/e8dea6375f1d3ba5fcb0b3583e2b493e77379834c74fd5a22d66d85d6540/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:836398932192dae4146c8f6f737d74baeac8b70ce14831a239bdb1ca882fc261", size = 487877, upload-time = "2025-10-14T15:05:20.094Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/5b/df24cfc6424a12deb41503b64d42fbea6b8cb357ec62ca84a5a3476f654a/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:743185e7372b7bc7c389e1badcc606931a827112fbbd37f14c537320fca08620", size = 595176, upload-time = "2025-10-14T15:05:21.134Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/b5/853b6757f7347de4e9b37e8cc3289283fb983cba1ab4d2d7144694871d9c/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:afaeff7696e0ad9f02cbb8f56365ff4686ab205fcf9c4c5b6fdfaaa16549dd04", size = 473577, upload-time = "2025-10-14T15:05:22.306Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/f7/0a4467be0a56e80447c8529c9fce5b38eab4f513cb3d9bf82e7392a5696b/watchfiles-1.1.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3f7eb7da0eb23aa2ba036d4f616d46906013a68caf61b7fdbe42fc8b25132e77", size = 455425, upload-time = "2025-10-14T15:05:23.348Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e0/82583485ea00137ddf69bc84a2db88bd92ab4a6e3c405e5fb878ead8d0e7/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:831a62658609f0e5c64178211c942ace999517f5770fe9436be4c2faeba0c0ef", size = 628826, upload-time = "2025-10-14T15:05:24.398Z" },
+    { url = "https://files.pythonhosted.org/packages/28/9a/a785356fccf9fae84c0cc90570f11702ae9571036fb25932f1242c82191c/watchfiles-1.1.1-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:f9a2ae5c91cecc9edd47e041a930490c31c3afb1f5e6d71de3dc671bfaca02bf", size = 622208, upload-time = "2025-10-14T15:05:25.45Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f4/0872229324ef69b2c3edec35e84bd57a1289e7d3fe74588048ed8947a323/watchfiles-1.1.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:d1715143123baeeaeadec0528bb7441103979a1d5f6fd0e1f915383fea7ea6d5", size = 404315, upload-time = "2025-10-14T15:05:26.501Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/22/16d5331eaed1cb107b873f6ae1b69e9ced582fcf0c59a50cd84f403b1c32/watchfiles-1.1.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:39574d6370c4579d7f5d0ad940ce5b20db0e4117444e39b6d8f99db5676c52fd", size = 390869, upload-time = "2025-10-14T15:05:27.649Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/7e/5643bfff5acb6539b18483128fdc0ef2cccc94a5b8fbda130c823e8ed636/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7365b92c2e69ee952902e8f70f3ba6360d0d596d9299d55d7d386df84b6941fb", size = 449919, upload-time = "2025-10-14T15:05:28.701Z" },
+    { url = "https://files.pythonhosted.org/packages/51/2e/c410993ba5025a9f9357c376f48976ef0e1b1aefb73b97a5ae01a5972755/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bfff9740c69c0e4ed32416f013f3c45e2ae42ccedd1167ef2d805c000b6c71a5", size = 460845, upload-time = "2025-10-14T15:05:30.064Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a4/2df3b404469122e8680f0fcd06079317e48db58a2da2950fb45020947734/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b27cf2eb1dda37b2089e3907d8ea92922b673c0c427886d4edc6b94d8dfe5db3", size = 489027, upload-time = "2025-10-14T15:05:31.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/84/4587ba5b1f267167ee715b7f66e6382cca6938e0a4b870adad93e44747e6/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:526e86aced14a65a5b0ec50827c745597c782ff46b571dbfe46192ab9e0b3c33", size = 595615, upload-time = "2025-10-14T15:05:32.074Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/0f/c6988c91d06e93cd0bb3d4a808bcf32375ca1904609835c3031799e3ecae/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:04e78dd0b6352db95507fd8cb46f39d185cf8c74e4cf1e4fbad1d3df96faf510", size = 474836, upload-time = "2025-10-14T15:05:33.209Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/36/ded8aebea91919485b7bbabbd14f5f359326cb5ec218cd67074d1e426d74/watchfiles-1.1.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5c85794a4cfa094714fb9c08d4a218375b2b95b8ed1666e8677c349906246c05", size = 455099, upload-time = "2025-10-14T15:05:34.189Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e0/8c9bdba88af756a2fce230dd365fab2baf927ba42cd47521ee7498fd5211/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:74d5012b7630714b66be7b7b7a78855ef7ad58e8650c73afc4c076a1f480a8d6", size = 630626, upload-time = "2025-10-14T15:05:35.216Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/84/a95db05354bf2d19e438520d92a8ca475e578c647f78f53197f5a2f17aaf/watchfiles-1.1.1-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:8fbe85cb3201c7d380d3d0b90e63d520f15d6afe217165d7f98c9c649654db81", size = 622519, upload-time = "2025-10-14T15:05:36.259Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/ce/d8acdc8de545de995c339be67711e474c77d643555a9bb74a9334252bd55/watchfiles-1.1.1-cp314-cp314-win32.whl", hash = "sha256:3fa0b59c92278b5a7800d3ee7733da9d096d4aabcfabb9a928918bd276ef9b9b", size = 272078, upload-time = "2025-10-14T15:05:37.63Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c9/a74487f72d0451524be827e8edec251da0cc1fcf111646a511ae752e1a3d/watchfiles-1.1.1-cp314-cp314-win_amd64.whl", hash = "sha256:c2047d0b6cea13b3316bdbafbfa0c4228ae593d995030fda39089d36e64fc03a", size = 287664, upload-time = "2025-10-14T15:05:38.95Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b8/8ac000702cdd496cdce998c6f4ee0ca1f15977bba51bdf07d872ebdfc34c/watchfiles-1.1.1-cp314-cp314-win_arm64.whl", hash = "sha256:842178b126593addc05acf6fce960d28bc5fae7afbaa2c6c1b3a7b9460e5be02", size = 277154, upload-time = "2025-10-14T15:05:39.954Z" },
+    { url = "https://files.pythonhosted.org/packages/47/a8/e3af2184707c29f0f14b1963c0aace6529f9d1b8582d5b99f31bbf42f59e/watchfiles-1.1.1-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:88863fbbc1a7312972f1c511f202eb30866370ebb8493aef2812b9ff28156a21", size = 403820, upload-time = "2025-10-14T15:05:40.932Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ec/e47e307c2f4bd75f9f9e8afbe3876679b18e1bcec449beca132a1c5ffb2d/watchfiles-1.1.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:55c7475190662e202c08c6c0f4d9e345a29367438cf8e8037f3155e10a88d5a5", size = 390510, upload-time = "2025-10-14T15:05:41.945Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/a0/ad235642118090f66e7b2f18fd5c42082418404a79205cdfca50b6309c13/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3f53fa183d53a1d7a8852277c92b967ae99c2d4dcee2bfacff8868e6e30b15f7", size = 448408, upload-time = "2025-10-14T15:05:43.385Z" },
+    { url = "https://files.pythonhosted.org/packages/df/85/97fa10fd5ff3332ae17e7e40e20784e419e28521549780869f1413742e9d/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6aae418a8b323732fa89721d86f39ec8f092fc2af67f4217a2b07fd3e93c6101", size = 458968, upload-time = "2025-10-14T15:05:44.404Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c2/9059c2e8966ea5ce678166617a7f75ecba6164375f3b288e50a40dc6d489/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f096076119da54a6080e8920cbdaac3dbee667eb91dcc5e5b78840b87415bd44", size = 488096, upload-time = "2025-10-14T15:05:45.398Z" },
+    { url = "https://files.pythonhosted.org/packages/94/44/d90a9ec8ac309bc26db808a13e7bfc0e4e78b6fc051078a554e132e80160/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:00485f441d183717038ed2e887a7c868154f216877653121068107b227a2f64c", size = 596040, upload-time = "2025-10-14T15:05:46.502Z" },
+    { url = "https://files.pythonhosted.org/packages/95/68/4e3479b20ca305cfc561db3ed207a8a1c745ee32bf24f2026a129d0ddb6e/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a55f3e9e493158d7bfdb60a1165035f1cf7d320914e7b7ea83fe22c6023b58fc", size = 473847, upload-time = "2025-10-14T15:05:47.484Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/55/2af26693fd15165c4ff7857e38330e1b61ab8c37d15dc79118cdba115b7a/watchfiles-1.1.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8c91ed27800188c2ae96d16e3149f199d62f86c7af5f5f4d2c61a3ed8cd3666c", size = 455072, upload-time = "2025-10-14T15:05:48.928Z" },
+    { url = "https://files.pythonhosted.org/packages/66/1d/d0d200b10c9311ec25d2273f8aad8c3ef7cc7ea11808022501811208a750/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:311ff15a0bae3714ffb603e6ba6dbfba4065ab60865d15a6ec544133bdb21099", size = 629104, upload-time = "2025-10-14T15:05:49.908Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/bd/fa9bb053192491b3867ba07d2343d9f2252e00811567d30ae8d0f78136fe/watchfiles-1.1.1-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:a916a2932da8f8ab582f242c065f5c81bed3462849ca79ee357dd9551b0e9b01", size = 622112, upload-time = "2025-10-14T15:05:50.941Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/7b/bac442e6b96c9d25092695578dda82403c77936104b5682307bd4deb1ad4/websockets-16.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:71c989cbf3254fbd5e84d3bff31e4da39c43f884e64f2551d14bb3c186230f00", size = 177365, upload-time = "2026-01-10T09:22:46.787Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/fe/136ccece61bd690d9c1f715baaeefd953bb2360134de73519d5df19d29ca/websockets-16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8b6e209ffee39ff1b6d0fa7bfef6de950c60dfb91b8fcead17da4ee539121a79", size = 175038, upload-time = "2026-01-10T09:22:47.999Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1e/9771421ac2286eaab95b8575b0cb701ae3663abf8b5e1f64f1fd90d0a673/websockets-16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:86890e837d61574c92a97496d590968b23c2ef0aeb8a9bc9421d174cd378ae39", size = 175328, upload-time = "2026-01-10T09:22:49.809Z" },
+    { url = "https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9b5aca38b67492ef518a8ab76851862488a478602229112c4b0d58d63a7a4d5c", size = 184915, upload-time = "2026-01-10T09:22:51.071Z" },
+    { url = "https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0334872c0a37b606418ac52f6ab9cfd17317ac26365f7f65e203e2d0d0d359f", size = 186152, upload-time = "2026-01-10T09:22:52.224Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/34/9bf8df0c0cf88fa7bfe36678dc7b02970c9a7d5e065a3099292db87b1be2/websockets-16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a0b31e0b424cc6b5a04b8838bbaec1688834b2383256688cf47eb97412531da1", size = 185583, upload-time = "2026-01-10T09:22:53.443Z" },
+    { url = "https://files.pythonhosted.org/packages/47/88/4dd516068e1a3d6ab3c7c183288404cd424a9a02d585efbac226cb61ff2d/websockets-16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:485c49116d0af10ac698623c513c1cc01c9446c058a4e61e3bf6c19dff7335a2", size = 184880, upload-time = "2026-01-10T09:22:55.033Z" },
+    { url = "https://files.pythonhosted.org/packages/91/d6/7d4553ad4bf1c0421e1ebd4b18de5d9098383b5caa1d937b63df8d04b565/websockets-16.0-cp312-cp312-win32.whl", hash = "sha256:eaded469f5e5b7294e2bdca0ab06becb6756ea86894a47806456089298813c89", size = 178261, upload-time = "2026-01-10T09:22:56.251Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f0/f3a17365441ed1c27f850a80b2bc680a0fa9505d733fe152fdf5e98c1c0b/websockets-16.0-cp312-cp312-win_amd64.whl", hash = "sha256:5569417dc80977fc8c2d43a86f78e0a5a22fee17565d78621b6bb264a115d4ea", size = 178693, upload-time = "2026-01-10T09:22:57.478Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364, upload-time = "2026-01-10T09:22:59.333Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039, upload-time = "2026-01-10T09:23:01.171Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323, upload-time = "2026-01-10T09:23:02.341Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975, upload-time = "2026-01-10T09:23:03.756Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203, upload-time = "2026-01-10T09:23:05.01Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653, upload-time = "2026-01-10T09:23:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920, upload-time = "2026-01-10T09:23:07.492Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255, upload-time = "2026-01-10T09:23:09.245Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689, upload-time = "2026-01-10T09:23:10.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/1d/e88022630271f5bd349ed82417136281931e558d628dd52c4d8621b4a0b2/websockets-16.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0", size = 177406, upload-time = "2026-01-10T09:23:12.178Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904", size = 175085, upload-time = "2026-01-10T09:23:13.511Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4", size = 175328, upload-time = "2026-01-10T09:23:14.727Z" },
+    { url = "https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e", size = 185044, upload-time = "2026-01-10T09:23:15.939Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/6e/9a0927ac24bd33a0a9af834d89e0abc7cfd8e13bed17a86407a66773cc0e/websockets-16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4", size = 186279, upload-time = "2026-01-10T09:23:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ca/bf1c68440d7a868180e11be653c85959502efd3a709323230314fda6e0b3/websockets-16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1", size = 185711, upload-time = "2026-01-10T09:23:18.372Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f8/fdc34643a989561f217bb477cbc47a3a07212cbda91c0e4389c43c296ebf/websockets-16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3", size = 184982, upload-time = "2026-01-10T09:23:19.652Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/574fa27e233764dbac9c52730d63fcf2823b16f0856b3329fc6268d6ae4f/websockets-16.0-cp314-cp314-win32.whl", hash = "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8", size = 177915, upload-time = "2026-01-10T09:23:21.458Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f1/ae6b937bf3126b5134ce1f482365fde31a357c784ac51852978768b5eff4/websockets-16.0-cp314-cp314-win_amd64.whl", hash = "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d", size = 178381, upload-time = "2026-01-10T09:23:22.715Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9b/f791d1db48403e1f0a27577a6beb37afae94254a8c6f08be4a23e4930bc0/websockets-16.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244", size = 177737, upload-time = "2026-01-10T09:23:24.523Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/40/53ad02341fa33b3ce489023f635367a4ac98b73570102ad2cdd770dacc9a/websockets-16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e", size = 175268, upload-time = "2026-01-10T09:23:25.781Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/6158d4e459b984f949dcbbb0c5d270154c7618e11c01029b9bbd1bb4c4f9/websockets-16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641", size = 175486, upload-time = "2026-01-10T09:23:27.033Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/2d/7583b30208b639c8090206f95073646c2c9ffd66f44df967981a64f849ad/websockets-16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8", size = 185331, upload-time = "2026-01-10T09:23:28.259Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b0/cce3784eb519b7b5ad680d14b9673a31ab8dcb7aad8b64d81709d2430aa8/websockets-16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e", size = 186501, upload-time = "2026-01-10T09:23:29.449Z" },
+    { url = "https://files.pythonhosted.org/packages/19/60/b8ebe4c7e89fb5f6cdf080623c9d92789a53636950f7abacfc33fe2b3135/websockets-16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944", size = 186062, upload-time = "2026-01-10T09:23:31.368Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356, upload-time = "2026-01-10T09:23:32.627Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Expose all configured graphs as MCP tools via Streamable HTTP at `/mcp` using [FastMCP](https://gofastmcp.com)
- Auth reuses the existing Aegra auth backend (ASGI middleware + ContextVar)
- Optional OIDC proxy support via FastMCP's `OIDCProxy` for spec-compliant MCP OAuth flow
- Configurable `final_response_only` mode to return only the last AI message
- Disable via `http.disable_mcp` in `aegra.json`

## Changes

- `adapters/mcp_adapter.py` — auth middleware, `_GraphTool` subclass, OIDC builder, lifespan management
- `config.py` — `McpConfig`, `McpOidcConfig` TypedDicts, `load_mcp_config()`
- `settings.py` — `McpSettings` for `MCP_OIDC_CLIENT_SECRET` env var
- `main.py` — register tools on startup, mount `/mcp`, enter MCP lifespan
- `docs/mcp.md` — full user-facing documentation
- `docs/reference/configuration.mdx` — `http.disable_mcp`, `mcp.*`, `mcp.oidc.*` reference

## Test plan

- [x] Unit tests (`test_mcp_adapter.py` — 24 tests)
- [x] Integration tests (`test_mcp_endpoint.py` — 9 tests)
- [x] Config tests (`test_config.py` — MCP section)
- [x] `ruff check` / `ruff format` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Model Context Protocol (MCP) support: streamable /mcp HTTP endpoint, expose deployed agents as tools, configurable final_response_only, optional OIDC proxy with environment-secret placeholders

* **Documentation**
  * README and docs expanded with MCP architecture, config reference, examples, enable/disable and OIDC guidance

* **Tests**
  * Added unit, integration, and end-to-end tests covering MCP endpoint, tool registration, auth, OIDC, and config parsing

* **Chores**
  * Updated example env template and bumped package versions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/aegra/aegra/pull/383)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a Model Context Protocol (MCP) adapter that exposes every configured Aegra graph as an MCP tool via Streamable HTTP at `/mcp`, using FastMCP with the existing Aegra auth stack and an optional OIDC proxy for spec-compliant OAuth flow.

- **New `adapters/mcp_adapter.py`**: `_AuthMiddleware` bridges MCP requests to Aegra's auth backend; `_GraphTool.run` prepares a run, awaits completion, reads the result, and cleans up the ephemeral thread — all within a structured `try/finally` that ensures cleanup on both success and error paths.
- **`langgraph_service.py`**: Extended to parse a new dict-format graph config entry alongside the existing bare-string format, populating the description field consumed by MCP tool registration.
- **`config.py` / `main.py`**: `McpConfig`/`McpAuthConfig` TypedDicts added; `disable_mcp` guard applied symmetrically in both `create_app` (mount) and `lifespan` (tool registration).

<h3>Confidence Score: 4/5</h3>

The adapter is safe to merge with minor style concerns; all critical execution paths are handled correctly.

The run execution flow in _GraphTool.run is structured correctly — _read_run_result executes inside the try block before the finally cleans up the ephemeral thread, TimeoutError and HTTPException from _prepare_run are caught explicitly, and the finally block ensures thread deletion on every exit path. Remaining concerns are style issues that do not affect runtime behaviour.

libs/aegra-api/src/aegra_api/adapters/mcp_adapter.py deserves the most careful review — it owns the auth handoff, run lifecycle, and cleanup logic for the new protocol endpoint.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/adapters/mcp_adapter.py | New MCP adapter core — auth middleware, _GraphTool run/cleanup, OIDC loading, lifespan wiring. Exception handling is structured; some broad except Exception catches remain in tension with CLAUDE.md. |
| libs/aegra-api/src/aegra_api/config.py | Adds McpConfig/McpAuthConfig TypedDicts and load_mcp_config(); structlog f-string inconsistency was previously flagged. |
| libs/aegra-api/src/aegra_api/main.py | MCP adapter wired into lifespan and create_app with symmetric disable_mcp guards; mcp_lifespan context manager wraps the yield correctly. |
| libs/aegra-api/src/aegra_api/services/langgraph_service.py | New dict-format graph config support; fallback to empty string when path key is absent produces a cryptic error message for misconfigured entries. |
| libs/aegra-api/tests/unit/test_adapters/test_mcp_adapter.py | Comprehensive 24-test unit suite; autouse fixture omits _mcp_app_lifespan reset unlike the integration fixture, a latent isolation gap. |
| libs/aegra-api/tests/integration/test_mcp_endpoint.py | 9-test integration suite with full module-state fixture; covers auth rejection, tool listing, OIDC provider loading, and config parsing. |
| libs/aegra-api/tests/e2e/test_mcp.py | 3 E2E tests against a running server; uses settings fallback for SERVER_URL correctly and covers initialize, tools/list, and malformed JSON-RPC paths. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as MCP Client
    participant M as _AuthMiddleware
    participant AB as Aegra Auth Backend
    participant GT as _GraphTool.run
    participant DB as PostgreSQL
    participant E as Executor

    C->>M: POST /mcp (Bearer token)
    M->>AB: backend.authenticate(request)
    alt Auth succeeds
        AB-->>M: (credentials, user_obj)
        M->>M: _current_user.set(user)
        M->>GT: tool invocation
        GT->>DB: _prepare_run (create thread+run, submit job)
        DB-->>GT: run_id
        GT->>E: wait_for_completion(run_id)
        E-->>GT: completed
        GT->>DB: _read_run_result(run_id)
        DB-->>GT: (status, output, error_msg)
        GT->>DB: _delete_thread_by_id (finally)
        alt "status == error"
            GT-->>C: ToolError(error_msg)
        else "status == success"
            GT-->>C: ToolResult(json output)
        end
    else Auth fails + OAuth disabled
        M-->>C: 401 Authentication failed
    else Auth fails + OAuth enabled
        M->>GT: pass-through (FastMCP handles)
    end
```

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `libs/aegra-api/pyproject.toml`, line 3 ([link](https://github.com/aegra/aegra/blob/39b77a0c21960c63c44aa2619eca572e225d0e58/libs/aegra-api/pyproject.toml#L3)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Missing version bump for a new feature**

   CLAUDE.md requires: *"Always bump the version before creating a PR. New non-breaking feature → patch bump."* and *"aegra-api and aegra-cli MUST always have the same version."* Both `libs/aegra-api/pyproject.toml` and `libs/aegra-cli/pyproject.toml` are still at `0.9.16` — neither was bumped for this new MCP adapter feature. The PR should include a patch bump to `0.9.17` in both files.

   **Context Used:** CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=1640ab19-5310-4fc5-aaf6-3760087c66e8))
   
   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Fpyproject.toml%0ALine%3A%203%0A%0AComment%3A%0A**Missing%20version%20bump%20for%20a%20new%20feature**%0A%0ACLAUDE.md%20requires%3A%20*%22Always%20bump%20the%20version%20before%20creating%20a%20PR.%20New%20non-breaking%20feature%20%E2%86%92%20patch%20bump.%22*%20and%20*%22aegra-api%20and%20aegra-cli%20MUST%20always%20have%20the%20same%20version.%22*%20Both%20%60libs%2Faegra-api%2Fpyproject.toml%60%20and%20%60libs%2Faegra-cli%2Fpyproject.toml%60%20are%20still%20at%20%600.9.16%60%20%E2%80%94%20neither%20was%20bumped%20for%20this%20new%20MCP%20adapter%20feature.%20The%20PR%20should%20include%20a%20patch%20bump%20to%20%600.9.17%60%20in%20both%20files.%0A%0A**Context%20Used%3A**%20CLAUDE.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D1640ab19-5310-4fc5-aaf6-3760087c66e8%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=aegra%2Faegra&pr=383&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=2" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Fpyproject.toml%0ALine%3A%203%0A%0AComment%3A%0A**Missing%20version%20bump%20for%20a%20new%20feature**%0A%0ACLAUDE.md%20requires%3A%20*%22Always%20bump%20the%20version%20before%20creating%20a%20PR.%20New%20non-breaking%20feature%20%E2%86%92%20patch%20bump.%22*%20and%20*%22aegra-api%20and%20aegra-cli%20MUST%20always%20have%20the%20same%20version.%22*%20Both%20%60libs%2Faegra-api%2Fpyproject.toml%60%20and%20%60libs%2Faegra-cli%2Fpyproject.toml%60%20are%20still%20at%20%600.9.16%60%20%E2%80%94%20neither%20was%20bumped%20for%20this%20new%20MCP%20adapter%20feature.%20The%20PR%20should%20include%20a%20patch%20bump%20to%20%600.9.17%60%20in%20both%20files.%0A%0A**Context%20Used%3A**%20CLAUDE.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D1640ab19-5310-4fc5-aaf6-3760087c66e8%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=383&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22feat%2Fmcp%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fmcp%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20libs%2Faegra-api%2Fpyproject.toml%0ALine%3A%203%0A%0AComment%3A%0A**Missing%20version%20bump%20for%20a%20new%20feature**%0A%0ACLAUDE.md%20requires%3A%20*%22Always%20bump%20the%20version%20before%20creating%20a%20PR.%20New%20non-breaking%20feature%20%E2%86%92%20patch%20bump.%22*%20and%20*%22aegra-api%20and%20aegra-cli%20MUST%20always%20have%20the%20same%20version.%22*%20Both%20%60libs%2Faegra-api%2Fpyproject.toml%60%20and%20%60libs%2Faegra-cli%2Fpyproject.toml%60%20are%20still%20at%20%600.9.16%60%20%E2%80%94%20neither%20was%20bumped%20for%20this%20new%20MCP%20adapter%20feature.%20The%20PR%20should%20include%20a%20patch%20bump%20to%20%600.9.17%60%20in%20both%20files.%0A%0A**Context%20Used%3A**%20CLAUDE.md%20%28%5Bsource%5D%28https%3A%2F%2Fapp.greptile.com%2Freview%2Fcustom-context%3Fmemory%3D1640ab19-5310-4fc5-aaf6-3760087c66e8%29%29%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise."><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=2" height="20"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fservices%2Flanggraph_service.py%3A145-148%0A**Misleading%20error%20when%20dict-format%20graph%20config%20is%20missing%20%60path%60%20key**%0A%0A%60graph_value.get%28%22path%22%2C%20%22%22%29%60%20silently%20substitutes%20%60%22%22%60%20when%20the%20key%20is%20absent%2C%20then%20the%20downstream%20%60%22%3A%22%20not%20in%20graph_path%60%20guard%20raises%20%60ValueError%28%22Invalid%20graph%20path%20format%3A%20%22%29%60%20%E2%80%94%20an%20empty%20string%20that%20gives%20the%20user%20no%20indication%20of%20what's%20actually%20wrong.%20A%20user%20who%20accidentally%20writes%20%60%7B%22description%22%3A%20%22My%20agent%22%7D%60%20without%20the%20required%20%60path%60%20field%20will%20receive%20a%20cryptic%20error%20with%20no%20actionable%20message.%0A%0A%23%23%23%20Issue%202%20of%202%0Alibs%2Faegra-api%2Ftests%2Funit%2Ftest_adapters%2Ftest_mcp_adapter.py%3A35-38%0A**Unit%20test%20fixture%20omits%20%60_mcp_app_lifespan%60%20reset%2C%20unlike%20the%20integration%20fixture**%0A%0AThe%20integration-test%20%60_reset_module_state%60%20fixture%20explicitly%20resets%20%60mcp_adapter._mcp_app_lifespan%20%3D%20None%60%2C%20but%20the%20unit-test%20fixture%20does%20not.%20Any%20future%20unit%20test%20that%20calls%20%60mount_mcp%60%20would%20leave%20a%20stale%20lifespan%20handle%20in%20the%20module%2C%20potentially%20causing%20%60mcp_lifespan%28%29%60%20in%20a%20subsequent%20test%20to%20enter%20the%20wrong%20context%20manager.%0A%0A%60%60%60suggestion%0A%20%20%20%20mcp_adapter._final_response_only%20%3D%20None%0A%20%20%20%20mcp_adapter._mcp_app_lifespan%20%3D%20None%0A%20%20%20%20mcp_adapter._mcp_oauth_enabled%20%3D%20False%0A%20%20%20%20mcp_adapter.mcp_server.auth%20%3D%20None%0A%20%20%20%20mcp_adapter.mcp_server._local_provider._components.clear%28%29%0A%60%60%60%0A%0A&repo=aegra%2Faegra&pr=383&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fservices%2Flanggraph_service.py%3A145-148%0A**Misleading%20error%20when%20dict-format%20graph%20config%20is%20missing%20%60path%60%20key**%0A%0A%60graph_value.get%28%22path%22%2C%20%22%22%29%60%20silently%20substitutes%20%60%22%22%60%20when%20the%20key%20is%20absent%2C%20then%20the%20downstream%20%60%22%3A%22%20not%20in%20graph_path%60%20guard%20raises%20%60ValueError%28%22Invalid%20graph%20path%20format%3A%20%22%29%60%20%E2%80%94%20an%20empty%20string%20that%20gives%20the%20user%20no%20indication%20of%20what's%20actually%20wrong.%20A%20user%20who%20accidentally%20writes%20%60%7B%22description%22%3A%20%22My%20agent%22%7D%60%20without%20the%20required%20%60path%60%20field%20will%20receive%20a%20cryptic%20error%20with%20no%20actionable%20message.%0A%0A%23%23%23%20Issue%202%20of%202%0Alibs%2Faegra-api%2Ftests%2Funit%2Ftest_adapters%2Ftest_mcp_adapter.py%3A35-38%0A**Unit%20test%20fixture%20omits%20%60_mcp_app_lifespan%60%20reset%2C%20unlike%20the%20integration%20fixture**%0A%0AThe%20integration-test%20%60_reset_module_state%60%20fixture%20explicitly%20resets%20%60mcp_adapter._mcp_app_lifespan%20%3D%20None%60%2C%20but%20the%20unit-test%20fixture%20does%20not.%20Any%20future%20unit%20test%20that%20calls%20%60mount_mcp%60%20would%20leave%20a%20stale%20lifespan%20handle%20in%20the%20module%2C%20potentially%20causing%20%60mcp_lifespan%28%29%60%20in%20a%20subsequent%20test%20to%20enter%20the%20wrong%20context%20manager.%0A%0A%60%60%60suggestion%0A%20%20%20%20mcp_adapter._final_response_only%20%3D%20None%0A%20%20%20%20mcp_adapter._mcp_app_lifespan%20%3D%20None%0A%20%20%20%20mcp_adapter._mcp_oauth_enabled%20%3D%20False%0A%20%20%20%20mcp_adapter.mcp_server.auth%20%3D%20None%0A%20%20%20%20mcp_adapter.mcp_server._local_provider._components.clear%28%29%0A%60%60%60%0A%0A&pr=383&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22feat%2Fmcp%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fmcp%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fservices%2Flanggraph_service.py%3A145-148%0A**Misleading%20error%20when%20dict-format%20graph%20config%20is%20missing%20%60path%60%20key**%0A%0A%60graph_value.get%28%22path%22%2C%20%22%22%29%60%20silently%20substitutes%20%60%22%22%60%20when%20the%20key%20is%20absent%2C%20then%20the%20downstream%20%60%22%3A%22%20not%20in%20graph_path%60%20guard%20raises%20%60ValueError%28%22Invalid%20graph%20path%20format%3A%20%22%29%60%20%E2%80%94%20an%20empty%20string%20that%20gives%20the%20user%20no%20indication%20of%20what's%20actually%20wrong.%20A%20user%20who%20accidentally%20writes%20%60%7B%22description%22%3A%20%22My%20agent%22%7D%60%20without%20the%20required%20%60path%60%20field%20will%20receive%20a%20cryptic%20error%20with%20no%20actionable%20message.%0A%0A%23%23%23%20Issue%202%20of%202%0Alibs%2Faegra-api%2Ftests%2Funit%2Ftest_adapters%2Ftest_mcp_adapter.py%3A35-38%0A**Unit%20test%20fixture%20omits%20%60_mcp_app_lifespan%60%20reset%2C%20unlike%20the%20integration%20fixture**%0A%0AThe%20integration-test%20%60_reset_module_state%60%20fixture%20explicitly%20resets%20%60mcp_adapter._mcp_app_lifespan%20%3D%20None%60%2C%20but%20the%20unit-test%20fixture%20does%20not.%20Any%20future%20unit%20test%20that%20calls%20%60mount_mcp%60%20would%20leave%20a%20stale%20lifespan%20handle%20in%20the%20module%2C%20potentially%20causing%20%60mcp_lifespan%28%29%60%20in%20a%20subsequent%20test%20to%20enter%20the%20wrong%20context%20manager.%0A%0A%60%60%60suggestion%0A%20%20%20%20mcp_adapter._final_response_only%20%3D%20None%0A%20%20%20%20mcp_adapter._mcp_app_lifespan%20%3D%20None%0A%20%20%20%20mcp_adapter._mcp_oauth_enabled%20%3D%20False%0A%20%20%20%20mcp_adapter.mcp_server.auth%20%3D%20None%0A%20%20%20%20mcp_adapter.mcp_server._local_provider._components.clear%28%29%0A%60%60%60%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a>

<sub>Reviews (16): Last reviewed commit: ["fix: address remaining review comments o..."](https://github.com/aegra/aegra/commit/09d88d8bbb4a766fecf72f99d5aa822340f81d38) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31909210)</sub>

<!-- /greptile_comment -->