### PR TITLE
feat: add in-progress HTTP request metrics to Prometheus

### DIFF
--- a/docs/guides/observability.mdx
+++ b/docs/guides/observability.mdx
@@ -161,6 +161,17 @@ ENABLE_PROMETHEUS_METRICS=true
 
 This exposes a `/metrics` endpoint with standard HTTP request metrics in Prometheus exposition format. Scrape it with any Prometheus-compatible collector and visualize with Grafana.
 
+### Exposed metrics
+
+| Metric | Type | Description |
+| --- | --- | --- |
+| `http_requests_total` | Counter | Total requests by method, status, and handler |
+| `http_request_duration_seconds` | Histogram | Request latency by handler (few buckets, for aggregation) |
+| `http_request_duration_highr_seconds` | Histogram | Request latency with many buckets (for accurate percentiles) |
+| `http_request_size_bytes` | Summary | Content length of incoming requests by handler |
+| `http_response_size_bytes` | Summary | Content length of outgoing responses by handler |
+| `http_server_active_requests` | Gauge | Number of HTTP requests currently in progress |
+
 The `/metrics` endpoint is **not** protected by Aegra's authentication middleware. This is intentional — Prometheus scrapers typically do not support application-level auth. If you need to restrict access, use network-level controls (firewall rules, internal load-balancer listeners, etc.).
 
 See the [environment variables reference](/reference/environment-variables#prometheus-metrics) for details.

--- a/libs/aegra-api/src/aegra_api/observability/metrics.py
+++ b/libs/aegra-api/src/aegra_api/observability/metrics.py
@@ -41,8 +41,11 @@ def setup_prometheus_metrics(
     instrumentator = Instrumentator(
         should_group_status_codes=False,
         should_ignore_untemplated=True,
+        should_instrument_requests_inprogress=True,
         excluded_handlers=["/health", "/ready", "/live", "/info", "/metrics", "/docs", "/redoc", "/openapi.json"],
         registry=registry,
+        inprogress_name="http_server_active_requests",
+        inprogress_labels=True,
     )
     instrumentator.instrument(app)
     instrumentator.expose(app, endpoint="/metrics", include_in_schema=False)

--- a/libs/aegra-api/tests/unit/test_observability/test_metrics.py
+++ b/libs/aegra-api/tests/unit/test_observability/test_metrics.py
@@ -59,6 +59,7 @@ def test_excludes_health_and_docs(
     mock_cls.assert_called_once_with(
         should_group_status_codes=False,
         should_ignore_untemplated=True,
+        should_instrument_requests_inprogress=True,
         excluded_handlers=[
             "/health",
             "/ready",
@@ -70,6 +71,8 @@ def test_excludes_health_and_docs(
             "/openapi.json",
         ],
         registry=None,
+        inprogress_name="http_server_active_requests",
+        inprogress_labels=True,
     )
     mock_instance.instrument.assert_called_once_with(app)
     mock_instance.expose.assert_called_once_with(


### PR DESCRIPTION
## Description
- Enable the requests_inprogress gauge in the Prometheus instrumentator to track the number of HTTP requests currently being handled by the server
- Expose the metric as http_server_active_requests with per-route labels


## Why

Active request tracking gives operators real-time visibility into server load and concurrency, enabling alerting and HPA on request pile-ups and capacity planning. This complements the existing request count/duration histograms with a live concurrency signal.

## Testing
- [x] Enable ENABLE_PROMETHEUS_METRICS=true and hit /metrics — verify http_server_active_requests gauge appears
- [x] Confirm existing metrics (request count, duration) are unaffected

## Checklist
<!-- Ensure all items are checked before requesting review -->
- [x] Code follows project style (Ruff formatting)
- [x] All linting checks pass (`make lint`)
- [x] Type checking passes (`make type-check`)

## output

<img width="596" height="102" alt="Screenshot From 2026-07-02 10-12-09" src="https://github.com/user-attachments/assets/d0882291-5666-4fdb-9e3a-acc9cc02110c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled Prometheus in-progress request metrics to improve visibility into currently active server load.
  * Added `http_server_active_requests` in-progress metric with label support.
* **Tests**
  * Updated unit tests to validate the expanded Prometheus instrumentator configuration.
* **Documentation**
  * Added an “Exposed metrics” subsection listing the Prometheus metrics Aegra exposes, including active request metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds active HTTP request tracking to the Prometheus metrics setup. The main changes are:

- Enables the in-progress request gauge in the FastAPI instrumentator.
- Exposes the gauge as `http_server_active_requests` with route labels.
- Documents the exposed Prometheus metrics.
- Updates the metrics unit test expectations for the new instrumentator options.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/observability/metrics.py | Enables the Prometheus in-progress request gauge and sets its public metric name and labels. |
| libs/aegra-api/tests/unit/test_observability/test_metrics.py | Updates the metrics setup test to expect the new instrumentator options. |
| docs/guides/observability.mdx | Adds a table listing the Prometheus metrics exposed by the API. |

<sub>Reviews (3): Last reviewed commit: ["Add requests\_inprogress metrics"](https://github.com/aegra/aegra/commit/39521372e9c6acec338ea0a4e923fa105a4fea13) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41284302)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/aegra/github/aegra/aegra/-/custom-context?memory=1640ab19-5310-4fc5-aaf6-3760087c66e8))
- Context used - AGENTS.md ([source](https://app.greptile.com/aegra/github/aegra/aegra/-/custom-context?memory=15e5c4fa-b823-4fae-b564-d5a58cb22ed4))

<!-- /greptile_comment -->