### PR TITLE
feat(webhooks): deliver signed run-completion callbacks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,6 +94,19 @@ CRON_ENABLED=true
 # Soft cap on the JSONB payload size (bytes) accepted on create/update.
 # CRON_MAX_PAYLOAD_BYTES=65536
 
+# --- Webhook Delivery ---
+# Best-effort HTTP callback POSTed when a run completes (set per run or per cron).
+# WEBHOOK_ENABLED=true
+# Per-attempt timeout in seconds.
+# WEBHOOK_TIMEOUT_SECONDS=15
+# Total delivery attempts (1 = no retry).
+# WEBHOOK_MAX_ATTEMPTS=3
+# Exponential backoff base in seconds (delay = base * 2^(attempt-1)).
+# WEBHOOK_BACKOFF_BASE_SECONDS=1
+# Also refuse delivery to loopback/private hosts. Link-local/metadata
+# (169.254.169.254) is ALWAYS refused. Off by default so internal hooks work.
+# WEBHOOK_BLOCK_PRIVATE_IPS=false
+
 # --- Event Streaming (Agent Protocol v2) ---
 # The v2 thread streaming endpoints (/threads/{id}/stream/events and
 # /threads/{id}/commands) used by the latest LangGraph JS/Python SDKs.

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ async for chunk in client.runs.stream(
 - **[Agent Protocol](https://github.com/langchain-ai/agent-protocol) compliant** - Works with Agent Chat UI, LangGraph Studio, CopilotKit
 - **[Worker architecture](https://docs.aegra.dev/guides/worker-architecture)** - Redis job queue with 30 concurrent runs per instance, lease-based crash recovery, and horizontal scaling across multiple instances
 - **[Scheduled cron jobs](https://docs.aegra.dev/guides/cron)** - Trigger runs on a schedule with standard 5-field or seconds-level 6-field expressions, IANA timezone support, and multi-instance safe `SKIP LOCKED` claim
+- **[Webhook callbacks](https://docs.aegra.dev/guides/cron#webhook-callbacks)** - POST a signed (Standard Webhooks HMAC) callback when a run completes — bare URL or a rich object with method, headers, query params, and body — set per run or per cron
 - **[Human-in-the-loop](https://docs.aegra.dev/guides/human-in-the-loop)** - Approval gates and user intervention points
 - **[Streaming](https://docs.aegra.dev/guides/streaming)** - Real-time SSE streaming with cross-instance pub/sub and automatic reconnection with event replay. Supports both the legacy run-scoped stream and **Agent Protocol v2** thread-scoped streaming (content-block events, per-subgraph lifecycle, HITL resume) for the latest LangGraph SDKs and `useStream()`
 - **[Persistent state](https://docs.aegra.dev/guides/threads-and-state)** - PostgreSQL checkpoints via LangGraph

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,10 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+    # Lets the container reach host-run services (e.g. local webhook receivers
+    # in e2e tests) via host.docker.internal on Linux as well as Docker Desktop.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     healthcheck:
       test: ["CMD-SHELL", "curl -sf http://localhost:$${PORT:-2026}/health || exit 1"]
       interval: 30s

--- a/docs/feature-support.mdx
+++ b/docs/feature-support.mdx
@@ -42,6 +42,7 @@ description: "What Aegra supports today, what's coming soon, and what's not yet 
 | Subgraph streaming | Supported | Stream events from nested subgraphs. |
 | Stateless runs | Supported | Execute without persisting thread state. |
 | Cron / scheduled jobs | Supported | Trigger runs on a schedule. Standard and seconds-level cron expressions. IANA timezone support. |
+| Webhook callbacks | Supported | POST a signed callback to a URL when a run completes. Bare URL or rich object (method/headers/query/body/HMAC secret). Set per run or per cron. |
 
 ### Scaling and reliability
 
@@ -120,8 +121,7 @@ description: "What Aegra supports today, what's coming soon, and what's not yet 
 | Feature | Status | Notes |
 |:--|:--|:--|
 | RemoteGraph | Not yet planned | Call remote graphs as local subgraphs. |
-| Encryption at rest | Not yet planned | Database-level encryption. Use Postgres TDE or volume encryption. |
-| Webhook callbacks | Not yet planned | Notify external services on run completion. |
+| Encryption at rest | Not yet planned | Database-level encryption. Webhook secrets are stored plaintext; use Postgres TDE or volume encryption. |
 | Rate limiting | Not yet planned | Per-user or per-key request throttling. |
 | Multi-org workspaces | Not yet planned | Tenant isolation within a single deployment. |
 

--- a/docs/guides/cron.mdx
+++ b/docs/guides/cron.mdx
@@ -96,6 +96,65 @@ run = await client.crons.create_for_thread(
 print(f"Cron ID: {run['cron_id']}")
 ```
 
+## Webhook callbacks
+
+Attach a `webhook` to a cron (or to any run) and Aegra POSTs a callback when each
+fired run reaches a terminal state (`success`, `error`, or `interrupted`). The
+webhook is forwarded from the cron onto every run it fires.
+
+`webhook` accepts either a bare URL string (LangGraph SDK-compatible) or a rich
+object:
+
+```python
+run = await client.crons.create(
+    assistant_id="agent",
+    schedule="0 9 * * *",
+    input={"messages": [{"role": "user", "content": "Daily report"}]},
+    webhook={
+        "url": "https://hooks.example.com/aegra",
+        "method": "POST",                       # POST (default) | PUT | PATCH
+        "headers": {"Authorization": "Bearer <token>"},
+        "params": {"source": "cron"},           # appended to the query string
+        "body": {"env": "prod"},                # merged over the run payload
+        "secret": "whsec_...",                  # enables HMAC signing
+    },
+)
+```
+
+| Field | Type | Description |
+|---|---|---|
+| `url` | `string` | Callback URL. Must be `http`/`https` with a host. Required. |
+| `method` | `string` | `POST` (default), `PUT`, or `PATCH`. |
+| `headers` | `object` | Extra request headers (e.g. auth). Masked on read. |
+| `params` | `object` | Query-string parameters. |
+| `body` | `object` | Fields merged over the run payload in the request body. |
+| `secret` | `string` | HMAC key; when set, [Standard Webhooks](https://www.standardwebhooks.com) signature headers are added. Masked on read. |
+
+**Delivery payload** matches the LangGraph Platform webhook Run object:
+`run_id`, `thread_id`, `assistant_id`, `status`, `metadata`, `multitask_strategy`,
+`values` (final thread state), `kwargs` (`input`/`config`/`context`), `error`
+(`{ "message": ... }` or `null`), `created_at`, `updated_at`, `run_ended_at`, and
+`webhook_sent_at` — with your `body` merged on top.
+
+**Signing.** When `secret` is set, each request carries `webhook-id`,
+`webhook-timestamp`, and `webhook-signature` (`v1,<base64 HMAC-SHA256>`) per the
+Standard Webhooks spec. Verify with any Standard Webhooks library.
+
+<Note>
+Delivery is **best-effort**: failures are retried with exponential backoff
+(`WEBHOOK_MAX_ATTEMPTS`, default 3) and then logged — a webhook never fails or
+delays the run. Because cron firing is at-least-once, a receiver may occasionally
+see duplicate deliveries for one occurrence; dedupe on `webhook-id` (the run id)
+and make handlers idempotent.
+</Note>
+
+<Warning>
+Webhook `headers` and `secret` are stored in plaintext (same posture as other
+secrets) and masked only on API reads. Delivery is SSRF-guarded: link-local /
+cloud-metadata (`169.254.169.254`) targets are always refused, and
+`WEBHOOK_BLOCK_PRIVATE_IPS=true` additionally refuses loopback and private ranges.
+</Warning>
+
 ## Cron expression format
 
 Aegra uses [croniter](https://github.com/kiorky/croniter) for schedule parsing.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Aegra",
     "description": "Production-ready Agent Protocol server",
-    "version": "0.9.24"
+    "version": "0.9.25"
   },
   "paths": {
     "/info": {
@@ -3854,14 +3854,12 @@
           "webhook": {
             "anyOf": [
               {
-                "type": "string",
-                "maxLength": 2048
+                "$ref": "#/components/schemas/WebhookConfig"
               },
               {
                 "type": "null"
               }
-            ],
-            "title": "Webhook"
+            ]
           },
           "on_run_completed": {
             "anyOf": [
@@ -4226,14 +4224,12 @@
           "webhook": {
             "anyOf": [
               {
-                "type": "string",
-                "maxLength": 2048
+                "$ref": "#/components/schemas/WebhookConfig"
               },
               {
                 "type": "null"
               }
-            ],
-            "title": "Webhook"
+            ]
           },
           "interrupt_before": {
             "anyOf": [
@@ -4803,6 +4799,17 @@
             "title": "Stream Subgraphs",
             "description": "Whether to include subgraph events in streaming. When True, includes events from all subgraphs. When False (default when None), excludes subgraph events. Defaults to False for backwards compatibility.",
             "default": false
+          },
+          "webhook": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/WebhookConfig"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "URL or webhook object POSTed when the run completes."
           },
           "metadata": {
             "anyOf": [
@@ -5846,6 +5853,89 @@
           "type"
         ],
         "title": "ValidationError"
+      },
+      "WebhookConfig": {
+        "properties": {
+          "url": {
+            "type": "string",
+            "maxLength": 2048,
+            "title": "Url",
+            "description": "Callback URL (http/https)."
+          },
+          "method": {
+            "type": "string",
+            "enum": [
+              "POST",
+              "PUT",
+              "PATCH"
+            ],
+            "title": "Method",
+            "description": "HTTP method for the callback.",
+            "default": "POST"
+          },
+          "headers": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Headers",
+            "description": "Extra request headers (may carry auth; masked on read)."
+          },
+          "params": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Params",
+            "description": "Query-string parameters appended to the URL."
+          },
+          "body": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Body",
+            "description": "Fields merged over the run payload in the request body."
+          },
+          "secret": {
+            "anyOf": [
+              {
+                "type": "string",
+                "maxLength": 256
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Secret",
+            "description": "HMAC signing key. When set, Standard Webhooks signature headers are added."
+          }
+        },
+        "type": "object",
+        "required": [
+          "url"
+        ],
+        "title": "WebhookConfig",
+        "description": "Where and how to POST a run-completion callback."
       }
     }
   },

--- a/docs/reference/environment-variables.mdx
+++ b/docs/reference/environment-variables.mdx
@@ -169,6 +169,20 @@ Set `CRON_ENABLED=false` to disable scheduling without removing cron records. Jo
 Cron firing is **at-least-once**: if a worker crashes after claiming a cron but before the run setup commits, the claim eventually expires (after `CRON_CLAIM_DURATION_SECONDS`) and another tick re-fires the cron. Make agent runs idempotent if duplicate firings are unacceptable.
 </Note>
 
+## Webhook delivery
+
+Best-effort HTTP callback POSTed when a run completes (configured per run or per cron). See the [cron webhook section](/guides/cron#webhook-callbacks).
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `WEBHOOK_ENABLED` | `true` | Master switch for outbound webhook delivery |
+| `WEBHOOK_TIMEOUT_SECONDS` | `15` | Per-attempt HTTP timeout |
+| `WEBHOOK_MAX_ATTEMPTS` | `3` | Total delivery attempts (`1` = no retry) |
+| `WEBHOOK_BACKOFF_BASE_SECONDS` | `1` | Exponential backoff base (delay = base × 2^(attempt−1)) |
+| `WEBHOOK_BLOCK_PRIVATE_IPS` | `false` | Also refuse loopback/private-range hosts. Link-local/metadata (169.254.169.254) is **always** refused regardless of this flag |
+
+Delivery never fails or delays a run: exhausted retries are logged and dropped. Every delivery is SSRF-guarded: the target host is resolved and link-local/metadata/multicast/reserved addresses are always refused; enable `WEBHOOK_BLOCK_PRIVATE_IPS` to also refuse loopback and RFC1918 private ranges. Requests are signed with [Standard Webhooks](https://www.standardwebhooks.com) HMAC headers when the webhook has a `secret`.
+
 ## Prometheus metrics
 
 | Variable | Default | Description |

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.9.24"
+version = "0.9.25"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -56,6 +56,9 @@ dependencies = [
 
     # Cron expression parsing
     "croniter>=6.0.0",
+
+    # Outbound webhook delivery (also a transitive dep of langgraph-sdk; pinned direct here)
+    "httpx>=0.27.0",
 ]
 
 [project.urls]

--- a/libs/aegra-api/src/aegra_api/main.py
+++ b/libs/aegra-api/src/aegra_api/main.py
@@ -39,6 +39,7 @@ from aegra_api.services.cron_scheduler import cron_scheduler
 from aegra_api.services.executor import executor
 from aegra_api.services.langgraph_service import get_langgraph_service
 from aegra_api.services.lease_reaper import lease_reaper
+from aegra_api.services.webhook_service import drain as drain_webhooks
 from aegra_api.settings import settings
 from aegra_api.utils.setup_logging import setup_logging
 
@@ -140,12 +141,14 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
 
     yield
 
-    # Shutdown order: cron → reaper → executor (drains jobs) → broker → Redis → DB
+    # Shutdown order: cron → reaper → executor (drains jobs) → webhooks → broker → Redis → DB
     if settings.cron.CRON_ENABLED:
         await cron_scheduler.stop()
     if settings.redis.REDIS_BROKER_ENABLED:
         await lease_reaper.stop()
     await executor.stop()
+    # Drain in-flight webhook deliveries created as jobs finalized during executor.stop().
+    await drain_webhooks()
     await broker_manager.stop()
 
     # Close Redis broker (if enabled)

--- a/libs/aegra-api/src/aegra_api/models/__init__.py
+++ b/libs/aegra-api/src/aegra_api/models/__init__.py
@@ -42,6 +42,7 @@ from aegra_api.models.threads import (
     ThreadStateUpdateResponse,
     ThreadUpdate,
 )
+from aegra_api.models.webhooks import WebhookConfig
 
 __all__ = [
     # Assistants
@@ -73,6 +74,8 @@ __all__ = [
     "CronUpdate",
     "CronSearchRequest",
     "CronCountRequest",
+    # Webhooks
+    "WebhookConfig",
     # Store
     "StorePutRequest",
     "StoreGetResponse",

--- a/libs/aegra-api/src/aegra_api/models/crons.py
+++ b/libs/aegra-api/src/aegra_api/models/crons.py
@@ -2,36 +2,19 @@
 
 from datetime import UTC, datetime
 from typing import Any, Literal
-from urllib.parse import urlparse
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from aegra_api.models.webhooks import WebhookField
 from aegra_api.settings import settings
 
 # Field length caps. Keep these conservative; cron metadata is small by nature.
 _SCHEDULE_MAX_LEN = 256
 _TIMEZONE_MAX_LEN = 64
-_WEBHOOK_MAX_LEN = 2048
 _STREAM_MODE_MAX_LEN = 64
 _STR_FIELD_MAX_LEN = 256
 
 OnRunCompleted = Literal["delete", "keep"]
-
-
-def _validate_webhook_url(value: str | None) -> str | None:
-    """Reject malformed or non-http(s) webhook URLs at the API boundary.
-
-    The cron record stores ``webhook`` verbatim. When a future runtime wires
-    webhook delivery this is the SSRF entry point, so we constrain it now.
-    """
-    if value is None:
-        return None
-    parsed = urlparse(value)
-    if parsed.scheme not in ("http", "https"):
-        raise ValueError("webhook must use http or https scheme")
-    if not parsed.netloc:
-        raise ValueError("webhook must include a host")
-    return value
 
 
 def _validate_payload_size(model: BaseModel) -> None:
@@ -53,7 +36,7 @@ class CronCreate(BaseModel):
     context: dict[str, Any] | None = None
     interrupt_before: Literal["*"] | list[str] | None = None
     interrupt_after: Literal["*"] | list[str] | None = None
-    webhook: str | None = Field(None, max_length=_WEBHOOK_MAX_LEN)
+    webhook: WebhookField = None
     on_run_completed: OnRunCompleted | None = None
     multitask_strategy: str | None = Field(None, max_length=_STR_FIELD_MAX_LEN)
     end_time: datetime | None = None
@@ -67,7 +50,6 @@ class CronCreate(BaseModel):
 
     @model_validator(mode="after")
     def _check(self) -> "CronCreate":
-        self.webhook = _validate_webhook_url(self.webhook)
         if isinstance(self.stream_mode, str) and len(self.stream_mode) > _STREAM_MODE_MAX_LEN:
             raise ValueError("stream_mode is too long")
         if self.end_time is not None:
@@ -108,7 +90,7 @@ class CronUpdate(BaseModel):
     metadata: dict[str, Any] | None = None
     config: dict[str, Any] | None = None
     context: dict[str, Any] | None = None
-    webhook: str | None = Field(None, max_length=_WEBHOOK_MAX_LEN)
+    webhook: WebhookField = None
     interrupt_before: Literal["*"] | list[str] | None = None
     interrupt_after: Literal["*"] | list[str] | None = None
     on_run_completed: OnRunCompleted | None = None
@@ -122,7 +104,6 @@ class CronUpdate(BaseModel):
 
     @model_validator(mode="after")
     def _check(self) -> "CronUpdate":
-        self.webhook = _validate_webhook_url(self.webhook)
         if isinstance(self.stream_mode, str) and len(self.stream_mode) > _STREAM_MODE_MAX_LEN:
             raise ValueError("stream_mode is too long")
         if self.end_time is not None:

--- a/libs/aegra-api/src/aegra_api/models/run_job.py
+++ b/libs/aegra-api/src/aegra_api/models/run_job.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any
 from pydantic import BaseModel, ConfigDict, Field
 
 from aegra_api.models.auth import User
+from aegra_api.models.webhooks import WebhookConfig
 
 if TYPE_CHECKING:
     from aegra_api.core.orm import Run as RunORM
@@ -28,6 +29,8 @@ class RunIdentity(BaseModel):
     run_id: str
     thread_id: str
     graph_id: str
+    # Carried so the completion webhook payload can report assistant_id.
+    assistant_id: str | None = None
 
 
 class RunExecution(BaseModel):
@@ -43,6 +46,9 @@ class RunExecution(BaseModel):
     command: dict[str, Any] | None = None
     # When true, stream via the native v3 protocol producer for Agent Protocol v2.
     event_streaming_v2: bool = False
+    # POSTed on run completion; round-trips through execution_params in both executors.
+    # Its secret/headers sit unmasked there, but execution_params has no client read path.
+    webhook: WebhookConfig | None = None
 
 
 class RunBehavior(BaseModel):
@@ -99,6 +105,8 @@ class RunJob(BaseModel):
                 run_id=run_orm.run_id,
                 thread_id=run_orm.thread_id,
                 graph_id=params["graph_id"],
+                # getattr tolerates lightweight fake ORMs in tests; real rows always have it.
+                assistant_id=getattr(run_orm, "assistant_id", None),
             ),
             user=User.model_validate(params["user"]),
             execution=RunExecution.model_validate(params["execution"]),

--- a/libs/aegra-api/src/aegra_api/models/runs.py
+++ b/libs/aegra-api/src/aegra_api/models/runs.py
@@ -12,6 +12,7 @@ from pydantic import (
     model_validator,
 )
 
+from aegra_api.models.webhooks import WebhookField
 from aegra_api.utils.status_compat import validate_run_status
 
 # Constraints for ``RunCreate.metadata`` keys/values, enforced at request
@@ -76,6 +77,9 @@ class RunCreate(BaseModel):
         False,
         description="Whether to include subgraph events in streaming. When True, includes events from all subgraphs. When False (default when None), excludes subgraph events. Defaults to False for backwards compatibility.",
     )
+
+    # Accepts a bare URL string (SDK contract) or a rich webhook object.
+    webhook: WebhookField = Field(None, description="URL or webhook object POSTed when the run completes.")
 
     # Request metadata (top-level in payload).  Reaches OTEL trace
     # attributes as ``langfuse.trace.metadata.<key>`` (and the

--- a/libs/aegra-api/src/aegra_api/models/webhooks.py
+++ b/libs/aegra-api/src/aegra_api/models/webhooks.py
@@ -1,0 +1,113 @@
+"""Webhook configuration, signing, and redaction — shared by crons and runs.
+
+A webhook is either a bare URL string (the LangGraph SDK contract) or a rich
+object carrying method/headers/params/body/secret. This module is deliberately
+import-cycle-free (only stdlib + pydantic) so both ``models`` and ``services``
+can depend on it. Delivery lives in ``services.webhook_service``.
+"""
+
+import base64
+import hashlib
+import hmac
+from typing import Annotated, Any, Literal
+from urllib.parse import urlparse, urlunparse
+
+from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, field_validator
+
+_URL_MAX_LEN = 2048
+_SECRET_MAX_LEN = 256
+_MASK = "***"
+
+
+class WebhookConfig(BaseModel):
+    """Where and how to POST a run-completion callback."""
+
+    model_config = ConfigDict(frozen=True)
+
+    url: str = Field(..., max_length=_URL_MAX_LEN, description="Callback URL (http/https).")
+    method: Literal["POST", "PUT", "PATCH"] = Field("POST", description="HTTP method for the callback.")
+    headers: dict[str, str] | None = Field(None, description="Extra request headers (may carry auth; masked on read).")
+    params: dict[str, str] | None = Field(None, description="Query-string parameters appended to the URL.")
+    body: dict[str, Any] | None = Field(None, description="Fields merged over the run payload in the request body.")
+    secret: str | None = Field(
+        None,
+        max_length=_SECRET_MAX_LEN,
+        description="HMAC signing key. When set, Standard Webhooks signature headers are added.",
+    )
+
+    @field_validator("url")
+    @classmethod
+    def _validate_url(cls, value: str) -> str:
+        """Reject non-http(s) or host-less URLs — this is the SSRF entry point."""
+        parsed = urlparse(value)
+        if parsed.scheme not in ("http", "https"):
+            raise ValueError("webhook url must use http or https scheme")
+        if not parsed.netloc:
+            raise ValueError("webhook url must include a host")
+        return value
+
+    def to_payload(self) -> str | dict[str, Any]:
+        """Serialize for JSONB storage: bare URL collapses to a str (SDK-compatible), else a dict."""
+        if self.method == "POST" and not (self.headers or self.params or self.body or self.secret):
+            return self.url
+        return self.model_dump(exclude_none=True)
+
+
+def normalize(value: Any) -> Any:
+    """BeforeValidator hook: turn a bare URL string into a WebhookConfig-shaped dict."""
+    return {"url": value} if isinstance(value, str) else value
+
+
+# Reusable field type: accepts a URL string or a webhook object, yields WebhookConfig.
+WebhookField = Annotated[WebhookConfig | None, BeforeValidator(normalize)]
+
+
+def _decode_secret(secret: str) -> bytes:
+    """Standard Webhooks keys are base64 behind a ``whsec_`` prefix; otherwise raw utf-8.
+
+    Tolerates missing base64 padding — Standard Webhooks keys are commonly stored
+    unpadded, and an unpadded key must not crash signing (silent non-delivery).
+    """
+    if secret.startswith("whsec_"):
+        raw = secret[len("whsec_") :]
+        return base64.b64decode(raw + "=" * (-len(raw) % 4))
+    return secret.encode()
+
+
+def sign(secret: str, msg_id: str, timestamp: int, body: bytes) -> str:
+    """Return a Standard Webhooks signature: ``v1,<base64(HMAC-SHA256(secret, id.ts.body))>``."""
+    signed = b".".join((msg_id.encode(), str(timestamp).encode(), body))
+    digest = hmac.new(_decode_secret(secret), signed, hashlib.sha256).digest()
+    return "v1," + base64.b64encode(digest).decode()
+
+
+def _strip_userinfo(url: str) -> str:
+    """Drop ``user:pass@`` from a URL so credentials never round-trip on read.
+
+    Strips only the userinfo segment (before the last ``@``) to preserve the host
+    verbatim — rebuilding from ``parsed.hostname`` would drop IPv6 ``[...]`` brackets.
+    """
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return url
+    if "@" not in parsed.netloc:
+        return url
+    host_port = parsed.netloc.rsplit("@", 1)[1]
+    return urlunparse(parsed._replace(netloc=host_port))
+
+
+def redact(webhook: str | dict[str, Any]) -> str | dict[str, Any]:
+    """Mask credentials in a stored webhook: URL userinfo, secret, header + query values."""
+    if isinstance(webhook, str):
+        return _strip_userinfo(webhook)
+    masked = dict(webhook)
+    if isinstance(masked.get("url"), str):
+        masked["url"] = _strip_userinfo(masked["url"])
+    if masked.get("secret") is not None:
+        masked["secret"] = _MASK
+    # headers/params commonly carry auth tokens (e.g. ?access_token=...).
+    for field in ("headers", "params"):
+        if isinstance(masked.get(field), dict):
+            masked[field] = dict.fromkeys(masked[field], _MASK)
+    return masked

--- a/libs/aegra-api/src/aegra_api/services/cron_scheduler.py
+++ b/libs/aegra-api/src/aegra_api/services/cron_scheduler.py
@@ -62,6 +62,7 @@ def _build_run_create(cron: CronORM) -> RunCreate:
         stream_subgraphs=payload.get("stream_subgraphs"),
         stream_mode=payload.get("stream_mode"),
         multitask_strategy=payload.get("multitask_strategy"),
+        webhook=payload.get("webhook"),
         # Cron metadata_dict is stored on the cron record for search/filter, not
         # forwarded onto fired runs. Re-wire here if run-level tagging is needed.
         metadata=None,

--- a/libs/aegra-api/src/aegra_api/services/cron_service.py
+++ b/libs/aegra-api/src/aegra_api/services/cron_service.py
@@ -6,7 +6,6 @@ to the existing run preparation pipeline.
 
 from datetime import UTC, datetime, timedelta
 from typing import Any, cast
-from urllib.parse import urlparse, urlunparse
 from uuid import uuid4
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
@@ -27,6 +26,7 @@ from aegra_api.models.crons import (
     CronUpdate,
     OnRunCompleted,
 )
+from aegra_api.models.webhooks import redact
 from aegra_api.services.langgraph_service import LangGraphService, get_langgraph_service
 from aegra_api.settings import settings
 from aegra_api.utils.assistants import resolve_assistant_id
@@ -55,8 +55,10 @@ def _build_payload(request: CronCreate | CronUpdate) -> dict[str, Any]:
         "timezone",
     ):
         value = getattr(request, field, None)
-        if value is not None:
-            payload[field] = value
+        if value is None:
+            continue
+        # webhook is a WebhookConfig; store its JSONB wire form (bare URL or dict).
+        payload[field] = value.to_payload() if field == "webhook" else value
     return payload
 
 
@@ -123,33 +125,14 @@ def _compute_next_run(
     return result.astimezone(UTC)
 
 
-def _mask_webhook_credentials(url: str) -> str:
-    """Strip userinfo from a webhook URL before surfacing it back to clients.
-
-    Webhooks like ``https://user:token@host/path`` leak the credential on
-    every read of the cron. We retain the host/path so callers can still
-    audit destination, but the secret never round-trips.
-    """
-    try:
-        parsed = urlparse(url)
-    except ValueError:
-        return url
-    if not parsed.hostname:
-        return url
-    netloc = parsed.hostname
-    if parsed.port is not None:
-        netloc = f"{netloc}:{parsed.port}"
-    return urlunparse(parsed._replace(netloc=netloc))
-
-
 def _redact_payload(payload: dict[str, Any] | None) -> dict[str, Any]:
-    """Return a copy of *payload* with webhook credentials masked."""
+    """Return a copy of *payload* with webhook credentials (userinfo, secret, headers) masked."""
     if not payload:
         return {}
     masked = dict(payload)
     webhook = masked.get("webhook")
-    if isinstance(webhook, str) and webhook:
-        masked["webhook"] = _mask_webhook_credentials(webhook)
+    if webhook:
+        masked["webhook"] = redact(webhook)
     return masked
 
 

--- a/libs/aegra-api/src/aegra_api/services/run_executor.py
+++ b/libs/aegra-api/src/aegra_api/services/run_executor.py
@@ -21,6 +21,7 @@ from aegra_api.services.graph_streaming import stream_graph_events
 from aegra_api.services.langgraph_service import create_run_config, get_langgraph_service
 from aegra_api.services.run_status import finalize_run, update_run_status
 from aegra_api.services.streaming_service import streaming_service
+from aegra_api.services.webhook_service import dispatch as dispatch_webhook
 from aegra_api.settings import settings
 from aegra_api.utils.run_utils import map_command_to_langgraph
 
@@ -48,6 +49,11 @@ async def execute_run(job: RunJob) -> None:
     run_id = job.identity.run_id
     thread_id = job.identity.thread_id
     is_lease_loss = False
+    # Terminal outcome captured for best-effort webhook delivery (fired in finally).
+    # Left None on lease loss so the losing worker never double-delivers.
+    webhook_status: str | None = None
+    webhook_output: dict[str, Any] | None = None
+    webhook_error: str | None = None
 
     try:
         await update_run_status(run_id, "running")
@@ -62,6 +68,7 @@ async def execute_run(job: RunJob) -> None:
                 thread_status="interrupted",
                 output=final_output.data,
             )
+            webhook_status, webhook_output = "interrupted", final_output.data
         else:
             await finalize_run(
                 run_id,
@@ -70,6 +77,7 @@ async def execute_run(job: RunJob) -> None:
                 thread_status="idle",
                 output=final_output.data,
             )
+            webhook_status, webhook_output = "success", final_output.data
 
     except asyncio.CancelledError:
         if run_id in _lease_loss_cancellations:
@@ -81,12 +89,14 @@ async def execute_run(job: RunJob) -> None:
         else:
             await finalize_run(run_id, thread_id, status="interrupted", thread_status="idle", output={})
             await _best_effort_signal(streaming_service.signal_run_cancelled, run_id)
+            webhook_status, webhook_output = "interrupted", {}
         raise
     except Exception as exc:
         logger.exception("Run failed", run_id=run_id)
         safe_message = f"{type(exc).__name__}: execution failed"
         await finalize_run(run_id, thread_id, status="error", thread_status="error", output={}, error=str(exc))
         await _best_effort_signal(streaming_service.signal_run_error, run_id, safe_message, type(exc).__name__)
+        webhook_status, webhook_error = "error", str(exc)
     else:
         status = "interrupted" if final_output.has_interrupt else "success"
         await _best_effort_signal(_signal_end_event, run_id, status)
@@ -96,6 +106,8 @@ async def execute_run(job: RunJob) -> None:
         if not is_lease_loss:
             await streaming_service.cleanup_run(run_id)
             await _signal_run_done(run_id)
+            if webhook_status is not None:
+                dispatch_webhook(job, webhook_status, webhook_output, webhook_error)
 
 
 # ------------------------------------------------------------------

--- a/libs/aegra-api/src/aegra_api/services/run_preparation.py
+++ b/libs/aegra-api/src/aegra_api/services/run_preparation.py
@@ -252,7 +252,12 @@ async def _prepare_run(
 
     # Build the RunJob before persisting so we can store execution_params
     job = RunJob(
-        identity=RunIdentity(run_id=run_id, thread_id=thread_id, graph_id=assistant.graph_id),
+        identity=RunIdentity(
+            run_id=run_id,
+            thread_id=thread_id,
+            graph_id=assistant.graph_id,
+            assistant_id=resolved_assistant_id,
+        ),
         user=user,
         execution=RunExecution(
             input_data=request.input,  # preserve None so LangGraph resumes from checkpoint
@@ -262,6 +267,7 @@ async def _prepare_run(
             checkpoint=request.checkpoint,
             command=request.command,
             event_streaming_v2=event_streaming_v2,
+            webhook=request.webhook,
         ),
         behavior=RunBehavior(
             interrupt_before=request.interrupt_before,

--- a/libs/aegra-api/src/aegra_api/services/webhook_service.py
+++ b/libs/aegra-api/src/aegra_api/services/webhook_service.py
@@ -1,0 +1,203 @@
+"""Best-effort outbound webhook delivery on run completion.
+
+``dispatch`` is fire-and-forget: it schedules a detached task and returns
+immediately so the run pipeline is never blocked or failed by a webhook.
+Delivery retries transient failures with exponential backoff and signs the
+request per the Standard Webhooks spec when a secret is configured.
+
+The body is a LangGraph Platform-aligned Run object: run_id / thread_id /
+assistant_id / status / metadata / multitask_strategy / kwargs / values / error /
+created_at / updated_at / run_ended_at / webhook_sent_at.
+"""
+
+import asyncio
+import ipaddress
+import json
+import socket
+import time
+from datetime import UTC, datetime
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+import structlog
+from sqlalchemy.exc import SQLAlchemyError
+
+from aegra_api.core.orm import Run as RunORM
+from aegra_api.core.orm import _get_session_maker
+from aegra_api.models.run_job import RunJob
+from aegra_api.models.webhooks import WebhookConfig, sign
+from aegra_api.settings import settings
+
+logger = structlog.getLogger(__name__)
+
+# Strong refs so fire-and-forget delivery tasks survive GC until done.
+_delivery_tasks: set[asyncio.Task[None]] = set()
+
+# Transient statuses worth retrying; other 4xx are client-contract errors.
+_RETRYABLE_STATUS = frozenset({408, 425, 429, 500, 502, 503, 504})
+
+
+def dispatch(job: RunJob, status: str, output: dict[str, Any] | None, error: str | None) -> None:
+    """Schedule webhook delivery for a completed run. No-op when unset or disabled.
+
+    Captures only small fields + the final state (never the RunJob) so a slow or
+    retrying delivery can't pin the run's full input/context in memory.
+    """
+    webhook = job.execution.webhook
+    if webhook is None or not settings.webhook.WEBHOOK_ENABLED:
+        return
+    meta: dict[str, Any] = {
+        "run_id": job.identity.run_id,
+        "thread_id": job.identity.thread_id,
+        "assistant_id": job.identity.assistant_id,
+        "status": status,
+        "values": output,
+        "error": error,
+        "metadata": dict(job.run_metadata),
+        "multitask_strategy": job.behavior.multitask_strategy,
+    }
+    task = asyncio.create_task(_run_delivery(webhook, meta))
+    _delivery_tasks.add(task)
+    task.add_done_callback(_delivery_tasks.discard)
+
+
+async def drain(timeout: float = 5.0) -> None:
+    """Await outstanding delivery tasks on shutdown, up to *timeout* seconds."""
+    if not _delivery_tasks:
+        return
+    await asyncio.wait(set(_delivery_tasks), timeout=timeout)
+
+
+async def _run_delivery(webhook: WebhookConfig, meta: dict[str, Any]) -> None:
+    """Task boundary: build the payload and deliver. Swallows all errors (best-effort)."""
+    run_id = meta["run_id"]
+    try:
+        await deliver(webhook, await _build_payload(meta), msg_id=run_id)
+    except Exception:
+        logger.exception("Webhook delivery task crashed", run_id=run_id)
+
+
+async def _build_payload(meta: dict[str, Any]) -> dict[str, Any]:
+    """Shape the LangGraph Platform-aligned Run body from captured fields + the run row.
+
+    Enriches with the persisted run (created_at/updated_at, kwargs); falls back to
+    the captured fields when the row is unreadable/gone.
+    """
+    err = meta["error"]
+    payload: dict[str, Any] = {
+        "run_id": meta["run_id"],
+        "thread_id": meta["thread_id"],
+        "assistant_id": meta["assistant_id"],
+        "status": meta["status"],
+        "metadata": meta["metadata"],
+        "multitask_strategy": meta["multitask_strategy"],
+        "values": meta["values"],  # final thread state (latest checkpoint values)
+        "error": {"message": err} if err else None,
+        "kwargs": {},
+        "created_at": None,
+        "updated_at": None,
+        "run_ended_at": None,
+    }
+    row = await _read_run(meta["run_id"])
+    if row is not None:
+        payload["created_at"] = row["created_at"]
+        payload["updated_at"] = row["updated_at"]
+        payload["run_ended_at"] = row["updated_at"]  # run just finalized; no separate end column
+        payload["kwargs"] = {"input": row["input"], "config": row["config"], "context": row["context"]}
+        if row["error_message"] and payload["error"] is None:
+            payload["error"] = {"message": row["error_message"]}
+    return payload
+
+
+async def _read_run(run_id: str) -> dict[str, Any] | None:
+    """Read the finalized run row's payload fields (None if unreadable/gone)."""
+    maker = _get_session_maker()
+    try:
+        async with maker() as session:
+            row = await session.get(RunORM, run_id)
+            if row is None:
+                return None
+            return {
+                "created_at": row.created_at.isoformat() if row.created_at else None,
+                "updated_at": row.updated_at.isoformat() if row.updated_at else None,
+                "input": row.input,
+                "config": row.config,
+                "context": row.context,
+                "error_message": row.error_message,
+            }
+    except SQLAlchemyError:
+        logger.warning("Webhook payload DB read failed; sending captured fields only", run_id=run_id)
+        return None
+
+
+async def deliver(webhook: WebhookConfig, payload: dict[str, Any], *, msg_id: str) -> None:
+    """POST *payload* to the webhook with retries. Best-effort — never raises."""
+    if await _blocked(webhook.url):
+        logger.warning("Webhook blocked by SSRF guard", host=_host(webhook.url))
+        return
+    body = json.dumps(
+        {**payload, "webhook_sent_at": datetime.now(UTC).isoformat(), **(webhook.body or {})},
+        default=str,
+    ).encode()
+    attempts = settings.webhook.WEBHOOK_MAX_ATTEMPTS
+    async with httpx.AsyncClient(
+        timeout=settings.webhook.WEBHOOK_TIMEOUT_SECONDS,
+        follow_redirects=False,  # SSRF: no redirect-based bypass of the url check
+    ) as client:
+        for attempt in range(1, attempts + 1):
+            if await _attempt(client, webhook, body, msg_id=msg_id):
+                return
+            if attempt < attempts:
+                await asyncio.sleep(settings.webhook.WEBHOOK_BACKOFF_BASE_SECONDS * 2 ** (attempt - 1))
+    logger.warning("Webhook delivery exhausted", host=_host(webhook.url), attempts=attempts)
+
+
+async def _attempt(client: httpx.AsyncClient, webhook: WebhookConfig, body: bytes, *, msg_id: str) -> bool:
+    """Perform one delivery attempt. Return True to stop (done/non-retryable), False to retry."""
+    headers = {"content-type": "application/json", **(webhook.headers or {})}
+    if webhook.secret:
+        timestamp = int(time.time())
+        headers["webhook-id"] = msg_id
+        headers["webhook-timestamp"] = str(timestamp)
+        headers["webhook-signature"] = sign(webhook.secret, msg_id, timestamp, body)
+    try:
+        response = await client.request(
+            webhook.method, webhook.url, content=body, headers=headers, params=webhook.params
+        )
+    except httpx.RequestError as exc:
+        logger.warning("Webhook attempt failed", host=_host(webhook.url), error=type(exc).__name__)
+        return False
+    if response.status_code < 400:
+        return True
+    if response.status_code in _RETRYABLE_STATUS:
+        logger.warning("Webhook retryable status", status=response.status_code, host=_host(webhook.url))
+        return False
+    logger.warning("Webhook rejected", status=response.status_code, host=_host(webhook.url))
+    return True
+
+
+def _host(url: str) -> str:
+    """Hostname for logging — never log the full URL (may carry path secrets)."""
+    return urlparse(url).hostname or "?"
+
+
+async def _blocked(url: str) -> bool:
+    """SSRF guard. Link-local (incl. cloud metadata 169.254.169.254) is always
+    refused; loopback/private ranges only when WEBHOOK_BLOCK_PRIVATE_IPS is set."""
+    host = urlparse(url).hostname
+    if not host:
+        return True
+    loop = asyncio.get_running_loop()
+    try:
+        infos = await loop.getaddrinfo(host, None)
+    except socket.gaierror:
+        return True  # unresolvable → refuse
+    block_private = settings.webhook.WEBHOOK_BLOCK_PRIVATE_IPS
+    for info in infos:
+        ip = ipaddress.ip_address(info[4][0].split("%")[0])
+        if ip.is_link_local or ip.is_multicast or ip.is_reserved:
+            return True
+        if block_private and (ip.is_private or ip.is_loopback):
+            return True
+    return False

--- a/libs/aegra-api/src/aegra_api/settings.py
+++ b/libs/aegra-api/src/aegra_api/settings.py
@@ -441,6 +441,33 @@ class EventStreamingSettings(EnvBase):
     FF_V2_EVENT_STREAMING: bool = True
 
 
+class WebhookSettings(EnvBase):
+    """Outbound webhook delivery on run completion.
+
+    Delivery is best-effort: a failed webhook is logged and never fails or
+    delays the run. See services/webhook_service.py.
+    """
+
+    WEBHOOK_ENABLED: bool = True
+    WEBHOOK_TIMEOUT_SECONDS: float = 15.0
+    WEBHOOK_MAX_ATTEMPTS: int = 3
+    WEBHOOK_BACKOFF_BASE_SECONDS: float = 1.0
+    # Also refuse loopback/private ranges (link-local/metadata is always refused).
+    # Off by default so internal hooks (e.g. host.docker.internal) keep working.
+    WEBHOOK_BLOCK_PRIVATE_IPS: bool = False
+
+    @model_validator(mode="after")
+    def _validate(self) -> "WebhookSettings":
+        """Reject non-positive timeouts/attempts during settings validation."""
+        if self.WEBHOOK_TIMEOUT_SECONDS <= 0:
+            raise ValueError(f"WEBHOOK_TIMEOUT_SECONDS must be greater than 0, got {self.WEBHOOK_TIMEOUT_SECONDS}")
+        if self.WEBHOOK_MAX_ATTEMPTS < 1:
+            raise ValueError(f"WEBHOOK_MAX_ATTEMPTS must be >= 1, got {self.WEBHOOK_MAX_ATTEMPTS}")
+        if self.WEBHOOK_BACKOFF_BASE_SECONDS < 0:
+            raise ValueError(f"WEBHOOK_BACKOFF_BASE_SECONDS must be >= 0, got {self.WEBHOOK_BACKOFF_BASE_SECONDS}")
+        return self
+
+
 class Settings:
     """Container object that instantiates all application settings groups."""
 
@@ -454,6 +481,7 @@ class Settings:
         self.worker = WorkerSettings()
         self.cron = CronSettings()
         self.event_streaming = EventStreamingSettings()
+        self.webhook = WebhookSettings()
 
 
 settings = Settings()

--- a/libs/aegra-api/src/aegra_api/utils/setup_logging.py
+++ b/libs/aegra-api/src/aegra_api/utils/setup_logging.py
@@ -1,12 +1,63 @@
 import logging
 import logging.config
+import re
 import sys
 from typing import Any
 
 import structlog
 import structlog.typing
+from pydantic import SecretStr
 
 from aegra_api.settings import settings
+
+# Keys whose values are secrets. Bare "token" is intentionally excluded so
+# usage counts (total_tokens, ...) survive; the real token secrets are matched
+# via their access/refresh/auth prefixes.
+_SECRET_KEY_RE = re.compile(
+    r"api[_-]?key|apikey|secret|password|passwd|authorization|"
+    r"access[_-]?token|refresh[_-]?token|auth[_-]?token|private[_-]?key",
+    re.IGNORECASE,
+)
+_REDACTED = "***REDACTED***"
+_MAX_REDACT_DEPTH = 6
+
+
+def _redact(value: Any, depth: int = 0) -> Any:
+    """Mask secret-looking dict keys and unwrap SecretStr for safe rendering.
+
+    Copy-on-first-change: the container is copied only once a descendant actually
+    changes; a clean (no-secret) value is returned by identity with zero allocation,
+    so the common log line costs only the per-key scan. Container type is preserved
+    — structlog's ``positional_args`` tuple must stay a tuple for ``event % args``.
+    """
+    if isinstance(value, SecretStr):
+        return str(value)  # "**********"; also stops JSONRenderer choking on SecretStr
+    if depth >= _MAX_REDACT_DEPTH:
+        return value
+    if isinstance(value, dict):
+        result: dict[Any, Any] | None = None
+        for key, val in value.items():
+            new = _REDACTED if (isinstance(key, str) and _SECRET_KEY_RE.search(key)) else _redact(val, depth + 1)
+            if new is not val:
+                if result is None:
+                    result = dict(value)  # lazy copy; unchanged keys keep their original values
+                result[key] = new
+        return result if result is not None else value
+    if isinstance(value, (list, tuple)):
+        result = None
+        for index, item in enumerate(value):
+            new = _redact(item, depth + 1)
+            if new is not item:
+                if result is None:
+                    result = list(value)  # lazy copy
+                result[index] = new
+        return value if result is None else type(value)(result)
+    return value
+
+
+def redact_secrets(_logger: Any, _method: str, event_dict: structlog.typing.EventDict) -> structlog.typing.EventDict:
+    """structlog processor: mask secret-looking keys and unwrap SecretStr values."""
+    return _redact(event_dict, 0)
 
 
 def get_logging_config() -> dict[str, Any]:
@@ -57,6 +108,8 @@ def get_logging_config() -> dict[str, Any]:
     #   - format_exc_info (production only) must come after StackInfoRenderer
     shared_processors: list[Any] = [
         structlog.contextvars.merge_contextvars,
+        # After merge_contextvars so context-bound secrets are masked too.
+        redact_secrets,
         structlog.stdlib.add_log_level,
         structlog.stdlib.add_logger_name,
         structlog.stdlib.ExtraAdder(),

--- a/libs/aegra-api/tests/e2e/test_webhooks/test_webhook_delivery_e2e.py
+++ b/libs/aegra-api/tests/e2e/test_webhooks/test_webhook_delivery_e2e.py
@@ -1,0 +1,89 @@
+"""E2E: a completed run POSTs to the configured webhook with a valid signature.
+
+A local HTTP receiver runs on the host; the server (in Docker) reaches it via
+host.docker.internal. The run may error (no live LLM needed) — a webhook fires
+on any terminal state, which is exactly what we assert.
+"""
+
+import asyncio
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import httpx
+import pytest
+
+from aegra_api.models.webhooks import sign
+from aegra_api.settings import settings
+from tests.e2e._utils import elog
+
+# whsec_ + base64("e2e-webhook-secret")
+_SECRET = "whsec_ZTJlLXdlYmhvb2stc2VjcmV0"
+
+
+class _Collector(BaseHTTPRequestHandler):
+    deliveries: list[dict] = []
+
+    def do_POST(self) -> None:  # noqa: N802 (stdlib naming)
+        length = int(self.headers.get("content-length", 0))
+        body = self.rfile.read(length)
+        _Collector.deliveries.append({"headers": dict(self.headers), "body": body})
+        self.send_response(200)
+        self.end_headers()
+
+    def log_message(self, *_args: object) -> None:
+        """Silence the default stderr access log."""
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_run_completion_delivers_signed_webhook() -> None:
+    _Collector.deliveries = []
+    server = HTTPServer(("0.0.0.0", 0), _Collector)  # nosec B104 — test receiver, ephemeral port
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    # The server (Docker) reaches the host receiver via host.docker.internal.
+    webhook_url = f"http://host.docker.internal:{port}/hook"
+    try:
+        async with httpx.AsyncClient(base_url=settings.app.SERVER_URL, timeout=60.0) as client:
+            resp = await client.post(
+                "/runs",
+                json={
+                    "assistant_id": "agent",
+                    "input": {"messages": [{"role": "user", "content": "ping"}]},
+                    "webhook": {
+                        "url": webhook_url,
+                        "headers": {"X-Source": "aegra-e2e"},
+                        "params": {"tag": "e2e"},
+                        "secret": _SECRET,
+                    },
+                },
+            )
+            assert resp.status_code in (200, 201), resp.text
+            elog("created run", resp.json())
+
+        # Poll for the delivery (run executes + completes in the background).
+        for _ in range(60):
+            if _Collector.deliveries:
+                break
+            await asyncio.sleep(1)
+
+        assert _Collector.deliveries, "webhook was never delivered"
+        delivery = _Collector.deliveries[0]
+        headers = {k.lower(): v for k, v in delivery["headers"].items()}
+        payload = json.loads(delivery["body"])
+        elog("received webhook", {"headers": headers, "payload": payload})
+
+        # Canonical run payload + custom header forwarded.
+        assert payload["run_id"]
+        assert payload["status"] in ("success", "error", "interrupted")
+        assert headers.get("x-source") == "aegra-e2e"
+
+        # Signature verifies against the raw body (Standard Webhooks).
+        expected = sign(_SECRET, headers["webhook-id"], int(headers["webhook-timestamp"]), delivery["body"])
+        assert headers["webhook-signature"] == expected
+    finally:
+        server.shutdown()
+        server.server_close()

--- a/libs/aegra-api/tests/integration/test_api/test_crons_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_crons_crud.py
@@ -659,3 +659,48 @@ class TestTimezoneField:
         call_args = mock_cron_service.create_cron.call_args
         request_obj = call_args.args[0]
         assert request_obj.timezone is None
+
+
+class TestCronWebhookConfig:
+    """Webhook accepts a bare URL (SDK-compatible) or a rich object; rejects bad URLs."""
+
+    def test_accepts_bare_url_string(self, client, mock_cron_service: AsyncMock) -> None:
+        mock_cron_service.create_cron.return_value = AsyncMock()
+        resp = client.post(
+            "/runs/crons",
+            json={
+                "assistant_id": "asst-001",
+                "schedule": "*/5 * * * *",
+                "webhook": "https://hooks.example.com/x",
+            },
+        )
+        assert resp.status_code == 200
+
+    def test_accepts_rich_object(self, client, mock_cron_service: AsyncMock) -> None:
+        mock_cron_service.create_cron.return_value = AsyncMock()
+        resp = client.post(
+            "/runs/crons",
+            json={
+                "assistant_id": "asst-001",
+                "schedule": "*/5 * * * *",
+                "webhook": {
+                    "url": "https://hooks.example.com/x",
+                    "method": "POST",
+                    "headers": {"Authorization": "Bearer t"},
+                    "params": {"source": "cron"},
+                    "secret": "whsec_abc",
+                },
+            },
+        )
+        assert resp.status_code == 200
+
+    def test_rejects_non_http_webhook(self, client, mock_cron_service: AsyncMock) -> None:
+        resp = client.post(
+            "/runs/crons",
+            json={
+                "assistant_id": "asst-001",
+                "schedule": "*/5 * * * *",
+                "webhook": "ftp://bad.example.com/x",
+            },
+        )
+        assert resp.status_code == 422

--- a/libs/aegra-api/tests/unit/test_api/test_runs_wait.py
+++ b/libs/aegra-api/tests/unit/test_api/test_runs_wait.py
@@ -54,6 +54,7 @@ def _make_request() -> MagicMock:
     request.multitask_strategy = None
     request.stream_subgraphs = False
     request.metadata = None
+    request.webhook = None
     return request
 
 

--- a/libs/aegra-api/tests/unit/test_models/test_cron_validation.py
+++ b/libs/aegra-api/tests/unit/test_models/test_cron_validation.py
@@ -32,7 +32,8 @@ class TestWebhookValidation:
     @pytest.mark.parametrize("url", ["http://example.com/hook", "https://example.com/hook"])
     def test_accepts_http_https(self, url: str) -> None:
         req = CronCreate(assistant_id="a", schedule="* * * * *", webhook=url)
-        assert req.webhook == url
+        assert req.webhook is not None
+        assert req.webhook.url == url
 
 
 class TestEndTimeMustBeFuture:

--- a/libs/aegra-api/tests/unit/test_models/test_webhook_config.py
+++ b/libs/aegra-api/tests/unit/test_models/test_webhook_config.py
@@ -1,0 +1,92 @@
+"""Unit tests for the shared webhook model: coercion, validation, signing, redaction."""
+
+import pytest
+from pydantic import ValidationError
+
+from aegra_api.models.webhooks import WebhookConfig, redact, sign
+
+
+class TestUrlValidation:
+    @pytest.mark.parametrize(
+        "url",
+        ["ftp://example.com/h", "javascript:alert(1)", "file:///etc/passwd", "//example.com", "http:///no-host"],
+    )
+    def test_rejects_non_http_or_hostless(self, url: str) -> None:
+        with pytest.raises(ValidationError):
+            WebhookConfig(url=url)
+
+    @pytest.mark.parametrize("url", ["http://example.com/h", "https://example.com/h"])
+    def test_accepts_http_https(self, url: str) -> None:
+        assert WebhookConfig(url=url).url == url
+
+    def test_rejects_bad_method(self) -> None:
+        with pytest.raises(ValidationError):
+            WebhookConfig(url="https://x.io/h", method="DELETE")  # type: ignore[arg-type]
+
+    def test_rejects_oversized_url(self) -> None:
+        with pytest.raises(ValidationError):
+            WebhookConfig(url="https://x.io/" + "a" * 4096)
+
+
+class TestToPayload:
+    def test_bare_url_collapses_to_string(self) -> None:
+        assert WebhookConfig(url="https://x.io/h").to_payload() == "https://x.io/h"
+
+    def test_rich_returns_dict(self) -> None:
+        payload = WebhookConfig(url="https://x.io/h", headers={"A": "b"}, secret="s").to_payload()
+        assert isinstance(payload, dict)
+        assert payload["url"] == "https://x.io/h"
+        assert payload["headers"] == {"A": "b"}
+        assert payload["secret"] == "s"
+
+    def test_non_post_method_stays_dict(self) -> None:
+        assert isinstance(WebhookConfig(url="https://x.io/h", method="PUT").to_payload(), dict)
+
+
+class TestSign:
+    def test_matches_standard_webhooks_vector(self) -> None:
+        """Known vector from the Standard Webhooks spec."""
+        secret = "whsec_MfKQ9r8GKYqrTwjUPD8ILPZIo2LaLaSw"
+        msg_id = "msg_p5jXN8AQM9LWM0D4loKWxJek"
+        timestamp = 1614265330
+        body = b'{"test": 2432232314}'
+        assert sign(secret, msg_id, timestamp, body) == "v1,g0hM9SsE+OTPJTGt/tmIKtSyZlE3uFJELVlNIOLJ1OE="
+
+    def test_raw_secret_without_prefix(self) -> None:
+        sig = sign("plainsecret", "id1", 1000, b"{}")
+        assert sig.startswith("v1,")
+
+    def test_unpadded_whsec_secret_does_not_crash(self) -> None:
+        # Regression: unpadded base64 whsec_ key must not raise "Incorrect padding".
+        assert sign("whsec_abc", "id1", 1000, b"{}").startswith("v1,")
+
+
+class TestRedact:
+    def test_strips_userinfo_from_string(self) -> None:
+        assert redact("https://user:secret@host.io/x") == "https://host.io/x"
+
+    def test_preserves_port_and_path(self) -> None:
+        assert redact("https://u:p@host.io:8443/a/b?q=1") == "https://host.io:8443/a/b?q=1"
+
+    def test_preserves_ipv6_brackets(self) -> None:
+        # Regression: rebuilding netloc from parsed.hostname dropped IPv6 brackets.
+        assert redact("http://[::1]:9000/hook") == "http://[::1]:9000/hook"
+        assert redact("https://u:p@[::1]:8443/x") == "https://[::1]:8443/x"
+
+    def test_masks_secret_headers_and_params(self) -> None:
+        masked = redact(
+            {
+                "url": "https://u:p@host.io/x",
+                "secret": "whsec_x",
+                "headers": {"Authorization": "Bearer t"},
+                "params": {"access_token": "SECRET"},
+            }
+        )
+        assert masked["url"] == "https://host.io/x"
+        assert masked["secret"] == "***"
+        assert masked["headers"] == {"Authorization": "***"}
+        assert masked["params"] == {"access_token": "***"}  # tokens ride in query params
+
+    def test_leaves_non_credential_fields(self) -> None:
+        masked = redact({"url": "https://host.io/x", "method": "POST"})
+        assert masked["method"] == "POST"

--- a/libs/aegra-api/tests/unit/test_services/test_assistant_service.py
+++ b/libs/aegra-api/tests/unit/test_services/test_assistant_service.py
@@ -120,7 +120,6 @@ class TestToPydantic:
         mock_orm.config = {}
         mock_orm.context = {}
         mock_orm.metadata_dict = {}
-
         result = to_pydantic(mock_orm)
 
         assert isinstance(result, Assistant)
@@ -178,7 +177,6 @@ class TestToPydantic:
         mock_orm.config = {}
         mock_orm.context = {}
         mock_orm.metadata_dict = {}
-
         result = to_pydantic(mock_orm)
 
         assert result.assistant_id == str(test_uuid)
@@ -232,7 +230,6 @@ class TestToPydantic:
         mock_orm.config = {}
         mock_orm.context = {}
         mock_orm.metadata_dict = {}
-
         result = to_pydantic(mock_orm)
 
         assert result.assistant_id == "test-id"
@@ -267,7 +264,6 @@ class TestAssistantServiceCreate:
         mock_assistant.config = {}
         mock_assistant.context = {}
         mock_assistant.metadata_dict = {}
-
         assistant_service.session.add = Mock()
         assistant_service.session.commit = AsyncMock()
 
@@ -439,7 +435,6 @@ class TestAssistantServiceCreate:
         existing_assistant.config = {}
         existing_assistant.context = {}
         existing_assistant.metadata_dict = {}
-
         mock_table = Mock()
         mock_column = Mock()
         mock_column.name = "assistant_id"
@@ -501,7 +496,6 @@ class TestAssistantServiceGet:
         mock_assistant.config = {}
         mock_assistant.context = {}
         mock_assistant.metadata_dict = {}
-
         mock_table = Mock()
         mock_column1 = Mock()
         mock_column1.name = "assistant_id"
@@ -547,7 +541,6 @@ class TestAssistantServiceGet:
         mock_assistant.config = {}
         mock_assistant.context = {}
         mock_assistant.metadata_dict = {}
-
         mock_table = Mock()
         mock_column1 = Mock()
         mock_column1.name = "assistant_id"
@@ -589,7 +582,6 @@ class TestAssistantServiceUpdate:
         mock_assistant.config = {}
         mock_assistant.context = {}
         mock_assistant.metadata_dict = {}
-
         mock_updated_assistant = Mock()
         mock_updated_assistant.assistant_id = "test-id"
         mock_updated_assistant.name = "Updated Assistant"
@@ -602,7 +594,6 @@ class TestAssistantServiceUpdate:
         mock_updated_assistant.config = {"temperature": 0.8}
         mock_updated_assistant.context = {}
         mock_updated_assistant.metadata_dict = {"env": "updated"}
-
         mock_table = Mock()
         mock_column1 = Mock()
         mock_column1.name = "assistant_id"
@@ -721,7 +712,6 @@ class TestAssistantServiceVersionManagement:
         mock_assistant.config = {}
         mock_assistant.context = {}
         mock_assistant.metadata_dict = {"version": "latest"}
-
         # Mock existing version
         mock_version = Mock()
         mock_version.name = "Version Name"
@@ -730,7 +720,6 @@ class TestAssistantServiceVersionManagement:
         mock_version.context = {"ctx": "val"}
         mock_version.graph_id = "test-graph"
         mock_version.metadata_dict = {"version": "latest"}
-
         assistant_service.session.scalar.side_effect = [
             mock_assistant,
             mock_version,

--- a/libs/aegra-api/tests/unit/test_services/test_cron_scheduler.py
+++ b/libs/aegra-api/tests/unit/test_services/test_cron_scheduler.py
@@ -588,3 +588,39 @@ class TestSchedulerLoop:
             await scheduler._loop()
 
         assert call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# _build_run_create webhook forwarding (regression for the previously-dropped link)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildRunCreateWebhook:
+    """_build_run_create must forward the stored webhook onto the fired RunCreate."""
+
+    def test_forwards_bare_url_webhook(self) -> None:
+        from aegra_api.services.cron_scheduler import _build_run_create
+
+        cron = _make_cron_orm(payload={"input": {"msg": "tick"}, "webhook": "https://hooks.example.com/x"})
+        run_create = _build_run_create(cron)
+        assert run_create.webhook is not None
+        assert run_create.webhook.url == "https://hooks.example.com/x"
+
+    def test_forwards_rich_webhook(self) -> None:
+        from aegra_api.services.cron_scheduler import _build_run_create
+
+        cron = _make_cron_orm(
+            payload={
+                "input": {"msg": "tick"},
+                "webhook": {"url": "https://h.io/x", "headers": {"Authorization": "Bearer t"}},
+            }
+        )
+        run_create = _build_run_create(cron)
+        assert run_create.webhook is not None
+        assert run_create.webhook.headers == {"Authorization": "Bearer t"}
+
+    def test_none_when_absent(self) -> None:
+        from aegra_api.services.cron_scheduler import _build_run_create
+
+        cron = _make_cron_orm(payload={"input": {"msg": "tick"}})
+        assert _build_run_create(cron).webhook is None

--- a/libs/aegra-api/tests/unit/test_services/test_run_job.py
+++ b/libs/aegra-api/tests/unit/test_services/test_run_job.py
@@ -171,3 +171,34 @@ class TestRunJob:
 
         restored = RunJob.from_run_orm(LegacyORM())
         assert restored.run_metadata == {}
+
+
+class TestRunExecutionWebhook:
+    """webhook round-trips through execution_params in both executor modes."""
+
+    def test_webhook_roundtrip(self) -> None:
+        from aegra_api.models.webhooks import WebhookConfig
+
+        job = RunJob(
+            identity=RunIdentity(run_id="r1", thread_id="t1", graph_id="g1", assistant_id="a1"),
+            user=User(identity="u1"),
+            execution=RunExecution(
+                webhook=WebhookConfig(url="https://h.io/x", headers={"Authorization": "Bearer t"}, secret="s")
+            ),
+        )
+        params = job.to_execution_params()
+        assert params["execution"]["webhook"]["url"] == "https://h.io/x"
+
+        class FakeORM:
+            run_id = "r1"
+            thread_id = "t1"
+            assistant_id = "a1"
+            execution_params = params
+
+        restored = RunJob.from_run_orm(FakeORM())
+        assert restored.execution.webhook == job.execution.webhook
+        assert restored.identity.assistant_id == "a1"
+
+    def test_no_webhook_defaults_none(self) -> None:
+        execution = RunExecution()
+        assert execution.webhook is None

--- a/libs/aegra-api/tests/unit/test_services/test_webhook_service.py
+++ b/libs/aegra-api/tests/unit/test_services/test_webhook_service.py
@@ -1,0 +1,257 @@
+"""Unit tests for webhook delivery: retries, signing, body merge, dispatch guards."""
+
+import functools
+
+import httpx
+import pytest
+
+from aegra_api.models.auth import User
+from aegra_api.models.run_job import RunExecution, RunIdentity, RunJob
+from aegra_api.models.webhooks import WebhookConfig
+from aegra_api.services import webhook_service
+
+
+@pytest.fixture(autouse=True)
+def _fast_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Zero backoff so retry tests don't sleep; deterministic attempt cap."""
+    monkeypatch.setattr(webhook_service.settings.webhook, "WEBHOOK_BACKOFF_BASE_SECONDS", 0.0)
+    monkeypatch.setattr(webhook_service.settings.webhook, "WEBHOOK_MAX_ATTEMPTS", 3)
+
+
+def _install_handler(monkeypatch: pytest.MonkeyPatch, handler) -> None:
+    """Route the module's AsyncClient through an httpx.MockTransport."""
+    factory = functools.partial(httpx.AsyncClient, transport=httpx.MockTransport(handler))
+    monkeypatch.setattr(webhook_service.httpx, "AsyncClient", factory)
+
+
+class TestDeliver:
+    @pytest.mark.asyncio
+    async def test_success_single_attempt(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        calls: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls.append(request)
+            return httpx.Response(200)
+
+        _install_handler(monkeypatch, handler)
+        await webhook_service.deliver(WebhookConfig(url="https://x.io/h"), {"run_id": "r1"}, msg_id="r1")
+        assert len(calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_retries_then_succeeds(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        statuses = iter([503, 200])
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(next(statuses))
+
+        _install_handler(monkeypatch, handler)
+        await webhook_service.deliver(WebhookConfig(url="https://x.io/h"), {}, msg_id="r1")
+        # exhausts nothing: second attempt returns 200
+
+    @pytest.mark.asyncio
+    async def test_gives_up_after_max_attempts(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        calls: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls.append(request)
+            return httpx.Response(503)
+
+        _install_handler(monkeypatch, handler)
+        await webhook_service.deliver(WebhookConfig(url="https://x.io/h"), {}, msg_id="r1")
+        assert len(calls) == 3  # WEBHOOK_MAX_ATTEMPTS
+
+    @pytest.mark.asyncio
+    async def test_no_retry_on_client_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        calls: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls.append(request)
+            return httpx.Response(404)
+
+        _install_handler(monkeypatch, handler)
+        await webhook_service.deliver(WebhookConfig(url="https://x.io/h"), {}, msg_id="r1")
+        assert len(calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_transport_error_swallowed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        calls: list[int] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls.append(1)
+            raise httpx.ConnectError("boom")
+
+        _install_handler(monkeypatch, handler)
+        # Must not raise despite every attempt failing.
+        await webhook_service.deliver(WebhookConfig(url="https://x.io/h"), {}, msg_id="r1")
+        assert len(calls) == 3
+
+    @pytest.mark.asyncio
+    async def test_signature_headers_only_with_secret(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        seen: dict[str, httpx.Headers] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen["headers"] = request.headers
+            return httpx.Response(200)
+
+        _install_handler(monkeypatch, handler)
+        await webhook_service.deliver(WebhookConfig(url="https://x.io/h"), {}, msg_id="r1")
+        assert "webhook-signature" not in seen["headers"]
+
+        await webhook_service.deliver(WebhookConfig(url="https://x.io/h", secret="whsec_YWJj"), {}, msg_id="r1")
+        assert "webhook-signature" in seen["headers"]
+        assert seen["headers"]["webhook-id"] == "r1"
+
+    @pytest.mark.asyncio
+    async def test_body_merge_params_and_headers(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: dict[str, object] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            import json
+
+            captured["body"] = json.loads(request.content)
+            captured["query"] = request.url.params.get("source")
+            captured["auth"] = request.headers.get("authorization")
+            return httpx.Response(200)
+
+        _install_handler(monkeypatch, handler)
+        webhook = WebhookConfig(
+            url="https://x.io/h",
+            headers={"Authorization": "Bearer tok"},
+            params={"source": "cron"},
+            body={"status": "override"},
+        )
+        await webhook_service.deliver(webhook, {"run_id": "r1", "status": "success"}, msg_id="r1")
+        assert captured["body"]["run_id"] == "r1"
+        assert captured["body"]["status"] == "override"  # webhook.body overrides run payload
+        assert captured["body"]["webhook_sent_at"]  # LangGraph-aligned send timestamp
+        assert captured["query"] == "cron"
+        assert captured["auth"] == "Bearer tok"
+
+
+def _job_with_webhook(webhook: WebhookConfig | None) -> RunJob:
+    return RunJob(
+        identity=RunIdentity(run_id="r1", thread_id="t1", graph_id="g1", assistant_id="a1"),
+        user=User(identity="u1"),
+        execution=RunExecution(webhook=webhook),
+    )
+
+
+class TestDispatch:
+    def test_noop_when_no_webhook(self) -> None:
+        before = len(webhook_service._delivery_tasks)
+        webhook_service.dispatch(_job_with_webhook(None), "success", {}, None)
+        assert len(webhook_service._delivery_tasks) == before
+
+    def test_noop_when_disabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(webhook_service.settings.webhook, "WEBHOOK_ENABLED", False)
+        before = len(webhook_service._delivery_tasks)
+        webhook_service.dispatch(_job_with_webhook(WebhookConfig(url="https://x.io/h")), "success", {}, None)
+        assert len(webhook_service._delivery_tasks) == before
+
+
+class TestBlockedSSRF:
+    """_blocked: link-local/metadata always refused; private only when opted in (B1)."""
+
+    @staticmethod
+    def _patch_resolve(monkeypatch: pytest.MonkeyPatch, ip: str) -> None:
+        import asyncio
+        from unittest.mock import AsyncMock
+
+        loop = asyncio.get_running_loop()
+        monkeypatch.setattr(loop, "getaddrinfo", AsyncMock(return_value=[(2, 1, 6, "", (ip, 0))]))
+
+    @pytest.mark.asyncio
+    async def test_link_local_metadata_always_blocked(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(webhook_service.settings.webhook, "WEBHOOK_BLOCK_PRIVATE_IPS", False)
+        self._patch_resolve(monkeypatch, "169.254.169.254")
+        assert await webhook_service._blocked("http://metadata.example/x") is True
+
+    @pytest.mark.asyncio
+    async def test_private_allowed_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(webhook_service.settings.webhook, "WEBHOOK_BLOCK_PRIVATE_IPS", False)
+        self._patch_resolve(monkeypatch, "192.168.1.5")
+        assert await webhook_service._blocked("http://internal.example/x") is False
+
+    @pytest.mark.asyncio
+    async def test_private_blocked_when_opted_in(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(webhook_service.settings.webhook, "WEBHOOK_BLOCK_PRIVATE_IPS", True)
+        self._patch_resolve(monkeypatch, "192.168.1.5")
+        assert await webhook_service._blocked("http://internal.example/x") is True
+
+    @pytest.mark.asyncio
+    async def test_public_host_allowed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(webhook_service.settings.webhook, "WEBHOOK_BLOCK_PRIVATE_IPS", False)
+        self._patch_resolve(monkeypatch, "93.184.216.34")
+        assert await webhook_service._blocked("https://example.com/x") is False
+
+
+class TestBuildPayload:
+    """Delivery body is shaped like a LangGraph Platform Run webhook payload."""
+
+    @pytest.mark.asyncio
+    async def test_langgraph_aligned_shape(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from unittest.mock import AsyncMock
+
+        monkeypatch.setattr(
+            webhook_service,
+            "_read_run",
+            AsyncMock(
+                return_value={
+                    "created_at": "2026-01-01T00:00:00+00:00",
+                    "updated_at": "2026-01-01T00:00:05+00:00",
+                    "input": {"messages": []},
+                    "config": {"configurable": {"model": "openai/gpt-4o"}},
+                    "context": {"model": "openai/gpt-4o"},
+                    "error_message": None,
+                }
+            ),
+        )
+        meta = {
+            "run_id": "r1",
+            "thread_id": "t1",
+            "assistant_id": "a1",
+            "status": "success",
+            "values": {"messages": ["hi"]},
+            "error": None,
+            "metadata": {"env": "prod"},
+            "multitask_strategy": "reject",
+        }
+        payload = await webhook_service._build_payload(meta)
+        for field in (
+            "run_id",
+            "thread_id",
+            "assistant_id",
+            "status",
+            "metadata",
+            "multitask_strategy",
+            "values",
+            "error",
+            "kwargs",
+            "created_at",
+            "updated_at",
+            "run_ended_at",
+        ):
+            assert field in payload, f"missing LangGraph field {field}"
+        assert payload["values"] == {"messages": ["hi"]}
+        assert payload["kwargs"]["input"] == {"messages": []}
+        assert payload["run_ended_at"] == "2026-01-01T00:00:05+00:00"
+        assert payload["error"] is None
+
+    @pytest.mark.asyncio
+    async def test_error_object_and_db_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from unittest.mock import AsyncMock
+
+        monkeypatch.setattr(webhook_service, "_read_run", AsyncMock(return_value=None))
+        meta = {
+            "run_id": "r1",
+            "thread_id": "t1",
+            "assistant_id": "a1",
+            "status": "error",
+            "values": None,
+            "error": "boom",
+            "metadata": {},
+            "multitask_strategy": None,
+        }
+        payload = await webhook_service._build_payload(meta)
+        assert payload["error"] == {"message": "boom"}  # LangGraph error object shape
+        assert payload["kwargs"] == {}  # DB unreadable → captured-only fallback

--- a/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
+++ b/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
@@ -60,6 +60,7 @@ def _make_run_orm(
     orm.run_id = run_id
     orm.thread_id = thread_id
     orm.status = status
+    orm.assistant_id = "test-assistant"
     orm.execution_params = execution_params or {
         "graph_id": "test-graph",
         "user": {"identity": "test-user", "is_authenticated": True, "permissions": []},

--- a/libs/aegra-api/tests/unit/test_utils/test_setup_logging_redaction.py
+++ b/libs/aegra-api/tests/unit/test_utils/test_setup_logging_redaction.py
@@ -1,0 +1,78 @@
+"""Unit tests for the structlog secret-redaction processor."""
+
+from pydantic import SecretStr
+
+from aegra_api.utils.setup_logging import _REDACTED, redact_secrets
+
+
+def _run(event_dict: dict) -> dict:
+    return redact_secrets(None, "info", event_dict)
+
+
+class TestRedactSecrets:
+    def test_masks_secret_keys(self) -> None:
+        out = _run({"event": "x", "api_key": "sk-1", "authorization": "Bearer t", "access_token": "at"})
+        assert out["api_key"] == _REDACTED
+        assert out["authorization"] == _REDACTED
+        assert out["access_token"] == _REDACTED
+
+    def test_masks_nested_dict(self) -> None:
+        out = _run({"event": "x", "data": {"password": "p", "keep": "v"}})
+        assert out["data"]["password"] == _REDACTED
+        assert out["data"]["keep"] == "v"
+
+    def test_unwraps_secretstr(self) -> None:
+        out = _run({"event": "x", "creds": SecretStr("supersecret")})
+        assert out["creds"] == "**********"
+        assert "supersecret" not in str(out)
+
+    def test_preserves_non_secret_and_counts(self) -> None:
+        # "total_tokens" must survive (bare 'token' is intentionally not matched).
+        out = _run({"event": "x", "total_tokens": 42, "run_id": "r1"})
+        assert out["total_tokens"] == 42
+        assert out["run_id"] == "r1"
+
+    def test_preserves_tuple_type(self) -> None:
+        # structlog's positional_args is a tuple consumed by ``event % args``.
+        out = _run({"event": "hi %s", "positional_args": ("world",)})
+        assert isinstance(out["positional_args"], tuple)
+
+    def test_depth_cap_does_not_crash(self) -> None:
+        nested: dict = {"event": "x"}
+        cursor = nested
+        for _ in range(10):
+            child: dict = {}
+            cursor["child"] = child
+            cursor = child
+        cursor["api_key"] = "deep"  # deeper than _MAX_REDACT_DEPTH; must not raise
+        _run(nested)  # no assertion — just must not raise
+
+
+class TestRedactLazy:
+    """Copy-on-first-change: clean values are returned by identity (zero allocation)."""
+
+    def test_returns_same_object_when_clean(self) -> None:
+        from aegra_api.utils.setup_logging import _redact
+
+        inner = {"env": "prod"}
+        event = {"event": "hi", "run_id": "r1", "meta": inner, "positional_args": ("x",)}
+        out = _redact(event, 0)
+        assert out is event  # no allocation when nothing matches
+        assert out["meta"] is inner  # nested clean dict kept by identity
+
+    def test_copies_only_on_change_keeping_clean_nested_identity(self) -> None:
+        from aegra_api.utils.setup_logging import _REDACTED, _redact
+
+        clean = {"env": "prod"}
+        event = {"event": "hi", "api_key": "sk", "clean": clean}
+        out = _redact(event, 0)
+        assert out is not event  # copied because api_key changed
+        assert out["api_key"] == _REDACTED
+        assert out["clean"] is clean  # unchanged nested dict not re-copied
+
+    def test_tuple_identity_preserved_when_clean(self) -> None:
+        from aegra_api.utils.setup_logging import _redact
+
+        args = ("world",)
+        out = _redact({"event": "hi %s", "positional_args": args}, 0)
+        assert out["positional_args"] is args  # same tuple object, still a tuple

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.9.24"
+version = "0.9.25"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-cli/src/aegra_cli/templates/env.example.template
+++ b/libs/aegra-cli/src/aegra_cli/templates/env.example.template
@@ -94,6 +94,19 @@ CRON_ENABLED=true
 # Soft cap on the JSONB payload size (bytes) accepted on create/update.
 # CRON_MAX_PAYLOAD_BYTES=65536
 
+# --- Webhook Delivery ---
+# Best-effort HTTP callback POSTed when a run completes (set per run or per cron).
+# WEBHOOK_ENABLED=true
+# Per-attempt timeout in seconds.
+# WEBHOOK_TIMEOUT_SECONDS=15
+# Total delivery attempts (1 = no retry).
+# WEBHOOK_MAX_ATTEMPTS=3
+# Exponential backoff base in seconds (delay = base * 2^(attempt-1)).
+# WEBHOOK_BACKOFF_BASE_SECONDS=1
+# Also refuse delivery to loopback/private hosts. Link-local/metadata
+# (169.254.169.254) is ALWAYS refused. Off by default so internal hooks work.
+# WEBHOOK_BLOCK_PRIVATE_IPS=false
+
 # --- Event Streaming (Agent Protocol v2) ---
 # The v2 thread streaming endpoints (/threads/{id}/stream/events and
 # /threads/{id}/commands) used by the latest LangGraph JS/Python SDKs.

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.9.24"
+version = "0.9.25"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -24,6 +24,7 @@ dependencies = [
     { name = "croniter" },
     { name = "fastapi" },
     { name = "greenlet" },
+    { name = "httpx" },
     { name = "langgraph" },
     { name = "langgraph-checkpoint-postgres" },
     { name = "langgraph-sdk" },
@@ -65,6 +66,7 @@ requires-dist = [
     { name = "croniter", specifier = ">=6.0.0" },
     { name = "fastapi", specifier = ">=0.110.1" },
     { name = "greenlet", specifier = ">=3.1.0" },
+    { name = "httpx", specifier = ">=0.27.0" },
     { name = "langgraph", specifier = ">=1.0.3" },
     { name = "langgraph-checkpoint-postgres", specifier = ">=2.0.23" },
     { name = "langgraph-sdk", specifier = ">=0.3.5" },
@@ -100,7 +102,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.9.24"
+version = "0.9.25"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
Add outbound webhook delivery when a run reaches a terminal state, set per run (RunCreate.webhook) or per cron (forwarded onto fired runs). Accepts a bare URL string (LangGraph SDK contract) or a rich object with method/headers/params/body/secret.

- Delivery fires from the shared execute_run hook (covers dev LocalExecutor and prod WorkerExecutor); best-effort with timeout + exponential-backoff retries; never fails or delays the run.
- Payload matches the LangGraph Platform webhook Run object (run_id, status, values, kwargs, error, timestamps, webhook_sent_at).
- HMAC-SHA256 signing per the Standard Webhooks spec when a secret is set.
- SSRF guard: link-local/metadata always refused; loopback/private behind WEBHOOK_BLOCK_PRIVATE_IPS; redirects disabled.
- Webhook secret/headers/params masked on cron reads; structlog processor scrubs secret-looking keys from logs (copy-on-write, zero-alloc when clean).
- New WebhookSettings; httpx added as a direct dependency; docs + OpenAPI regenerated. Version 0.9.24 -> 0.9.25.

## Description
<!-- Provide a clear description of your changes -->

## Type of Change
<!-- Check the relevant option -->
- [ ] `feat`: New feature
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation changes
- [ ] `style`: Code style/formatting
- [ ] `refactor`: Code refactoring
- [ ] `perf`: Performance improvement
- [ ] `test`: Tests added/updated
- [ ] `chore`: Maintenance (dependencies, build, etc.)
- [ ] `ci`: CI/CD changes

## Related Issues
<!-- Link related issues: Fixes #123, Closes #456 -->

## Changes Made
<!-- List the main changes -->
-
-
-

## Testing
<!-- Describe how you tested your changes -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing performed

## Checklist
<!-- Ensure all items are checked before requesting review -->
- [ ] Code follows project style (Ruff formatting)
- [ ] All linting checks pass (`make lint`)
- [ ] Type checking passes (`make type-check`)
- [ ] All tests pass (`make test`)
- [ ] Documentation updated (if needed)
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] PR title follows Conventional Commits format

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Additional Notes
<!-- Any additional information for reviewers -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added webhook callbacks for completed runs and cron-triggered runs.
  * Supports custom URLs, methods, headers, query parameters, bodies, and optional HMAC signing.
  * Added configurable retries, timeouts, backoff, and destination safety controls.
  * Webhook payloads include run status, results, errors, and metadata.

* **Documentation**
  * Added webhook configuration guidance, API schema details, environment variables, and security considerations.
  * Updated the feature support matrix to mark webhook callbacks as supported.

* **Security**
  * Added protection against unsafe destinations and automatic masking of webhook credentials in responses and logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds run-completion webhooks for runs and crons. The main changes are:

- Webhook config models for bare URLs and rich callback objects.
- Best-effort delivery from the shared run executor.
- HMAC signing, retries, timeouts, and shutdown draining.
- Cron forwarding and API-read redaction for webhook secrets.
- Webhook settings, docs, OpenAPI, dependency, and tests.

<h3>Confidence Score: 4/5</h3>

The webhook URL fetch path needs fixes before merging.

- User-supplied webhook URLs can reach internal network targets by default.
- The DNS-based guard can be bypassed between validation and connection.
- The executor integration and model serialization paths otherwise look consistent from the inspected changes.

libs/aegra-api/src/aegra_api/services/webhook_service.py

<details open><summary><h3>Security Review</h3></summary>

The new outbound webhook path introduces SSRF risk. User-supplied callback URLs can reach private network targets by default, and the DNS check can be bypassed by rebinding between validation and connection.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/services/webhook_service.py | Adds webhook delivery, signing, retries, payload loading, and SSRF checks; the URL guard needs fixes for private-network blocking and DNS rebinding. |
| libs/aegra-api/src/aegra_api/models/webhooks.py | Adds webhook configuration, signing helpers, URL validation, and redaction. |
| libs/aegra-api/src/aegra_api/services/run_executor.py | Dispatches completion webhooks after terminal run finalization while avoiding lease-loss duplicate sends. |
| libs/aegra-api/src/aegra_api/services/cron_service.py | Stores webhook payloads for crons and masks webhook credentials on reads. |
| libs/aegra-api/src/aegra_api/utils/setup_logging.py | Adds structlog redaction for secret-looking fields and SecretStr values. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client as Run/Cron creator
    participant API as Aegra API
    participant Exec as Run executor
    participant WH as webhook_service
    participant Target as Callback URL

    Client->>API: create run or cron with webhook
    API->>Exec: store RunJob.execution.webhook
    Exec->>Exec: finalize terminal run state
    Exec->>WH: dispatch(job, status, output, error)
    WH->>WH: build payload and sign when configured
    WH->>WH: resolve host for SSRF guard
    WH->>Target: send httpx request to original URL
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client as Run/Cron creator
    participant API as Aegra API
    participant Exec as Run executor
    participant WH as webhook_service
    participant Target as Callback URL

    Client->>API: create run or cron with webhook
    API->>Exec: store RunJob.execution.webhook
    Exec->>Exec: finalize terminal run state
    Exec->>WH: dispatch(job, status, output, error)
    WH->>WH: build payload and sign when configured
    WH->>WH: resolve host for SSRF guard
    WH->>Target: send httpx request to original URL
```

</a>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fservices%2Fwebhook_service.py%3A201-202%0A**Private%20Network%20Fetch%20Allowed**%0A%0ARun%20and%20cron%20creators%20can%20now%20provide%20%60webhook.url%60%2C%20and%20this%20default%20lets%20those%20callbacks%20reach%20loopback%20and%20RFC1918%20hosts%20unless%20%60WEBHOOK_BLOCK_PRIVATE_IPS%60%20is%20explicitly%20enabled.%20A%20public%20API%20caller%20can%20point%20a%20completed%20run%20at%20an%20internal%20service%20URL%20and%20make%20the%20server%20send%20the%20request%20from%20inside%20the%20deployment.%0A%0A%23%23%23%20Issue%202%20of%202%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fservices%2Fwebhook_service.py%3A136-147%0A**DNS%20Rebinding%20Bypasses%20Guard**%0A%0A%60_blocked%28%29%60%20resolves%20the%20host%20once%2C%20but%20%60httpx%60%20resolves%20%60webhook.url%60%20again%20when%20sending%20the%20request.%20A%20caller-controlled%20hostname%20can%20return%20a%20public%20address%20for%20the%20guard%20check%20and%20then%20rebind%20to%20link-local%2C%20loopback%2C%20or%20another%20internal%20address%20for%20the%20actual%20connection%2C%20so%20the%20SSRF%20filter%20can%20be%20bypassed%20even%20when%20private%20blocking%20is%20enabled.%0A%0A&repo=aegra%2Faegra&pr=456&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fservices%2Fwebhook_service.py%3A201-202%0A**Private%20Network%20Fetch%20Allowed**%0A%0ARun%20and%20cron%20creators%20can%20now%20provide%20%60webhook.url%60%2C%20and%20this%20default%20lets%20those%20callbacks%20reach%20loopback%20and%20RFC1918%20hosts%20unless%20%60WEBHOOK_BLOCK_PRIVATE_IPS%60%20is%20explicitly%20enabled.%20A%20public%20API%20caller%20can%20point%20a%20completed%20run%20at%20an%20internal%20service%20URL%20and%20make%20the%20server%20send%20the%20request%20from%20inside%20the%20deployment.%0A%0A%23%23%23%20Issue%202%20of%202%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fservices%2Fwebhook_service.py%3A136-147%0A**DNS%20Rebinding%20Bypasses%20Guard**%0A%0A%60_blocked%28%29%60%20resolves%20the%20host%20once%2C%20but%20%60httpx%60%20resolves%20%60webhook.url%60%20again%20when%20sending%20the%20request.%20A%20caller-controlled%20hostname%20can%20return%20a%20public%20address%20for%20the%20guard%20check%20and%20then%20rebind%20to%20link-local%2C%20loopback%2C%20or%20another%20internal%20address%20for%20the%20actual%20connection%2C%20so%20the%20SSRF%20filter%20can%20be%20bypassed%20even%20when%20private%20blocking%20is%20enabled.%0A%0A&pr=456&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22feat%2Fwebhook-callbacks%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fwebhook-callbacks%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fservices%2Fwebhook_service.py%3A201-202%0A**Private%20Network%20Fetch%20Allowed**%0A%0ARun%20and%20cron%20creators%20can%20now%20provide%20%60webhook.url%60%2C%20and%20this%20default%20lets%20those%20callbacks%20reach%20loopback%20and%20RFC1918%20hosts%20unless%20%60WEBHOOK_BLOCK_PRIVATE_IPS%60%20is%20explicitly%20enabled.%20A%20public%20API%20caller%20can%20point%20a%20completed%20run%20at%20an%20internal%20service%20URL%20and%20make%20the%20server%20send%20the%20request%20from%20inside%20the%20deployment.%0A%0A%23%23%23%20Issue%202%20of%202%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fservices%2Fwebhook_service.py%3A136-147%0A**DNS%20Rebinding%20Bypasses%20Guard**%0A%0A%60_blocked%28%29%60%20resolves%20the%20host%20once%2C%20but%20%60httpx%60%20resolves%20%60webhook.url%60%20again%20when%20sending%20the%20request.%20A%20caller-controlled%20hostname%20can%20return%20a%20public%20address%20for%20the%20guard%20check%20and%20then%20rebind%20to%20link-local%2C%20loopback%2C%20or%20another%20internal%20address%20for%20the%20actual%20connection%2C%20so%20the%20SSRF%20filter%20can%20be%20bypassed%20even%20when%20private%20blocking%20is%20enabled.%0A%0A&repo=aegra%2Faegra&pr=456&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(webhooks): deliver signed run-compl..."](https://github.com/aegra/aegra/commit/33f7a52291358daf56c8cf00e4924f6bf275e611) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43735269)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/aegra/github/aegra/aegra/-/custom-context?memory=1640ab19-5310-4fc5-aaf6-3760087c66e8))
- Context used - AGENTS.md ([source](https://app.greptile.com/aegra/github/aegra/aegra/-/custom-context?memory=15e5c4fa-b823-4fae-b564-d5a58cb22ed4))

<!-- /greptile_comment -->