### PR TITLE
feat(api): implement multitask_strategy (double-texting) for concurrent runs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,8 +79,9 @@ aegra/
 ### Run Execution Architecture
 - **Production mode** (`REDIS_BROKER_ENABLED=true`): Runs are dispatched via a Redis job queue (BLPOP). Workers run as concurrent asyncio tasks inside each instance (default: 3 workers x 10 jobs = 30 concurrent runs per instance). Lease-based crash recovery with heartbeat and reaper. Execution params stored in Postgres so workers can reconstruct jobs. OpenTelemetry trace context propagates across the Redis queue boundary.
 - **Dev mode** (`aegra dev`, `REDIS_BROKER_ENABLED=false`): Runs execute as in-process asyncio tasks via `LocalExecutor`. No Redis needed. SSE uses an in-memory broker.
+- **Double-texting (`multitask_strategy`)**: when a run is created on a thread that already has an active run, the per-thread admission gate in `run_preparation._apply_multitask_strategy` (under a `FOR UPDATE` thread lock) applies the strategy — `enqueue` (default; parks the run as `queued` internally, reported as `pending` over the API), `reject` (409), `interrupt`, or `rollback`. Queued runs are promoted FIFO by `BaseExecutor.dispatch_next_for_thread` from `run_status.finalize_run`, with stranded-queue recovery in `lease_reaper` (prod) and `LocalExecutor.start` (dev). User cancels converge through `run_status.terminalize_user_cancel` (CAS against the run task's own finalize).
 - Key files: `services/executor.py` (factory), `services/local_executor.py` (dev), `services/worker_executor.py` (prod), `services/lease_reaper.py` (crash recovery), `models/run_job.py` (serialized execution params).
-- See `docs/guides/worker-architecture.mdx` for the full architecture documentation.
+- See `docs/guides/worker-architecture.mdx` for the full architecture documentation, and `docs/guides/double-texting.mdx` for multitask strategies.
 
 ## Development Rules
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -51,7 +51,8 @@
               "guides/threads-and-state",
               "guides/streaming",
               "guides/human-in-the-loop",
-              "guides/cron"
+              "guides/cron",
+              "guides/double-texting"
             ]
           },
           {

--- a/docs/feature-support.mdx
+++ b/docs/feature-support.mdx
@@ -42,6 +42,7 @@ description: "What Aegra supports today, what's coming soon, and what's not yet 
 | Subgraph streaming | Supported | Stream events from nested subgraphs. |
 | Stateless runs | Supported | Execute without persisting thread state. |
 | Cron / scheduled jobs | Supported | Trigger runs on a schedule. Standard and seconds-level cron expressions. IANA timezone support. |
+| Double-texting / multitask | Supported | `multitask_strategy` per run: `enqueue` (default), `reject`, `interrupt`, `rollback`. See [Double-texting](/guides/double-texting). |
 
 ### Scaling and reliability
 

--- a/docs/guides/cron.mdx
+++ b/docs/guides/cron.mdx
@@ -96,6 +96,17 @@ run = await client.crons.create_for_thread(
 print(f"Cron ID: {run['cron_id']}")
 ```
 
+<Note>
+For a thread-bound cron, keep the payload's `multitask_strategy` at the default
+**`enqueue`**. The non-default strategies interact badly with periodic same-thread
+firing: `rollback`/`interrupt` cancel the still-running prior fire on every overlapping
+tick (a fire that outlasts the poll interval never completes), and `reject` 409s on every
+tick until the active fire finishes. Also note: if the bound thread is paused on a
+human-in-the-loop `interrupt()`, every cron fire is refused with `409` (regardless of
+strategy, including `enqueue`) until the thread is resumed. See
+[double-texting](/guides/double-texting) for the full semantics.
+</Note>
+
 ## Cron expression format
 
 Aegra uses [croniter](https://github.com/kiorky/croniter) for schedule parsing.

--- a/docs/guides/double-texting.mdx
+++ b/docs/guides/double-texting.mdx
@@ -1,0 +1,117 @@
+---
+title: "Double-texting (multitask)"
+description: "Control what happens when a new run is created on a thread that already has one in progress."
+---
+
+When a client creates a run on a thread that already has an active run — a user
+sending a follow-up before the agent has finished, or two API calls racing — the
+`multitask_strategy` field decides the outcome. The strategy names and request-time
+outcomes follow LangGraph Platform's
+[double-texting](https://docs.langchain.com/langsmith/double-texting) model; `rollback`
+reverts non-destructively via a checkpoint fork (nothing is deleted) rather than
+Platform's checkpoint deletion.
+
+## Strategies
+
+| Strategy | Behavior |
+|:--|:--|
+| `enqueue` *(default)* | Queue the new run and execute it after the active one finishes. |
+| `reject` | Refuse the new run with `409 Conflict` while a run is active. |
+| `interrupt` | Cancel the active run (kept as `interrupted`), then start the new run. |
+| `rollback` | Cancel the active run, then **fork** the new run from the checkpoint preceding it — reverting the cancelled run's writes. Nothing is deleted. |
+
+If `multitask_strategy` is omitted it defaults to `enqueue`, matching LangGraph
+Platform. An unknown value is rejected with `422` at request validation. Chat-style
+applications that want a cancel-and-resend to auto-repair the thread (see the
+`rollback` note below) should set `multitask_strategy="rollback"` explicitly,
+either per request or as a client-wide default.
+
+## Usage
+
+```python
+from langgraph_sdk import get_client
+
+client = get_client(url="http://localhost:2026")
+
+# Queue behind any active run (default)
+await client.runs.create(thread_id, assistant_id, input={...})
+
+# Refuse if the thread is busy
+await client.runs.create(thread_id, assistant_id, input={...}, multitask_strategy="reject")
+```
+
+Over HTTP:
+
+```bash
+curl -X POST http://localhost:2026/threads/$THREAD/runs \
+  -H "Content-Type: application/json" \
+  -d '{"assistant_id": "...", "input": {...}, "multitask_strategy": "interrupt"}'
+```
+
+## Parked runs and the internal `queued` status
+
+A run parked by `enqueue` is stored internally with status `queued`. It holds no
+worker slot and does not execute until the run ahead of it finalizes, at which point
+the oldest `queued` run on the thread is promoted to `pending` and dispatched (FIFO).
+Over the API a parked run is reported as `pending` — the LangGraph SDK's run-status
+vocabulary has no `queued` value, and LangGraph Platform reports enqueued
+double-texts the same way, so typed clients (Studio, Agent Chat UI, the JS SDK)
+see only standard statuses. Poll or stream it like any other run; on the wire it
+transitions `pending → running → success` (or `error`/`interrupted`). A later
+`interrupt` or `rollback` run admitted while this one is still parked *drops* it
+(marks it `interrupted`) instead of running it afterward — those strategies abandon
+all in-flight work, including earlier double-texts.
+
+At most one run per thread ever executes — the per-thread admission check is
+serialized with a `SELECT ... FOR UPDATE` on the thread row, so two concurrent
+creates cannot both start.
+
+## Behavior notes
+
+- **`rollback` mechanism.** The active run is cancelled, then the new run is
+  *forked* from the checkpoint that preceded the rolled-back run — so that run's
+  input and any partial/orphaned writes are abandoned along with the old branch
+  and the graph re-enters from `__start__` with no orphan left to repair. No
+  checkpoints are deleted; the old branch survives as harmless siblings, so
+  `GET /threads/{id}/history` shows both branches while `state` returns the new
+  clean head. With an active run, `rollback` reverts that run. On an *idle* thread
+  it repairs a broken last turn — reverting the most recent run only if it was
+  left `interrupted` or `error` (e.g. an orphaned tool call); a cleanly completed
+  run is left untouched, so `rollback` never silently undoes a successful turn.
+  Caveat: if the rolled-back run was the thread's *first* run there is no earlier
+  checkpoint to fork from — the new run still re-enters from `__start__`, where a
+  `before_agent` repair middleware can fix the orphan in place, but that first
+  run's input message is not physically removed. `rollback` only applies to a
+  fresh dict-input run (not a `command`/resume or an explicit client checkpoint).
+  One edge: a run cancelled while still `queued` (e.g. by a client disconnect) never
+  wrote a checkpoint, so if it is the most recent terminal run it has nothing to fork
+  from — `rollback` then runs fresh instead of repairing an earlier broken turn.
+- **Human-in-the-loop pauses are protected at admission.** A thread paused on a
+  LangGraph `interrupt()` has status `interrupted` with a pending interrupt. A new
+  run carrying fresh input (under *any* `multitask_strategy`) is refused with
+  `409 Conflict` rather than silently consuming the pending interrupt — resume the
+  pause with `command={"resume": ...}` instead. The guard runs both at run creation
+  AND at queued-run promotion (`dispatch_next_for_thread`), so a run enqueued *before*
+  the thread paused is not auto-promoted onto the pause either — it stays parked. A
+  resume command **jumps ahead of any parked runs** (it is the only run that can clear
+  the pause); once it finalizes, the parked runs are promoted as normal next turns.
+  While that resume is itself executing, `interrupt` and `rollback` are refused with
+  `409 Conflict` too — pre-empting an in-flight resume would land the new run on the
+  pending-interrupt checkpoint and consume the pause the same way.
+- **User cancels converge the thread.** `POST .../runs/{id}/cancel`, a
+  cancelling `PATCH`, force-delete, and disconnect-cancel all converge through the
+  same compare-and-swap terminal write as the run's own finalize: whoever wins
+  resets the thread status and immediately promotes the next queued run, so a
+  cancelled head never strands the queue or leaves the thread stuck `busy`. In
+  worker mode the cancel also releases the run's lease, so an instance that missed
+  the cancel pub/sub message self-cancels on its next heartbeat instead of racing
+  the new run to completion.
+- **Crash recovery.** Queued runs are durable in Postgres. In worker mode the
+  lease reaper re-dispatches a thread whose queue was stranded by a lost wakeup;
+  in dev mode (`LocalExecutor`) the same recovery runs on startup and via a periodic
+  ~30s sweep, so a stranded dev queue self-heals without a restart. A run finalizing
+  during shutdown does not dispatch the next queued run — it is picked up by the next
+  start or sweep instead.
+- **Both execution modes.** The strategy is enforced in the shared run-creation
+  path, so it behaves identically under `LocalExecutor` (dev) and the Redis worker
+  pool (production).

--- a/docs/guides/human-in-the-loop.mdx
+++ b/docs/guides/human-in-the-loop.mdx
@@ -224,5 +224,11 @@ if state["interrupts"]:
 
 - Interrupts work transparently across subgraph boundaries
 - The thread status changes to `"interrupted"` when paused and `"idle"` when completed
+- **A paused thread refuses fresh input.** Creating a run with plain `input` on a
+  thread whose status is `"interrupted"` returns `409 Conflict` (under any
+  [`multitask_strategy`](/guides/double-texting)) — running it would silently consume
+  the pending interrupt. Resume with `command={"resume": ...}` instead; a `null`
+  resume payload is refused the same way. Runs enqueued before the pause stay parked
+  until a resume clears it.
 - You can inspect the interrupt payload in thread state to show the user what the agent wants to do
 - Multiple sequential interrupts are supported in a single run

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Aegra",
     "description": "Production-ready Agent Protocol server",
-    "version": "0.9.24"
+    "version": "0.10.0"
   },
   "paths": {
     "/info": {
@@ -1946,7 +1946,7 @@
           "Thread Runs"
         ],
         "summary": "Delete Run",
-        "description": "Delete a run record.\n\nIf the run is active (pending or running) and `force=0`, returns 409\nConflict. Set `force=1` to cancel the run first (best-effort) and then\ndelete it. Returns 204 No Content on success.",
+        "description": "Delete a run record.\n\nIf the run is active (queued, pending, or running) and `force=0`, returns\n409 Conflict. Set `force=1` to cancel the run first (best-effort) and then\ndelete it. Returns 204 No Content on success.",
         "operationId": "delete_run_threads__thread_id__runs__run_id__delete",
         "parameters": [
           {
@@ -3882,7 +3882,12 @@
             "anyOf": [
               {
                 "type": "string",
-                "maxLength": 256
+                "enum": [
+                  "reject",
+                  "rollback",
+                  "interrupt",
+                  "enqueue"
+                ]
               },
               {
                 "type": "null"
@@ -4290,7 +4295,12 @@
             "anyOf": [
               {
                 "type": "string",
-                "maxLength": 256
+                "enum": [
+                  "reject",
+                  "rollback",
+                  "interrupt",
+                  "enqueue"
+                ]
               },
               {
                 "type": "null"
@@ -4522,7 +4532,7 @@
           "status": {
             "type": "string",
             "title": "Status",
-            "description": "Current run status: pending, running, error, success, timeout, or interrupted.",
+            "description": "Current run status: pending (includes runs enqueued behind another run), running, error, success, timeout, or interrupted.",
             "default": "pending"
           },
           "input": {
@@ -4617,7 +4627,7 @@
           "updated_at"
         ],
         "title": "Run",
-        "description": "Run entity model\n\nStatus values: pending, running, error, success, timeout, interrupted"
+        "description": "Run entity model\n\nStatus values: pending, running, error, success, timeout, interrupted.\nA run parked behind another run (double-texting enqueue) is internally\n'queued' and reported as 'pending', matching the LangGraph SDK vocabulary."
       },
       "RunCreate": {
         "properties": {
@@ -4733,14 +4743,20 @@
           "multitask_strategy": {
             "anyOf": [
               {
-                "type": "string"
+                "type": "string",
+                "enum": [
+                  "reject",
+                  "rollback",
+                  "interrupt",
+                  "enqueue"
+                ]
               },
               {
                 "type": "null"
               }
             ],
             "title": "Multitask Strategy",
-            "description": "Strategy for handling concurrent runs on same thread: 'reject', 'interrupt', 'rollback', or 'enqueue'."
+            "description": "How to handle a new run when the thread already has an active run. 'enqueue' (default) queues it to run after; 'reject' returns 409; 'interrupt' cancels the active run then starts this one; 'rollback' cancels the active run (kept as interrupted) \u2014 or, with no active run, reverts the last run only if it was left interrupted/errored (repairing a broken thread; a completed run is untouched) \u2014 then forks this run from the checkpoint preceding it, reverting that run's writes. None defaults to 'enqueue'."
           },
           "command": {
             "anyOf": [

--- a/examples/stress_test/graph.py
+++ b/examples/stress_test/graph.py
@@ -5,7 +5,10 @@ at high concurrency without burning API tokens.
 
 Input:
   {"messages": [{"role": "user", "content": "..."}]}
-  Content can optionally be JSON: {"delay": 2.0, "steps": 3, "fail": false}
+  Content can optionally be JSON:
+  {"delay": 2.0, "steps": 3, "fail": false, "interrupt": false, "_m": "marker"}
+  ("interrupt": true pauses on a HITL interrupt(); "_m" tags the echo so tests
+  can assert which runs executed and in what order.)
 
 Output:
   Echoes back with metadata about execution (node count, total delay).
@@ -19,6 +22,7 @@ from typing import Annotated, Any
 
 from langchain_core.messages import AIMessage, AnyMessage
 from langgraph.graph import StateGraph, add_messages
+from langgraph.types import interrupt
 
 
 @dataclass
@@ -50,6 +54,11 @@ async def process_step(state: State) -> dict[str, Any]:
     delay = float(config["delay"])
 
     await asyncio.sleep(delay)
+
+    # Optional human-in-the-loop pause (LLM-free HITL fixture), AFTER the simulated work so a
+    # caller can enqueue behind a still-running run before it pauses. Stays paused until resumed.
+    if config.get("interrupt"):
+        interrupt({"awaiting": config.get("_m", "input")})
 
     new_step = state.step_count + 1
     new_delay = state.total_delay + delay

--- a/libs/aegra-api/alembic/versions/20260716000000_runs_thread_status_created_index.py
+++ b/libs/aegra-api/alembic/versions/20260716000000_runs_thread_status_created_index.py
@@ -1,0 +1,37 @@
+"""runs: composite index for multitask per-thread admission and dispatch
+
+Revision ID: d2e3f4a5b6c7
+Revises: b88bb61be638
+Create Date: 2026-07-16 00:00:00.000000
+
+Adds a composite index on runs(thread_id, status, created_at) so the
+double-texting admission check (does this thread have an active/queued run?)
+and the FIFO queued-run dispatch (oldest queued run for a thread) are
+index-only instead of scanning all of a thread's runs.
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "d2e3f4a5b6c7"
+down_revision = "b88bb61be638"
+branch_labels = None
+depends_on = None
+
+
+INDEX_NAME = "idx_runs_thread_status_created"
+
+
+def upgrade() -> None:
+    # CONCURRENTLY so the build holds only SHARE UPDATE EXCLUSIVE (not SHARE) on
+    # the hot runs table — migrations run at lifespan startup on every deploy.
+    # DROP first: an interrupted CONCURRENTLY build leaves an INVALID index that
+    # IF NOT EXISTS would skip forever, so the retry must rebuild from scratch.
+    with op.get_context().autocommit_block():
+        op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {INDEX_NAME}")
+        op.execute(f"CREATE INDEX CONCURRENTLY {INDEX_NAME} ON runs (thread_id, status, created_at)")
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute(f"DROP INDEX CONCURRENTLY IF EXISTS {INDEX_NAME}")

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.9.24"
+version = "0.10.0"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-api/src/aegra_api/api/runs.py
+++ b/libs/aegra-api/src/aegra_api/api/runs.py
@@ -3,14 +3,14 @@
 import asyncio
 import contextlib
 from collections.abc import AsyncGenerator, MutableMapping
-from datetime import UTC, datetime
 from typing import Any
 
 import structlog
 from fastapi import APIRouter, Depends, Header, HTTPException, Query
 from fastapi.responses import StreamingResponse
 from redis import RedisError
-from sqlalchemy import delete, select, update
+from sqlalchemy import delete, select
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 from sse_starlette import EventSourceResponse
 
@@ -25,6 +25,7 @@ from aegra_api.models import Run, RunCreate, RunStatus, User
 from aegra_api.models.errors import CONFLICT, NOT_FOUND, SSE_RESPONSE
 from aegra_api.services.broker import broker_manager
 from aegra_api.services.run_preparation import _prepare_run
+from aegra_api.services.run_status import terminalize_user_cancel
 from aegra_api.services.run_waiters import TERMINAL_STATES, encode_output, heartbeat_wait_body
 from aegra_api.services.streaming_service import streaming_service
 from aegra_api.settings import settings
@@ -120,7 +121,11 @@ async def create_and_stream_run(
     async def _cancel_on_client_close(_msg: MutableMapping[str, Any]) -> None:
         try:
             await broker_manager.request_cancel(run_id, "cancel")
-        except (RedisError, OSError):
+            # Converge the terminal state: unpark a still-queued run, or CAS-finalize one
+            # already promoted past the request_cancel above (its execution-start CAS then
+            # fails, so a run promoted inside this window can never execute orphaned).
+            await terminalize_user_cancel(run_id, thread_id)
+        except (RedisError, OSError, SQLAlchemyError):
             # Swallow infra/transport failures so sse-starlette's task group
             # tears down cleanly. Programmer errors (TypeError, AttributeError,
             # ...) propagate. The lease reaper picks up unreachable runs.
@@ -244,14 +249,9 @@ async def update_run(
         logger.info(f"[update_run] cancelling/interrupting run_id={run_id} user={user.identity} thread_id={thread_id}")
         # Handle interruption - use interrupt_run for cooperative interruption
         await streaming_service.interrupt_run(run_id)
-        logger.info(f"[update_run] set DB status=interrupted run_id={run_id}")
-        await session.execute(
-            update(RunORM)
-            .where(RunORM.run_id == str(run_id))
-            .values(status="interrupted", updated_at=datetime.now(UTC))
-        )
-        await session.commit()
-        logger.info(f"[update_run] commit done (interrupted) run_id={run_id}")
+        # Converge the terminal state (CAS races the run task's own finalize benignly):
+        # the winner also resets the thread row and promotes the next queued run.
+        await terminalize_user_cancel(str(run_id), thread_id)
 
     # Return final run state
     run_orm = await session.scalar(select(RunORM).where(RunORM.run_id == run_id))
@@ -465,23 +465,12 @@ async def cancel_run_endpoint(
     if action == "interrupt":
         logger.info(f"[cancel_run] interrupt run_id={run_id} user={user.identity} thread_id={thread_id}")
         await streaming_service.interrupt_run(run_id)
-        # Persist status as interrupted
-        await session.execute(
-            update(RunORM)
-            .where(RunORM.run_id == str(run_id))
-            .values(status="interrupted", updated_at=datetime.now(UTC))
-        )
-        await session.commit()
     else:
         logger.info(f"[cancel_run] cancel run_id={run_id} user={user.identity} thread_id={thread_id}")
         await streaming_service.cancel_run(run_id)
-        # Persist status as interrupted
-        await session.execute(
-            update(RunORM)
-            .where(RunORM.run_id == str(run_id))
-            .values(status="interrupted", updated_at=datetime.now(UTC))
-        )
-        await session.commit()
+    # Converge the terminal state (CAS races the run task's own finalize benignly):
+    # the winner also resets the thread row and promotes the next queued run.
+    await terminalize_user_cancel(str(run_id), thread_id)
 
     # Optionally wait for the run to settle
     if wait:
@@ -495,6 +484,9 @@ async def cancel_run_endpoint(
             if fresh and fresh.status in TERMINAL_STATES:
                 break
 
+    # terminalize_user_cancel wrote through its own session; expire this one so the
+    # reload below reads the committed terminal state, not the identity-mapped row.
+    session.expire_all()
     # Reload and return updated Run (do NOT delete here; deletion is a separate endpoint)
     run_orm = await session.scalar(
         select(RunORM).where(
@@ -522,8 +514,8 @@ async def delete_run(
 ) -> None:
     """Delete a run record.
 
-    If the run is active (pending or running) and `force=0`, returns 409
-    Conflict. Set `force=1` to cancel the run first (best-effort) and then
+    If the run is active (queued, pending, or running) and `force=0`, returns
+    409 Conflict. Set `force=1` to cancel the run first (best-effort) and then
     delete it. Returns 204 No Content on success.
     """
     # Authorization check (delete action on runs resource)
@@ -542,7 +534,7 @@ async def delete_run(
         raise HTTPException(404, f"Run '{run_id}' not found")
 
     # If active and not forcing, reject deletion
-    if run_orm.status in ["pending", "running"] and not force:
+    if run_orm.status in ["queued", "pending", "running"] and not force:
         raise HTTPException(
             status_code=409,
             detail="Run is active. Retry with force=1 to cancel and delete.",
@@ -557,6 +549,13 @@ async def delete_run(
         if task:
             with contextlib.suppress(asyncio.CancelledError, Exception):
                 await task
+        # Converge BEFORE deleting the row: once it is gone the task's finalize
+        # matches nothing, so the thread reset and queued dispatch must happen here.
+        await terminalize_user_cancel(str(run_id), thread_id)
+    elif force and run_orm.status == "queued":
+        # No task/broker to cancel, but if this run heads a stranded queue the runs
+        # parked behind it must be promoted — converge before the row disappears.
+        await terminalize_user_cancel(str(run_id), thread_id)
 
     # Delete the record
     await session.execute(

--- a/libs/aegra-api/src/aegra_api/api/threads.py
+++ b/libs/aegra-api/src/aegra_api/api/threads.py
@@ -833,7 +833,7 @@ async def delete_thread(
     active_runs_stmt = select(RunORM).where(
         RunORM.thread_id == thread_id,
         RunORM.user_id == user.identity,
-        RunORM.status.in_(["pending", "running"]),
+        RunORM.status.in_(["queued", "pending", "running"]),
     )
     active_runs_list = (await session.scalars(active_runs_stmt)).all()
 

--- a/libs/aegra-api/src/aegra_api/core/orm.py
+++ b/libs/aegra-api/src/aegra_api/core/orm.py
@@ -188,6 +188,8 @@ class Run(Base):
         Index("idx_runs_assistant_id", "assistant_id"),
         Index("idx_runs_created_at", "created_at"),
         Index("idx_runs_lease_reaper", "status", "lease_expires_at"),
+        # Per-thread multitask admission + FIFO queued-run dispatch.
+        Index("idx_runs_thread_status_created", "thread_id", "status", "created_at"),
     )
 
 

--- a/libs/aegra-api/src/aegra_api/models/crons.py
+++ b/libs/aegra-api/src/aegra_api/models/crons.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from aegra_api.models.enums import MultitaskStrategy
 from aegra_api.settings import settings
 
 # Field length caps. Keep these conservative; cron metadata is small by nature.
@@ -55,7 +56,7 @@ class CronCreate(BaseModel):
     interrupt_after: Literal["*"] | list[str] | None = None
     webhook: str | None = Field(None, max_length=_WEBHOOK_MAX_LEN)
     on_run_completed: OnRunCompleted | None = None
-    multitask_strategy: str | None = Field(None, max_length=_STR_FIELD_MAX_LEN)
+    multitask_strategy: MultitaskStrategy | None = Field(None)
     end_time: datetime | None = None
     enabled: bool | None = None
     stream_mode: str | list[str] | None = None
@@ -112,7 +113,7 @@ class CronUpdate(BaseModel):
     interrupt_before: Literal["*"] | list[str] | None = None
     interrupt_after: Literal["*"] | list[str] | None = None
     on_run_completed: OnRunCompleted | None = None
-    multitask_strategy: str | None = Field(None, max_length=_STR_FIELD_MAX_LEN)
+    multitask_strategy: MultitaskStrategy | None = Field(None)
     enabled: bool | None = None
     stream_mode: str | list[str] | None = None
     stream_subgraphs: bool | None = None

--- a/libs/aegra-api/src/aegra_api/models/enums.py
+++ b/libs/aegra-api/src/aegra_api/models/enums.py
@@ -2,7 +2,8 @@
 
 from typing import Literal
 
-# Run status enum
+# Run status enum (API wire vocabulary — matches the LangGraph SDK). The internal
+# double-texting park state 'queued' is persisted-only and reported as 'pending'.
 RunStatus = Literal[
     "pending",
     "running",
@@ -27,3 +28,7 @@ MultitaskStrategy = Literal[
     "interrupt",
     "enqueue",
 ]
+
+# Applied when a run is created without an explicit multitask_strategy.
+# Matches LangGraph Platform's documented default (enqueue).
+MULTITASK_DEFAULT: MultitaskStrategy = "enqueue"

--- a/libs/aegra-api/src/aegra_api/models/run_job.py
+++ b/libs/aegra-api/src/aegra_api/models/run_job.py
@@ -43,6 +43,9 @@ class RunExecution(BaseModel):
     command: dict[str, Any] | None = None
     # When true, stream via the native v3 protocol producer for Agent Protocol v2.
     event_streaming_v2: bool = False
+    # rollback multitask: id of the prior run to revert. The worker resolves the
+    # pre-run base checkpoint by it and forks this run from there (no deletes).
+    rollback_target_run_id: str | None = None
 
 
 class RunBehavior(BaseModel):

--- a/libs/aegra-api/src/aegra_api/models/runs.py
+++ b/libs/aegra-api/src/aegra_api/models/runs.py
@@ -12,6 +12,7 @@ from pydantic import (
     model_validator,
 )
 
+from aegra_api.models.enums import MultitaskStrategy
 from aegra_api.utils.status_compat import validate_run_status
 
 # Constraints for ``RunCreate.metadata`` keys/values, enforced at request
@@ -52,9 +53,15 @@ class RunCreate(BaseModel):
         description="Behavior after stateless run completes: 'delete' (default) removes the ephemeral thread, 'keep' preserves it.",
     )
 
-    multitask_strategy: str | None = Field(
+    multitask_strategy: MultitaskStrategy | None = Field(
         None,
-        description="Strategy for handling concurrent runs on same thread: 'reject', 'interrupt', 'rollback', or 'enqueue'.",
+        description="How to handle a new run when the thread already has an active run. "
+        "'enqueue' (default) queues it to run after; 'reject' returns 409; "
+        "'interrupt' cancels the active run then starts this one; 'rollback' cancels the active "
+        "run (kept as interrupted) — or, with no active run, reverts the last run only if it was "
+        "left interrupted/errored (repairing a broken thread; a completed run is untouched) — then "
+        "forks this run from the checkpoint preceding it, reverting that run's writes. None defaults "
+        "to 'enqueue'.",
     )
 
     # Human-in-the-loop fields (core HITL functionality)
@@ -144,7 +151,9 @@ class RunCreate(BaseModel):
 class Run(BaseModel):
     """Run entity model
 
-    Status values: pending, running, error, success, timeout, interrupted
+    Status values: pending, running, error, success, timeout, interrupted.
+    A run parked behind another run (double-texting enqueue) is internally
+    'queued' and reported as 'pending', matching the LangGraph SDK vocabulary.
     """
 
     model_config = ConfigDict(from_attributes=True)
@@ -153,7 +162,8 @@ class Run(BaseModel):
     thread_id: str = Field(..., description="Thread this run belongs to.")
     assistant_id: str = Field(..., description="Assistant that is executing this run.")
     status: str = Field(
-        "pending", description="Current run status: pending, running, error, success, timeout, or interrupted."
+        "pending",
+        description="Current run status: pending (includes runs enqueued behind another run), running, error, success, timeout, or interrupted.",
     )
     input: dict[str, Any] | None = Field(
         None, description="Input data provided to the run. None for checkpoint-only resume."
@@ -178,6 +188,10 @@ class Run(BaseModel):
         """Validate status conforms to API specification."""
         if not isinstance(v, str):
             raise ValueError(f"Status must be a string, got {type(v)}")
+        # 'queued' is internal (double-texting park state); the LangGraph SDK's closed
+        # RunStatus vocabulary has no such value, so the wire reports it as 'pending'.
+        if v == "queued":
+            return "pending"
         return validate_run_status(v)
 
 

--- a/libs/aegra-api/src/aegra_api/services/base_executor.py
+++ b/libs/aegra-api/src/aegra_api/services/base_executor.py
@@ -5,12 +5,28 @@ one interface, two backends (local asyncio tasks vs Redis workers).
 """
 
 from abc import ABC, abstractmethod
+from datetime import UTC, datetime
 
+import structlog
+from sqlalchemy import select, update
+
+from aegra_api.core.orm import Run as RunORM
+from aegra_api.core.orm import Thread as ThreadORM
+from aegra_api.core.orm import _get_session_maker
 from aegra_api.models.run_job import RunJob
+
+logger = structlog.getLogger(__name__)
+
+_OCCUPYING_RUN_STATUSES = ("running", "pending")
 
 
 class BaseExecutor(ABC):
     """Dispatches RunJobs for execution and tracks their lifecycle."""
+
+    # Cleared in stop() so a run finalizing during shutdown does not promote a
+    # queued run that would be orphaned when the process exits. Queued runs are
+    # picked up on the next start by recovery instead.
+    _accepting: bool = True
 
     @abstractmethod
     async def submit(self, job: RunJob) -> None:
@@ -27,3 +43,61 @@ class BaseExecutor(ABC):
     @abstractmethod
     async def stop(self) -> None:
         """Drain in-flight work and release resources (called during shutdown)."""
+
+    async def dispatch_next_for_thread(self, thread_id: str) -> None:
+        """Promote the oldest queued run on a thread and submit it.
+
+        Called after a run finalizes to start the next double-texted run.
+        Locks the thread row so concurrent finalizes/reapers can't double
+        dispatch, and no-ops if another run is already occupying the thread.
+        """
+        if not self._accepting:
+            return
+        maker = _get_session_maker()
+        async with maker() as session:
+            thread = await session.scalar(select(ThreadORM).where(ThreadORM.thread_id == thread_id).with_for_update())
+            if thread is not None and thread.status == "interrupted":
+                # Thread is paused on a human-in-the-loop interrupt(). Promoting a queued
+                # fresh-input run would run it against the paused checkpoint and consume the
+                # pending interrupt — the admission 409 guard only covers run creation, so the
+                # guard must also hold here. Leave queued runs parked until a resume clears it.
+                return
+            occupying = await session.scalar(
+                select(RunORM.run_id)
+                .where(RunORM.thread_id == thread_id, RunORM.status.in_(_OCCUPYING_RUN_STATUSES))
+                .limit(1)
+            )
+            if occupying is not None:
+                # Heal a stale 'idle' a pre-empted run's finalize may have written.
+                await session.execute(
+                    update(ThreadORM)
+                    .where(ThreadORM.thread_id == thread_id)
+                    .values(status="busy", updated_at=datetime.now(UTC))
+                )
+                await session.commit()
+                return
+
+            run_orm = await session.scalar(
+                select(RunORM)
+                .where(RunORM.thread_id == thread_id, RunORM.status == "queued")
+                .order_by(RunORM.created_at.asc())
+                .limit(1)
+                .with_for_update(skip_locked=True)
+            )
+            if run_orm is None:
+                return
+
+            run_orm.status = "pending"
+            # Stamp updated_at so the stuck-pending reaper measures time since promotion,
+            # not since the run was first queued (created_at), and skips fresh promotions.
+            run_orm.updated_at = datetime.now(UTC)
+            await session.execute(
+                update(ThreadORM)
+                .where(ThreadORM.thread_id == thread_id)
+                .values(status="busy", updated_at=datetime.now(UTC))
+            )
+            job = RunJob.from_run_orm(run_orm)
+            await session.commit()
+
+        logger.info("Dispatched queued run", run_id=job.identity.run_id, thread_id=thread_id)
+        await self.submit(job)

--- a/libs/aegra-api/src/aegra_api/services/cron_scheduler.py
+++ b/libs/aegra-api/src/aegra_api/services/cron_scheduler.py
@@ -15,6 +15,7 @@ Follows the same ``start()/stop()`` lifecycle pattern used by
 import asyncio
 import contextlib
 from datetime import UTC, datetime
+from typing import get_args
 from uuid import uuid4
 
 import structlog
@@ -25,6 +26,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from aegra_api.core.orm import Cron as CronORM
 from aegra_api.core.orm import _get_session_maker
 from aegra_api.models import RunCreate, User
+from aegra_api.models.enums import MultitaskStrategy
 from aegra_api.services.cron_service import (
     CronService,
     should_delete_stateless_thread,
@@ -34,6 +36,8 @@ from aegra_api.services.run_preparation import _prepare_run
 from aegra_api.settings import settings
 
 logger = structlog.getLogger(__name__)
+
+_VALID_MULTITASK = frozenset(get_args(MultitaskStrategy))
 
 
 # Backwards-compat re-export. ``cron_scheduler.py`` previously exposed this
@@ -51,6 +55,11 @@ def _build_run_create(cron: CronORM) -> RunCreate:
     two code paths can never drift.
     """
     payload = cron.payload or {}
+    # Coerce a legacy/invalid stored strategy to None (-> default) so building the
+    # RunCreate can never raise mid-fire and wedge the cron in a claim/expire loop.
+    strategy = payload.get("multitask_strategy")
+    if strategy not in _VALID_MULTITASK:
+        strategy = None
     return RunCreate(
         assistant_id=cron.assistant_id,
         input=payload.get("input"),
@@ -61,7 +70,7 @@ def _build_run_create(cron: CronORM) -> RunCreate:
         interrupt_after=payload.get("interrupt_after"),
         stream_subgraphs=payload.get("stream_subgraphs"),
         stream_mode=payload.get("stream_mode"),
-        multitask_strategy=payload.get("multitask_strategy"),
+        multitask_strategy=strategy,
         # Cron metadata_dict is stored on the cron record for search/filter, not
         # forwarded onto fired runs. Re-wire here if run-level tagging is needed.
         metadata=None,

--- a/libs/aegra-api/src/aegra_api/services/event_streaming/commands.py
+++ b/libs/aegra-api/src/aegra_api/services/event_streaming/commands.py
@@ -9,6 +9,7 @@ identical; only the transport differs.
 
 from __future__ import annotations
 
+import asyncio
 import re
 from typing import Any
 
@@ -20,10 +21,15 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from aegra_api.core.orm import Run as RunORM
 from aegra_api.core.orm import Thread as ThreadORM
+from aegra_api.core.orm import _get_session_maker
 from aegra_api.models import User
 from aegra_api.models.runs import RunCreate
 from aegra_api.services.event_streaming.protocol import ErrorCode, build_error, build_success
-from aegra_api.services.run_preparation import _prepare_run
+from aegra_api.services.run_preparation import (
+    _RESUME_SETTLE_ATTEMPTS,
+    _RESUME_SETTLE_INTERVAL_SECONDS,
+    _prepare_run,
+)
 
 logger = structlog.getLogger(__name__)
 
@@ -108,7 +114,7 @@ async def _run_start(
     # would discard the pending tasks.
     input_data = params.get("input")
     command: dict[str, Any] | None = None
-    if input_data is not None and await _thread_is_interrupted(session, thread_id, user):
+    if input_data is not None and await _thread_interrupted_with_settle(session, thread_id, user):
         command = {"resume": input_data}
         input_data = None
 
@@ -135,6 +141,43 @@ async def _thread_is_interrupted(session: AsyncSession, thread_id: str, user: Us
         select(ThreadORM.status).where(ThreadORM.thread_id == thread_id, ThreadORM.user_id == user.identity)
     )
     return status == "interrupted"
+
+
+async def _thread_interrupted_with_settle(session: AsyncSession, thread_id: str, user: User) -> bool:
+    """Interrupt check for run.start input classification, settle-aware.
+
+    The interrupt event reaches the client (via the broker) before finalize_run
+    commits thread_status='interrupted' (see run_preparation's settle note). A client
+    answering the instant it sees the interrupt would be misclassified as fresh input
+    and parked behind the pause forever — so when a run is still in flight, poll fresh
+    sessions for the commit before deciding.
+    """
+    if await _thread_is_interrupted(session, thread_id, user):
+        return True
+    in_flight = await session.scalar(
+        select(RunORM.run_id)
+        .where(
+            RunORM.thread_id == thread_id,
+            RunORM.user_id == user.identity,
+            RunORM.status.in_(("running", "pending")),
+        )
+        .limit(1)
+    )
+    if in_flight is None:
+        return False
+    maker = _get_session_maker()
+    thread_stmt = select(ThreadORM.status).where(ThreadORM.thread_id == thread_id, ThreadORM.user_id == user.identity)
+    for _ in range(_RESUME_SETTLE_ATTEMPTS):
+        await asyncio.sleep(_RESUME_SETTLE_INTERVAL_SECONDS)
+        async with maker() as fresh:
+            status = await fresh.scalar(thread_stmt)
+        if status == "interrupted":
+            return True
+        if status != "busy":
+            # Settled to idle/error: the in-flight run finished without pausing,
+            # so this input is a genuine fresh turn.
+            return False
+    return False
 
 
 # langgraph interrupt ids are xxh3-128 hexdigests; a resume map is only

--- a/libs/aegra-api/src/aegra_api/services/event_streaming/session.py
+++ b/libs/aegra-api/src/aegra_api/services/event_streaming/session.py
@@ -100,6 +100,11 @@ class ThreadEventSession:
         while True:
             progressed = False
             for run_id, run_status, graph_name in await self._fresh_runs():
+                if run_status == "queued":
+                    # A parked double-text has no task and publishes no broker events, so
+                    # draining it would wedge on an empty broker. Defer it to a later tick:
+                    # it re-lists as pending/running once promoted, or terminal if dropped.
+                    continue
                 async for envelope in self._drain_run(run_id, run_status, graph_name):
                     progressed = True
                     yield envelope

--- a/libs/aegra-api/src/aegra_api/services/lease_reaper.py
+++ b/libs/aegra-api/src/aegra_api/services/lease_reaper.py
@@ -13,6 +13,7 @@ from datetime import UTC, datetime, timedelta
 import structlog
 from redis import RedisError
 from sqlalchemy import select, update
+from sqlalchemy.exc import SQLAlchemyError
 
 from aegra_api.core.orm import Run as RunORM
 from aegra_api.core.orm import _get_session_maker
@@ -61,9 +62,6 @@ class LeaseReaper:
         """Find crashed workers and stuck pending runs, recover them."""
         crashed, stuck_pending = await self._find_recoverable()
 
-        if not crashed and not stuck_pending:
-            return
-
         # Crashed workers: reset first (atomic claim), then check retries
         if crashed:
             logger.warning("Reaping crashed worker runs", count=len(crashed), run_ids=crashed)
@@ -80,11 +78,59 @@ class LeaseReaper:
             logger.warning("Re-enqueueing stuck pending runs", count=len(stuck_pending), run_ids=stuck_pending)
             await self._reenqueue(stuck_pending)
 
+        # Stranded queued: a prior run's dispatch wakeup was lost (process died,
+        # or its head run was just permanently-failed above). Detect AFTER the
+        # crashed/stuck handling so a freshly-failed head's successor is caught
+        # this cycle, not the next. Restart the queue.
+        stranded_queued = await self._find_stranded_queued_threads()
+        if stranded_queued:
+            logger.warning("Dispatching stranded queued runs", thread_count=len(stranded_queued))
+            await self._dispatch_stranded_queued(stranded_queued)
+
+        if not crashed and not stuck_pending and not stranded_queued:
+            return
+
         logger.info(
             "Lease recovery complete",
             crashed_recovered=len(crashed),
             stuck_reenqueued=len(stuck_pending),
+            stranded_dispatched=len(stranded_queued),
         )
+
+    @staticmethod
+    async def _find_stranded_queued_threads() -> list[str]:
+        """Threads with a queued run but no running/pending run holding them."""
+        maker = _get_session_maker()
+        async with maker() as session:
+            queued = {
+                row[0]
+                for row in (
+                    await session.execute(select(RunORM.thread_id).where(RunORM.status == "queued").distinct())
+                ).all()
+            }
+            if not queued:
+                return []
+            active = {
+                row[0]
+                for row in (
+                    await session.execute(
+                        select(RunORM.thread_id).where(RunORM.status.in_(("running", "pending"))).distinct()
+                    )
+                ).all()
+            }
+            return list(queued - active)
+
+    @staticmethod
+    async def _dispatch_stranded_queued(thread_ids: list[str]) -> None:
+        # Deferred import: executor -> run_executor -> run_status, none of which
+        # may import lease_reaper at module load.
+        from aegra_api.services.executor import executor
+
+        for thread_id in thread_ids:
+            try:
+                await executor.dispatch_next_for_thread(thread_id)
+            except (RedisError, SQLAlchemyError):
+                logger.exception("Failed to dispatch stranded queued run", thread_id=thread_id)
 
     @staticmethod
     async def _find_recoverable() -> tuple[list[str], list[str]]:
@@ -109,7 +155,9 @@ class LeaseReaper:
                 select(RunORM.run_id).where(
                     RunORM.status == "pending",
                     RunORM.claimed_by.is_(None),
-                    RunORM.created_at < now - timedelta(seconds=settings.worker.STUCK_PENDING_THRESHOLD_SECONDS),
+                    # updated_at, not created_at: a queued run promoted to pending keeps its
+                    # original created_at, so created_at would flag fresh promotions as stuck.
+                    RunORM.updated_at < now - timedelta(seconds=settings.worker.STUCK_PENDING_THRESHOLD_SECONDS),
                 )
             )
             stuck_pending = [row[0] for row in stuck_result.fetchall()]

--- a/libs/aegra-api/src/aegra_api/services/local_executor.py
+++ b/libs/aegra-api/src/aegra_api/services/local_executor.py
@@ -6,15 +6,33 @@ as background coroutines in the same event loop as the API server.
 
 import asyncio
 import contextlib
+from datetime import UTC, datetime
+from typing import Any, cast
 
 import structlog
+from sqlalchemy import CursorResult, select, update
+from sqlalchemy.exc import SQLAlchemyError
 
 from aegra_api.core.active_runs import active_runs
+from aegra_api.core.orm import Run as RunORM
+from aegra_api.core.orm import Thread as ThreadORM
+from aegra_api.core.orm import _get_session_maker
 from aegra_api.models.run_job import RunJob
 from aegra_api.observability.span_enrichment import make_run_trace_context
 from aegra_api.services.base_executor import BaseExecutor
 
 logger = structlog.getLogger(__name__)
+
+_TERMINAL_STATUSES = frozenset({"success", "error", "interrupted"})
+_STRANDED_SWEEP_INTERVAL_SECONDS = 30
+
+
+async def _is_run_terminal(run_id: str) -> bool:
+    """True if the run reached a terminal state (or no longer exists)."""
+    maker = _get_session_maker()
+    async with maker() as session:
+        status = await session.scalar(select(RunORM.status).where(RunORM.run_id == run_id))
+    return status is None or status in _TERMINAL_STATUSES
 
 
 class LocalExecutor(BaseExecutor):
@@ -41,16 +59,126 @@ class LocalExecutor(BaseExecutor):
         )
 
     async def wait_for_completion(self, run_id: str, *, timeout: float = 300.0) -> None:
-        task = active_runs.get(run_id)
-        if task is None:
-            return
-        with contextlib.suppress(TimeoutError, asyncio.CancelledError):
-            await asyncio.wait_for(asyncio.shield(task), timeout=timeout)
+        # A run may still be 'queued' (no task yet) — poll until it is dispatched
+        # (a task appears) or reaches a terminal state, so join/wait don't return
+        # an empty result for a double-texted run that hasn't started.
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + timeout
+        poll_count = 0
+        while loop.time() < deadline:
+            task = active_runs.get(run_id)
+            if task is not None:
+                with contextlib.suppress(TimeoutError, asyncio.CancelledError):
+                    await asyncio.wait_for(asyncio.shield(task), timeout=max(0.0, deadline - loop.time()))
+                return
+            # In-memory active_runs is checked every tick; the DB probe (for a
+            # still-queued or already-terminal run) only every other tick.
+            poll_count += 1
+            if poll_count % 2 == 0 and await _is_run_terminal(run_id):
+                return
+            await asyncio.sleep(0.5)
 
     async def start(self) -> None:
+        self._accepting = True
         logger.info("Local executor started (in-process asyncio tasks)")
+        await self._recover_orphaned_queue()
+        self._sweep_task = asyncio.create_task(self._stranded_queue_loop())
+
+    async def _stranded_queue_loop(self) -> None:
+        """Periodically dispatch threads stranded with a queued run but nothing running.
+
+        Mirrors the prod lease reaper: in dev a swallowed finalize-time dispatch failure
+        would otherwise wedge a queued run until the next restart.
+        """
+        while self._accepting:
+            try:
+                await asyncio.sleep(_STRANDED_SWEEP_INTERVAL_SECONDS)
+            except asyncio.CancelledError:
+                break
+            if not self._accepting:
+                break
+            # Catch-all (like the prod reaper's loop) so a corrupt-params row or any other
+            # non-SQLAlchemyError cannot permanently kill the periodic recovery task.
+            try:
+                await self._sweep_stranded_queues()
+            except Exception:
+                logger.exception("Stranded-queue sweep failed")
+
+    async def _sweep_stranded_queues(self) -> None:
+        """Re-dispatch every thread holding a queued run (a no-op when one is occupying)."""
+        maker = _get_session_maker()
+        async with maker() as session:
+            threads = {
+                row[0]
+                for row in (
+                    await session.execute(select(RunORM.thread_id).where(RunORM.status == "queued").distinct())
+                ).all()
+            }
+        for thread_id in threads:
+            # Per-thread isolation: one bad row must not abort recovery for the rest.
+            try:
+                await self.dispatch_next_for_thread(thread_id)
+            except Exception:
+                logger.exception("Stranded-queue dispatch failed", thread_id=thread_id)
+
+    async def _recover_orphaned_queue(self) -> None:
+        """Recover threads with in-flight or queued runs after a restart.
+
+        A fresh dev process has no live tasks, so any running/pending run is an
+        orphan from the dead process. For each affected thread, fail the orphaned
+        run (so the thread isn't wedged forever, esp. under reject) and dispatch
+        the next queued run, if any.
+        """
+        maker = _get_session_maker()
+        async with maker() as session:
+            threads = {
+                row[0]
+                for row in (
+                    await session.execute(
+                        select(RunORM.thread_id).where(RunORM.status.in_(("queued", "running", "pending"))).distinct()
+                    )
+                ).all()
+            }
+        if not threads:
+            return
+
+        logger.warning("Recovering threads after restart", thread_count=len(threads))
+        for thread_id in threads:
+            try:
+                async with maker() as session:
+                    result = cast(
+                        "CursorResult[Any]",
+                        await session.execute(
+                            update(RunORM)
+                            .where(RunORM.thread_id == thread_id, RunORM.status.in_(("running", "pending")))
+                            .values(
+                                status="error",
+                                error_message="Orphaned by server restart",
+                                updated_at=datetime.now(UTC),
+                            )
+                        ),
+                    )
+                    if result.rowcount > 0:
+                        # The orphans' finalizes never ran: reset the thread the way an error
+                        # finalize would have, so it is not left 'busy' with no active run.
+                        # Queued-only threads match nothing here, preserving a HITL pause.
+                        await session.execute(
+                            update(ThreadORM)
+                            .where(ThreadORM.thread_id == thread_id)
+                            .values(status="error", updated_at=datetime.now(UTC))
+                        )
+                    await session.commit()
+                await self.dispatch_next_for_thread(thread_id)
+            except SQLAlchemyError:
+                logger.exception("Failed to recover thread after restart", thread_id=thread_id)
 
     async def stop(self) -> None:
+        self._accepting = False
+        sweep_task = getattr(self, "_sweep_task", None)
+        if sweep_task is not None:
+            sweep_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await sweep_task
         tasks_to_cancel = [task for task in active_runs.values() if not task.done()]
         for task in tasks_to_cancel:
             task.cancel()

--- a/libs/aegra-api/src/aegra_api/services/run_cleanup.py
+++ b/libs/aegra-api/src/aegra_api/services/run_cleanup.py
@@ -39,7 +39,7 @@ async def delete_thread_by_id(thread_id: str, user_id: str) -> None:
         active_runs_stmt = select(RunORM).where(
             RunORM.thread_id == thread_id,
             RunORM.user_id == user_id,
-            RunORM.status.in_(["pending", "running"]),
+            RunORM.status.in_(["queued", "pending", "running"]),
         )
         active_runs_list = (await session.scalars(active_runs_stmt)).all()
 

--- a/libs/aegra-api/src/aegra_api/services/run_executor.py
+++ b/libs/aegra-api/src/aegra_api/services/run_executor.py
@@ -14,12 +14,13 @@ import structlog
 from aegra_api.core.active_runs import active_runs
 from aegra_api.core.auth_ctx import with_auth_ctx
 from aegra_api.core.redis_manager import redis_manager
+from aegra_api.models.auth import User
 from aegra_api.models.run_job import RunJob
 from aegra_api.services.broker import broker_manager
 from aegra_api.services.event_streaming.native_stream import stream_native_v3_events
 from aegra_api.services.graph_streaming import stream_graph_events
-from aegra_api.services.langgraph_service import create_run_config, get_langgraph_service
-from aegra_api.services.run_status import finalize_run, update_run_status
+from aegra_api.services.langgraph_service import create_run_config, create_thread_config, get_langgraph_service
+from aegra_api.services.run_status import finalize_run, get_run_status, try_mark_run_running
 from aegra_api.services.streaming_service import streaming_service
 from aegra_api.settings import settings
 from aegra_api.utils.run_utils import map_command_to_langgraph
@@ -27,6 +28,10 @@ from aegra_api.utils.run_utils import map_command_to_langgraph
 logger = structlog.getLogger(__name__)
 
 _DEFAULT_STREAM_MODES = ["values"]
+
+# Cap on checkpoints scanned to resolve a rollback base. A single run's checkpoint
+# count (its superstep count) is the bound; 1000 is far above any realistic turn.
+_ROLLBACK_HISTORY_LIMIT = 1000
 
 # Run IDs whose cancellation was triggered by lease loss (not user action).
 # When a heartbeat detects lease loss, it adds the run_id here before
@@ -50,7 +55,12 @@ async def execute_run(job: RunJob) -> None:
     is_lease_loss = False
 
     try:
-        await update_run_status(run_id, "running")
+        if not await try_mark_run_running(run_id):
+            # A multitask gate pre-empted this run between dispatch and start; the gate
+            # owns its status and the thread. Release any waiters and stop here.
+            logger.info("Run pre-empted before start, skipping execution", run_id=run_id)
+            await _best_effort_signal(streaming_service.signal_run_cancelled, run_id)
+            return
 
         final_output = await _stream_graph(job)
 
@@ -144,6 +154,21 @@ async def _stream_graph(job: RunJob) -> _GraphResult:
         ) as graph,
         with_auth_ctx(job.user, job.user.permissions),  # type: ignore[arg-type]
     ):
+        # Deep rollback: fork this run from the checkpoint that preceded the
+        # target run, so the target's writes (and any orphaned tool calls) are
+        # reverted and the graph re-enters via __start__. No checkpoints deleted.
+        if job.execution.rollback_target_run_id and not run_config.get("configurable", {}).get("checkpoint_id"):
+            base = await _rollback_fork_base(graph, job)
+            if base is not None:
+                run_config.setdefault("configurable", {})["checkpoint_id"] = base
+                logger.info(
+                    "Rollback fork from base checkpoint",
+                    run_id=job.identity.run_id,
+                    base_checkpoint_id=base,
+                )
+            else:
+                logger.info("Rollback running fresh (no base checkpoint)", run_id=job.identity.run_id)
+
         if job.execution.event_streaming_v2:
             await _stream_native_v2(job, graph, execution_input, run_config, result)
         else:
@@ -230,6 +255,61 @@ def _build_run_config(job: RunJob) -> dict[str, Any]:
         items = job.behavior.interrupt_after
         config["interrupt_after"] = items if isinstance(items, list) else [items]
     return config
+
+
+async def _rollback_fork_base(graph: Any, job: RunJob) -> str | None:
+    """Checkpoint this rollback run forks from, or None to run without reverting.
+
+    Re-reads the target's CURRENT status so a run that raced to ``success`` after the
+    admission gate marked it interrupted is never reverted (its finalize may commit
+    success after the gate's decision). Otherwise resolves the pre-target base.
+    """
+    target_run_id = job.execution.rollback_target_run_id
+    if target_run_id is None:
+        return None
+    if await get_run_status(target_run_id) == "success":
+        logger.info(
+            "Rollback skipped: target run completed successfully",
+            run_id=job.identity.run_id,
+            target_run_id=target_run_id,
+        )
+        return None
+    return await _resolve_rollback_base(graph, job.identity.thread_id, job.user, target_run_id)
+
+
+async def _resolve_rollback_base(graph: Any, thread_id: str, user: User, target_run_id: str) -> str | None:
+    """Find the checkpoint preceding ``target_run_id`` to fork the rollback from.
+
+    Resolved by LINEAGE: the target run's OLDEST checkpoint's ``parent_config`` points
+    at the clean pre-target state. aegra stamps every checkpoint's metadata with its
+    creating run_id; we scan the whole (bounded) history newest->oldest and keep the
+    OLDEST checkpoint whose run_id is the target. Scanning fully — rather than stopping
+    at the first non-target row — makes the result independent of checkpoint ORDER, so
+    a sibling branch from an earlier rollback, the current run's own partial, or a
+    straggler the cancelled target writes after the fork cannot mis-anchor it. Returns
+    None when the target was the thread's first run (no parent to fork).
+    """
+    history_config = create_thread_config(thread_id, user)
+    history_config.setdefault("configurable", {})["checkpoint_ns"] = ""
+    oldest_target = None
+    seen = 0
+    # Bounded limit pushes a SQL LIMIT so a long thread's full history is not fetched.
+    async for snapshot in graph.aget_state_history(history_config, limit=_ROLLBACK_HISTORY_LIMIT):
+        seen += 1
+        if (snapshot.metadata or {}).get("run_id") == target_run_id:
+            oldest_target = snapshot  # newest->oldest, so the last match is the oldest
+    if oldest_target is None:
+        return None
+    if seen >= _ROLLBACK_HISTORY_LIMIT and oldest_target.parent_config is not None:
+        # The capped window cannot prove the target's lineage is complete — interleaved
+        # sibling rows can end the window while older target checkpoints lie beyond it,
+        # so forking from the oldest IN-WINDOW match could land mid-run. Fail loud. (A
+        # parent-less oldest is provably the root → fall through to return None / fork fresh.)
+        raise RuntimeError(
+            f"rollback base unresolved: run {target_run_id} history exceeds {_ROLLBACK_HISTORY_LIMIT} checkpoints"
+        )
+    parent = oldest_target.parent_config or {}
+    return (parent.get("configurable") or {}).get("checkpoint_id")
 
 
 def _resolve_input(job: RunJob) -> Any:

--- a/libs/aegra-api/src/aegra_api/services/run_preparation.py
+++ b/libs/aegra-api/src/aegra_api/services/run_preparation.py
@@ -20,12 +20,14 @@ from aegra_api.core.orm import Run as RunORM
 from aegra_api.core.orm import Thread as ThreadORM
 from aegra_api.core.orm import _get_session_maker
 from aegra_api.models import Run, RunCreate, User
+from aegra_api.models.enums import MULTITASK_DEFAULT
 from aegra_api.models.run_job import RunBehavior, RunExecution, RunIdentity, RunJob
 from aegra_api.services.executor import executor
 from aegra_api.services.langgraph_service import get_langgraph_service
 from aegra_api.services.run_status import set_thread_status
+from aegra_api.services.streaming_service import streaming_service
 from aegra_api.utils.assistants import resolve_assistant_id
-from aegra_api.utils.run_utils import _merge_jsonb
+from aegra_api.utils.run_utils import _merge_jsonb, map_command_to_langgraph
 
 logger = structlog.getLogger(__name__)
 
@@ -39,34 +41,74 @@ _RESUME_SETTLE_ATTEMPTS = 10
 _RESUME_SETTLE_INTERVAL_SECONDS = 0.1
 
 
-async def _validate_resume_command(session: AsyncSession, thread_id: str, command: dict[str, Any] | None) -> None:
-    """Validate resume command requirements.
+async def _validate_resume_command(
+    session: AsyncSession, thread_id: str, command: dict[str, Any] | None, user: User
+) -> None:
+    """Validate a run's input mode against the thread's interrupt state.
 
-    Guard on the presence of the ``resume`` key, not a non-None value: ``None``
-    is a valid resume payload, and a ``{"resume": None}`` command must still be
-    rejected against a thread that is not interrupted.
+    A command bearing a ``resume`` key requires the thread to be paused, and a
+    ``None`` resume payload is rejected outright: LangGraph's ``map_command``
+    drops it, so the run would produce no writes and crash the pause to 'error'.
+    Symmetrically, a plain fresh-input run (no command) must not land on a thread
+    paused at a human-in-the-loop ``interrupt()``: running plain input there
+    silently consumes the pending interrupt, so reject and direct the caller to
+    resume with a command.
     """
-    if not command or "resume" not in command:
+    if command is not None:
+        # Reject a malformed command shape up front (e.g. {'goto': [0]}) so it can't bypass the
+        # gate and crash to 'error' mid-run — which on a paused thread would corrupt the HITL pause.
+        try:
+            map_command_to_langgraph(command)
+        except (TypeError, KeyError, ValueError, AttributeError) as exc:
+            raise HTTPException(status_code=422, detail=f"Invalid command: {exc}") from exc
+    # Key presence, not a non-None value: {'resume': None} must be gated as a resume
+    # attempt too, or it slips through and errors out mid-run on whatever thread it hits.
+    resume_shaped = command is not None and "resume" in command
+    # Truthiness matches LangGraph's map_command (`if cmd.update:` / `if cmd.goto:`): an
+    # empty container ({'update': {}}, {'goto': []}) produces no writes and would crash a
+    # paused thread to 'error', so it must NOT early-return — it falls through to the gate.
+    state_op = bool(command and (command.get("update") or command.get("goto")))
+    if command is not None and not resume_shaped and state_op:
+        # A deliberate update/goto command manipulates graph state directly and is allowed even
+        # on a paused thread. Safety here leans on two LangGraph behaviours: empty containers are
+        # falsy (so they fall through to the 409 gate, not here), and an unknown goto/Send target
+        # is silently ignored rather than raising. If a future LangGraph version raised on unknown
+        # targets, such a command could crash mid-run and clobber a HITL pause — gate it here then.
         return
 
-    thread_stmt = select(ThreadORM).where(ThreadORM.thread_id == thread_id)
+    thread_stmt = select(ThreadORM).where(ThreadORM.thread_id == thread_id, ThreadORM.user_id == user.identity)
     thread = await session.scalar(thread_stmt)
-    if not thread:
-        raise HTTPException(404, f"Thread '{thread_id}' not found")
-    if thread.status == "interrupted":
+    if resume_shaped:
+        if not thread:
+            raise HTTPException(404, f"Thread '{thread_id}' not found")
+        status = thread.status
+        if status != "interrupted":
+            # Not interrupted on the request session's snapshot — poll fresh sessions in
+            # case finalize_run's commit is still in flight.
+            maker = _get_session_maker()
+            for _ in range(_RESUME_SETTLE_ATTEMPTS):
+                await asyncio.sleep(_RESUME_SETTLE_INTERVAL_SECONDS)
+                async with maker() as fresh:
+                    fresh_thread = await fresh.scalar(thread_stmt)
+                if fresh_thread is not None and fresh_thread.status == "interrupted":
+                    status = "interrupted"
+                    break
+        if status != "interrupted":
+            raise HTTPException(400, "Cannot resume: thread is not in interrupted state")
+        if command is not None and command.get("resume") is None:
+            # map_command drops a None resume; the run would crash the pause to 'error'.
+            raise HTTPException(
+                409,
+                "Thread is paused on a human-in-the-loop interrupt; resume it with "
+                "a non-null command={'resume': ...} payload",
+            )
         return
-
-    # Not interrupted on the request session's snapshot — poll fresh sessions in
-    # case finalize_run's commit is still in flight.
-    maker = _get_session_maker()
-    for _ in range(_RESUME_SETTLE_ATTEMPTS):
-        await asyncio.sleep(_RESUME_SETTLE_INTERVAL_SECONDS)
-        async with maker() as fresh:
-            fresh_thread = await fresh.scalar(thread_stmt)
-        if fresh_thread is not None and fresh_thread.status == "interrupted":
-            return
-
-    raise HTTPException(400, "Cannot resume: thread is not in interrupted state")
+    if thread is not None and thread.status == "interrupted":
+        raise HTTPException(
+            409,
+            "Thread is paused on a human-in-the-loop interrupt; resume it with "
+            "command={'resume': ...} instead of starting a new run",
+        )
 
 
 _THREAD_NAME_MAX_LENGTH = 100
@@ -186,6 +228,115 @@ async def update_thread_metadata(
     )
 
 
+def _is_resume_run(run: RunORM) -> bool:
+    """Whether a run row was created to resume a HITL interrupt (command bears a resume key)."""
+    params = run.execution_params or {}
+    command = (params.get("execution") or {}).get("command")
+    return isinstance(command, dict) and "resume" in command
+
+
+# A run holds (or is queued for) its thread while in one of these states.
+_ACTIVE_RUN_STATUSES = ("running", "pending", "queued")
+# Only an actually-dispatched run has a task/worker to cancel.
+_CANCELLABLE_RUN_STATUSES = ("running", "pending")
+# Terminal states a rollback may target when no run is currently active.
+_TERMINAL_RUN_STATUSES = ("interrupted", "error", "success")
+
+
+async def _apply_multitask_strategy(
+    session: AsyncSession, thread_id: str, strategy: str, user: User, *, is_resume: bool = False
+) -> tuple[bool, list[str], str | None]:
+    """Resolve a new run against the thread's in-flight runs per ``strategy``.
+
+    Locks the thread row ``FOR UPDATE`` (thread-then-run order, matching
+    finalize_run) so concurrent creates serialize. Returns ``(should_run,
+    cancel_ids, rollback_target_run_id)``: should_run is True to execute now,
+    False to park as ``queued``; cancel_ids are runs the caller cancels AFTER
+    commit (so the lock is released before the cancel triggers the run's own
+    finalize); rollback_target_run_id is the prior run whose checkpoints the
+    worker will revert by forking. Raises 409 for reject. interrupt/rollback
+    mark the active run interrupted (no rows are deleted — rollback reverts via
+    a checkpoint fork, leaving the old branch as harmless siblings).
+    """
+    await session.execute(
+        select(ThreadORM.thread_id)
+        .where(ThreadORM.thread_id == thread_id, ThreadORM.user_id == user.identity)
+        .with_for_update()
+    )
+    active = (
+        await session.scalars(
+            select(RunORM)
+            .where(
+                RunORM.thread_id == thread_id,
+                RunORM.user_id == user.identity,
+                RunORM.status.in_(_ACTIVE_RUN_STATUSES),
+            )
+            .order_by(RunORM.created_at.asc())
+        )
+    ).all()
+    if is_resume:
+        # A resume jumps ahead of merely-*queued* runs (it alone can clear a HITL pause), but
+        # must still serialize behind a running/pending run. Checked under the FOR UPDATE lock,
+        # this rejects a second concurrent resume (which unblocks after the first commits its
+        # pending run) so two resumes cannot double-execute on one paused checkpoint.
+        if any(run.status in _CANCELLABLE_RUN_STATUSES for run in active):
+            raise HTTPException(status_code=409, detail=f"Thread '{thread_id}' already has an active run")
+        return True, [], None
+    if not active:
+        # Idle thread: rollback repairs a broken last turn (an interrupted/errored run can
+        # leave an orphaned tool call) but never silently reverts a cleanly completed one.
+        if strategy == "rollback":
+            last = await session.scalar(
+                select(RunORM)
+                .where(
+                    RunORM.thread_id == thread_id,
+                    RunORM.user_id == user.identity,
+                    RunORM.status.in_(_TERMINAL_RUN_STATUSES),
+                )
+                .order_by(RunORM.created_at.desc())
+                .limit(1)
+            )
+            target = last.run_id if last is not None and last.status != "success" else None
+            return True, [], target
+        return True, [], None
+
+    if strategy == "reject":
+        raise HTTPException(status_code=409, detail=f"Thread '{thread_id}' already has an active run")
+    if strategy == "enqueue":
+        return False, [], None
+
+    # interrupt / rollback: abandon all in-flight work (the active run AND any runs the
+    # user double-texted earlier that are still queued), then run the new one now.
+    cancel_ids: list[str] = []
+    rollback_target: str | None = None
+    for run in active:
+        if run.status == "queued":
+            # Parked behind the active run with no task/broker to cancel: drop it from
+            # the queue so it does not execute after the new run (stale double-text).
+            run.status = "interrupted"
+            continue
+        if run.status not in _CANCELLABLE_RUN_STATUSES:
+            continue
+        if _is_resume_run(run):
+            # Cancelling an in-flight resume and running fresh input would land the new
+            # run on the pending-interrupt checkpoint, silently consuming the HITL pause.
+            raise HTTPException(
+                status_code=409,
+                detail="Thread has a resume in flight for a pending interrupt; "
+                "wait for it to settle instead of pre-empting it",
+            )
+        cancel_ids.append(run.run_id)
+        run.status = "interrupted"
+        # Release the lease with the pre-emption so a prod worker whose pub/sub cancel
+        # is lost detects lease loss on its next heartbeat and self-cancels the job.
+        run.claimed_by = None
+        run.lease_expires_at = None
+        # The rollback target is the run that actually executed, never a queued one.
+        if strategy == "rollback" and rollback_target is None:
+            rollback_target = run.run_id
+    return True, cancel_ids, rollback_target
+
+
 async def _prepare_run(
     session: AsyncSession,
     thread_id: str,
@@ -201,7 +352,7 @@ async def _prepare_run(
     builds a RunJob, submits it to the executor, and returns the triple
     ``(run_id, run_model, job)``.
     """
-    await _validate_resume_command(session, thread_id, request.command)
+    await _validate_resume_command(session, thread_id, request.command, user)
 
     run_id = str(uuid4())
     langgraph_service = get_langgraph_service()
@@ -250,6 +401,27 @@ async def _prepare_run(
     )
     await set_thread_status(session, thread_id, "busy")
 
+    # Resolve double-texting: run now, queue behind the active run, reject, or
+    # interrupt/rollback the active run. None defaults to enqueue.
+    strategy = request.multitask_strategy or MULTITASK_DEFAULT
+    is_resume = bool(request.command and request.command.get("resume") is not None)
+    should_run, cancel_ids, rollback_target = await _apply_multitask_strategy(
+        session, thread_id, strategy, user, is_resume=is_resume
+    )
+    run_status = initial_status if should_run else "queued"
+
+    # rollback only makes sense for a fresh dict-input run (not a resume/command
+    # or an explicit client checkpoint, which target state themselves).
+    rollback_target_run_id = (
+        rollback_target
+        if strategy == "rollback"
+        and rollback_target is not None
+        and isinstance(request.input, dict)
+        and request.command is None
+        and request.checkpoint is None
+        else None
+    )
+
     # Build the RunJob before persisting so we can store execution_params
     job = RunJob(
         identity=RunIdentity(run_id=run_id, thread_id=thread_id, graph_id=assistant.graph_id),
@@ -262,6 +434,7 @@ async def _prepare_run(
             checkpoint=request.checkpoint,
             command=request.command,
             event_streaming_v2=event_streaming_v2,
+            rollback_target_run_id=rollback_target_run_id,
         ),
         behavior=RunBehavior(
             interrupt_before=request.interrupt_before,
@@ -288,7 +461,7 @@ async def _prepare_run(
         run_id=run_id,
         thread_id=thread_id,
         assistant_id=resolved_assistant_id,
-        status=initial_status,
+        status=run_status,
         input=request.input,  # preserve None for checkpoint-only resume; matches RunExecution.input_data
         config=config,
         context=context,
@@ -304,8 +477,18 @@ async def _prepare_run(
 
     run = Run.model_validate(run_orm)
 
-    # Submit to executor
-    await executor.submit(job)
-    logger.info("Submitted run to executor", run_id=run_id)
+    # Cancel pre-empted runs after commit so the thread lock is released before
+    # the cancel triggers their finalize (which also locks the thread row). The
+    # cancel is fire-and-forget, so a rolled-back active run may write one late
+    # checkpoint that briefly out-orders the new run's head in GET state until it
+    # stops — harmless: the rollback fork resolves its base by run_id, not by head.
+    for cancelled_id in cancel_ids:
+        await streaming_service.cancel_run(cancelled_id)
+
+    if should_run:
+        await executor.submit(job)
+        logger.info("Submitted run to executor", run_id=run_id)
+    else:
+        logger.info("Run queued behind active run", run_id=run_id, thread_id=thread_id)
 
     return run_id, run, job

--- a/libs/aegra-api/src/aegra_api/services/run_status.py
+++ b/libs/aegra-api/src/aegra_api/services/run_status.py
@@ -10,7 +10,7 @@ from datetime import UTC, datetime
 from typing import Any, cast
 
 import structlog
-from sqlalchemy import CursorResult, update
+from sqlalchemy import CursorResult, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from aegra_api.core.orm import Run as RunORM
@@ -21,6 +21,17 @@ from aegra_api.utils.status_compat import validate_run_status, validate_thread_s
 
 logger = structlog.getLogger(__name__)
 _serializer = GeneralSerializer()
+
+
+async def get_run_status(run_id: str) -> str | None:
+    """Return a run's current status, or None if the run no longer exists.
+
+    Used at rollback-fork time to re-read the target's status, so a run that
+    raced to success after the admission gate is not reverted.
+    """
+    maker = _get_session_maker()
+    async with maker() as session:
+        return await session.scalar(select(RunORM.status).where(RunORM.run_id == run_id))
 
 
 async def update_run_status(
@@ -52,6 +63,69 @@ async def update_run_status(
         await session.commit()
 
 
+async def try_mark_run_running(run_id: str) -> bool:
+    """CAS a run to ``running``; False when it is no longer pending/running.
+
+    A run the multitask gate pre-empted between dispatch and start must not
+    resurrect itself — the gate owns its terminal status, and a resurrected run's
+    finalize would stomp thread state the newer run now owns.
+    """
+    maker = _get_session_maker()
+    async with maker() as session:
+        result = cast(
+            "CursorResult[Any]",
+            await session.execute(
+                update(RunORM)
+                .where(RunORM.run_id == run_id, RunORM.status.in_(("pending", "running")))
+                .values(status="running", updated_at=datetime.now(UTC))
+            ),
+        )
+        await session.commit()
+    return result.rowcount > 0
+
+
+async def terminalize_user_cancel(run_id: str, thread_id: str) -> None:
+    """Converge a user-initiated cancel: unpark a queued run, else finalize an active one.
+
+    A queued run holds no task and does not occupy the thread, so a guarded status
+    flip suffices — but if it was the head of a stranded queue (its active predecessor
+    already gone), the runs parked behind it must not wait for the recovery sweep, so
+    dispatch follows the unpark. An active run needs the full finalize (thread reset +
+    next-queued dispatch); the CAS inside finalize_run makes this race benignly with
+    the run task's own finalize — exactly one caller wins and performs the duties.
+    """
+    maker = _get_session_maker()
+    async with maker() as session:
+        result = cast(
+            "CursorResult[Any]",
+            await session.execute(
+                update(RunORM)
+                .where(RunORM.run_id == run_id, RunORM.status == "queued")
+                .values(status="interrupted", updated_at=datetime.now(UTC))
+            ),
+        )
+        await session.commit()
+    if result.rowcount > 0:
+        logger.info("Cancelled queued run", run_id=run_id)
+        # Idempotent: no-ops when a run occupies the thread or a HITL pause holds it.
+        # Deferred import breaks the run_status <- executor <- run_executor cycle.
+        from aegra_api.services.executor import executor
+
+        try:
+            await executor.dispatch_next_for_thread(thread_id)
+        except Exception:  # intentionally broad — the cancel itself is already committed
+            logger.exception("Failed to dispatch next queued run", thread_id=thread_id)
+        return
+    await finalize_run(
+        run_id,
+        thread_id,
+        status="interrupted",
+        thread_status="idle",
+        output={},
+        clear_lease=True,
+    )
+
+
 async def set_thread_status(session: AsyncSession, thread_id: str, status: str) -> None:
     """Update a thread's status column.
 
@@ -79,11 +153,25 @@ async def finalize_run(
     thread_status: str,
     output: Any = None,
     error: str | None = None,
+    allow_terminal_override: bool = False,
+    claimed_by: str | None = None,
+    clear_lease: bool = False,
 ) -> None:
     """Update run status + thread status in a single transaction.
 
     Batches two UPDATE statements into one DB round-trip instead of
     opening separate sessions for update_run_status and set_thread_status.
+
+    The run UPDATE only matches a still-active run (``running``/``pending``) so a
+    run a multitask gate already moved to ``interrupted`` cannot be resurrected by
+    its own late finalize. If it matches nothing, this finalize does not own the run,
+    so the thread row and queue dispatch are left untouched (another run owns them).
+    ``allow_terminal_override`` lifts the active-run filter for the authoritative late
+    corrector (the worker timeout handler), which must overwrite a terminal status.
+    ``claimed_by`` narrows the override to runs still leased by that worker, so the
+    corrector cannot stomp an 'interrupted' a multitask gate wrote (gate cancels
+    clear the lease). ``clear_lease`` releases the lease with the terminal write so a
+    worker whose pub/sub cancel was lost self-cancels on its next heartbeat.
     """
     validated_run = validate_run_status(status)
     validated_thread = validate_thread_status(thread_status)
@@ -97,9 +185,33 @@ async def finalize_run(
         run_values["output"] = _safe_serialize(output, run_id)
     if error is not None:
         run_values["error_message"] = error
+    if clear_lease:
+        run_values["claimed_by"] = None
+        run_values["lease_expires_at"] = None
 
     async with maker() as session:
-        await session.execute(update(RunORM).where(RunORM.run_id == run_id).values(**run_values))
+        # Lock the thread row FIRST so finalize and the create-time multitask gate
+        # (which also locks thread-then-run) share one lock order — without this
+        # an interrupt/rollback create racing this finalize deadlocks (40P01).
+        await session.execute(select(ThreadORM.thread_id).where(ThreadORM.thread_id == thread_id).with_for_update())
+        # The corrector (timeout) may overwrite the cancel handler's 'interrupted', but never a
+        # committed 'success'/'error' — so even override only widens the set, never drops the filter.
+        overwritable = ("running", "pending", "interrupted") if allow_terminal_override else ("running", "pending")
+        conditions = [RunORM.run_id == run_id, RunORM.status.in_(overwritable)]
+        if claimed_by is not None:
+            conditions.append(RunORM.claimed_by == claimed_by)
+        # DML execute() returns a CursorResult at runtime; cast so ``.rowcount`` is reachable.
+        run_result = cast(
+            "CursorResult[Any]",
+            await session.execute(update(RunORM).where(*conditions).values(**run_values)),
+        )
+        if run_result.rowcount == 0:
+            # This finalize does not own the run (a multitask gate already terminalized it):
+            # leave the thread row and the queue alone — another run owns them now. Critically,
+            # this prevents a late pre-empted finalize from stomping a HITL pause back to 'idle'.
+            await session.commit()
+            logger.info("Finalize skipped non-owned run", run_id=run_id, attempted_status=validated_run)
+            return
         await session.execute(
             update(ThreadORM)
             .where(ThreadORM.thread_id == thread_id)
@@ -108,6 +220,17 @@ async def finalize_run(
         await session.commit()
 
     logger.info("Finalized run", run_id=run_id, status=validated_run, thread_status=validated_thread)
+
+    # Start the next double-texted (queued) run, if any. Best-effort: a dispatch
+    # failure must not bubble into execute_run's error path and clobber the status
+    # just committed — the queued run is durable and recovered by the reaper / boot
+    # sweep. Deferred import breaks run_status <- executor <- run_executor cycle.
+    from aegra_api.services.executor import executor
+
+    try:
+        await executor.dispatch_next_for_thread(thread_id)
+    except Exception:  # intentionally broad — ANY failure here must not clobber the committed status
+        logger.exception("Failed to dispatch next queued run", thread_id=thread_id)
 
 
 def _safe_serialize(output: Any, run_id: str) -> Any:

--- a/libs/aegra-api/src/aegra_api/services/worker_executor.py
+++ b/libs/aegra-api/src/aegra_api/services/worker_executor.py
@@ -100,6 +100,7 @@ class WorkerExecutor(BaseExecutor):
 
     async def start(self) -> None:
         self._running = True
+        self._accepting = True
         count = settings.worker.WORKER_COUNT
         if count == 0:
             logger.warning(
@@ -121,6 +122,7 @@ class WorkerExecutor(BaseExecutor):
 
     async def stop(self) -> None:
         self._running = False
+        self._accepting = False
         drain_timeout = settings.worker.WORKER_DRAIN_TIMEOUT
 
         # Wait for in-flight job tasks to finish
@@ -229,6 +231,12 @@ class WorkerExecutor(BaseExecutor):
                     status="error",
                     thread_status="error",
                     error="Job exceeded maximum execution time",
+                    # Authoritative late corrector: the cancel handler already finalized the run
+                    # to 'interrupted', so override that terminal status to 'error'. Scoped to
+                    # our own lease so a gate-pre-empted 'interrupted' (lease cleared) is never
+                    # stomped — its thread belongs to a newer run by now.
+                    allow_terminal_override=True,
+                    claimed_by=worker_name,
                 )
             else:
                 # Fallback: update run status only (thread_id lookup failed)

--- a/libs/aegra-api/tests/e2e/test_runs/test_runs_multitask_e2e.py
+++ b/libs/aegra-api/tests/e2e/test_runs/test_runs_multitask_e2e.py
@@ -1,0 +1,446 @@
+"""E2E tests for double-texting (multitask) strategies against a real server.
+
+Uses the LLM-free ``stress_test`` graph so concurrency/serialization can be
+exercised deterministically without API tokens. Run with a live server:
+
+    make e2e-dev    # LocalExecutor
+    make e2e-prod   # Redis workers
+"""
+
+import asyncio
+import json
+from typing import Any
+
+import httpx
+import pytest
+
+from aegra_api.settings import settings
+
+GRAPH = "stress_test"
+SLOW = '{"delay": 1.5, "steps": 3}'  # ~4.5s, valid JSON config for stress_test
+
+
+def _base_url() -> str:
+    return settings.app.SERVER_URL
+
+
+async def _wait_terminal(client: httpx.AsyncClient, thread_id: str, run_id: str, timeout: float = 30.0) -> str:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        resp = await client.get(f"/threads/{thread_id}/runs/{run_id}")
+        if resp.status_code == 404:
+            return "deleted"
+        status = resp.json().get("status")
+        if status in ("success", "error", "interrupted"):
+            return status
+        await asyncio.sleep(0.5)
+    raise AssertionError(f"run {run_id} did not settle within {timeout}s")
+
+
+async def _setup(client: httpx.AsyncClient) -> tuple[str, str]:
+    a = await client.post("/assistants", json={"graph_id": GRAPH, "if_exists": "do_nothing"})
+    a.raise_for_status()
+    t = await client.post("/threads", json={})
+    t.raise_for_status()
+    return a.json()["assistant_id"], t.json()["thread_id"]
+
+
+def _body(assistant_id: str, strategy: str | None) -> dict[str, Any]:
+    body: dict[str, Any] = {"assistant_id": assistant_id, "input": {"messages": [{"role": "user", "content": SLOW}]}}
+    if strategy is not None:
+        body["multitask_strategy"] = strategy
+    return body
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_default_strategy_enqueues_e2e() -> None:
+    """A run created with no strategy queues behind the active run (default=enqueue)."""
+    async with httpx.AsyncClient(base_url=_base_url(), timeout=60) as client:
+        aid, tid = await _setup(client)
+        a = await client.post(f"/threads/{tid}/runs", json=_body(aid, "enqueue"))
+        a.raise_for_status()
+        await asyncio.sleep(1.0)
+        b = await client.post(f"/threads/{tid}/runs", json=_body(aid, None))
+        b.raise_for_status()
+
+        # Internal 'queued' is reported as 'pending' on the wire (SDK vocabulary).
+        assert b.json()["status"] == "pending"
+        assert await _wait_terminal(client, tid, a.json()["run_id"]) == "success"
+        assert await _wait_terminal(client, tid, b.json()["run_id"]) == "success"
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_reject_returns_409_e2e() -> None:
+    async with httpx.AsyncClient(base_url=_base_url(), timeout=60) as client:
+        aid, tid = await _setup(client)
+        a = await client.post(f"/threads/{tid}/runs", json=_body(aid, "enqueue"))
+        a.raise_for_status()
+        await asyncio.sleep(1.0)
+
+        b = await client.post(f"/threads/{tid}/runs", json=_body(aid, "reject"))
+
+        assert b.status_code == 409
+        await _wait_terminal(client, tid, a.json()["run_id"])
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_enqueue_runs_after_active_e2e() -> None:
+    """The queued run only leaves 'queued' after the active run finishes."""
+    async with httpx.AsyncClient(base_url=_base_url(), timeout=60) as client:
+        aid, tid = await _setup(client)
+        a = await client.post(f"/threads/{tid}/runs", json=_body(aid, "enqueue"))
+        a.raise_for_status()
+        rid_a = a.json()["run_id"]
+        await asyncio.sleep(1.0)
+        b = await client.post(f"/threads/{tid}/runs", json=_body(aid, "enqueue"))
+        b.raise_for_status()
+        rid_b = b.json()["run_id"]
+
+        # While A runs, B must still be parked (not executing concurrently);
+        # internal 'queued' surfaces as 'pending' with no output yet.
+        mid = await client.get(f"/threads/{tid}/runs/{rid_b}")
+        assert mid.json()["status"] == "pending"
+        assert mid.json()["output"] is None
+
+        assert await _wait_terminal(client, tid, rid_a) == "success"
+        assert await _wait_terminal(client, tid, rid_b) == "success"
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_interrupt_drops_queued_double_text_e2e() -> None:
+    """interrupt over [running, queued] drops the queued double-text — it does not run afterward."""
+    async with httpx.AsyncClient(base_url=_base_url(), timeout=60) as client:
+        aid, tid = await _setup(client)
+        a = await client.post(f"/threads/{tid}/runs", json=_slow_marker_body(aid, "ACTIVE-A"))
+        a.raise_for_status()
+        rid_a = a.json()["run_id"]
+        await asyncio.sleep(1.0)  # A is running
+        b = await client.post(f"/threads/{tid}/runs", json=_marker_body(aid, "QUEUED-B", "enqueue"))
+        b.raise_for_status()
+        rid_b = b.json()["run_id"]
+        assert b.json()["status"] == "pending"  # internal 'queued'
+
+        # Interrupt supersedes both the running A and the queued B, then runs C now.
+        c = await client.post(f"/threads/{tid}/runs", json=_marker_body(aid, "NEW-C", "interrupt"))
+        c.raise_for_status()
+
+        assert await _wait_terminal(client, tid, rid_a) == "interrupted"
+        assert await _wait_terminal(client, tid, rid_b) == "interrupted"  # dropped, not run later
+        assert await _wait_terminal(client, tid, c.json()["run_id"]) == "success"
+        raw = str((await client.get(f"/threads/{tid}/state")).json().get("values", {}).get("messages", []))
+        assert "QUEUED-B" not in raw  # the stale double-text never executed
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_interrupt_cancels_active_e2e() -> None:
+    async with httpx.AsyncClient(base_url=_base_url(), timeout=60) as client:
+        aid, tid = await _setup(client)
+        a = await client.post(f"/threads/{tid}/runs", json=_body(aid, "enqueue"))
+        a.raise_for_status()
+        rid_a = a.json()["run_id"]
+        await asyncio.sleep(1.0)
+        b = await client.post(f"/threads/{tid}/runs", json=_body(aid, "interrupt"))
+        b.raise_for_status()
+
+        assert await _wait_terminal(client, tid, rid_a) == "interrupted"
+        assert await _wait_terminal(client, tid, b.json()["run_id"]) == "success"
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_rollback_cancels_active_e2e() -> None:
+    """rollback over an active run cancels it (kept as interrupted, not deleted)."""
+    async with httpx.AsyncClient(base_url=_base_url(), timeout=60) as client:
+        aid, tid = await _setup(client)
+        a = await client.post(f"/threads/{tid}/runs", json=_body(aid, "enqueue"))
+        a.raise_for_status()
+        rid_a = a.json()["run_id"]
+        await asyncio.sleep(1.0)
+        b = await client.post(f"/threads/{tid}/runs", json=_body(aid, "rollback"))
+        b.raise_for_status()
+
+        assert await _wait_terminal(client, tid, rid_a) == "interrupted"  # row kept, not 404
+        assert await _wait_terminal(client, tid, b.json()["run_id"]) == "success"
+
+
+def _marker_body(assistant_id: str, marker: str, strategy: str | None = None) -> dict[str, Any]:
+    """Valid stress_test JSON config carrying a unique marker that survives in the echo."""
+    content = json.dumps({"delay": 0.2, "steps": 1, "_m": marker})
+    body: dict[str, Any] = {"assistant_id": assistant_id, "input": {"messages": [{"role": "user", "content": content}]}}
+    if strategy is not None:
+        body["multitask_strategy"] = strategy
+    return body
+
+
+def _fail_marker_body(assistant_id: str, marker: str, strategy: str | None = None) -> dict[str, Any]:
+    """stress_test config that raises, leaving the run in a non-success (error) terminal state."""
+    content = json.dumps({"delay": 0.1, "steps": 1, "fail": True, "_m": marker})
+    body: dict[str, Any] = {"assistant_id": assistant_id, "input": {"messages": [{"role": "user", "content": content}]}}
+    if strategy is not None:
+        body["multitask_strategy"] = strategy
+    return body
+
+
+def _interrupt_marker_body(
+    assistant_id: str, marker: str, strategy: str | None = None, delay: float = 0.1
+) -> dict[str, Any]:
+    """stress_test config that pauses on a human-in-the-loop interrupt() (LLM-free HITL)."""
+    content = json.dumps({"delay": delay, "steps": 1, "interrupt": True, "_m": marker})
+    body: dict[str, Any] = {"assistant_id": assistant_id, "input": {"messages": [{"role": "user", "content": content}]}}
+    if strategy is not None:
+        body["multitask_strategy"] = strategy
+    return body
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_rollback_idle_keeps_completed_run_e2e() -> None:
+    """On an idle thread, rollback must NOT silently revert a cleanly completed run."""
+    async with httpx.AsyncClient(base_url=_base_url(), timeout=60) as client:
+        aid, tid = await _setup(client)
+
+        p = await client.post(f"/threads/{tid}/runs", json=_marker_body(aid, "PRIOR"))
+        p.raise_for_status()
+        assert await _wait_terminal(client, tid, p.json()["run_id"]) == "success"
+        a = await client.post(f"/threads/{tid}/runs", json=_marker_body(aid, "DONE"))
+        a.raise_for_status()
+        assert await _wait_terminal(client, tid, a.json()["run_id"]) == "success"
+
+        # Idle thread, last run succeeded: rollback just adds a turn, reverts nothing.
+        b = await client.post(f"/threads/{tid}/runs", json=_marker_body(aid, "NEW", "rollback"))
+        b.raise_for_status()
+        assert await _wait_terminal(client, tid, b.json()["run_id"]) == "success"
+
+        raw = str((await client.get(f"/threads/{tid}/state")).json().get("values", {}).get("messages", []))
+        assert "PRIOR" in raw  # prior state preserved
+        assert "NEW" in raw  # new run ran
+        assert "DONE" in raw  # the completed run is NOT reverted (no undo-last-turn footgun)
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_rollback_repairs_failed_last_run_e2e() -> None:
+    """On an idle thread, rollback reverts a last run left in a non-success state (broken-thread repair)."""
+    async with httpx.AsyncClient(base_url=_base_url(), timeout=60) as client:
+        aid, tid = await _setup(client)
+
+        p = await client.post(f"/threads/{tid}/runs", json=_marker_body(aid, "PRIOR"))
+        p.raise_for_status()
+        assert await _wait_terminal(client, tid, p.json()["run_id"]) == "success"
+
+        # A run that errors leaves the thread's last run in a non-success terminal state.
+        broken = await client.post(f"/threads/{tid}/runs", json=_fail_marker_body(aid, "BROKEN"))
+        broken.raise_for_status()
+        assert await _wait_terminal(client, tid, broken.json()["run_id"]) == "error"
+
+        # Idle now; rollback targets the errored run and forks from before it.
+        b = await client.post(f"/threads/{tid}/runs", json=_marker_body(aid, "NEW", "rollback"))
+        b.raise_for_status()
+        assert await _wait_terminal(client, tid, b.json()["run_id"]) == "success"
+
+        raw = str((await client.get(f"/threads/{tid}/state")).json().get("values", {}).get("messages", []))
+        assert "PRIOR" in raw  # prior state preserved
+        assert "NEW" in raw  # new run ran
+        assert "BROKEN" not in raw  # the errored run's writes were reverted
+
+
+def _slow_marker_body(assistant_id: str, marker: str, strategy: str | None = None) -> dict[str, Any]:
+    content = json.dumps({"delay": 2, "steps": 3, "_m": marker})  # ~6s, stays active long enough to preempt
+    body: dict[str, Any] = {"assistant_id": assistant_id, "input": {"messages": [{"role": "user", "content": content}]}}
+    if strategy is not None:
+        body["multitask_strategy"] = strategy
+    return body
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_rollback_reverts_active_run_e2e() -> None:
+    """rollback over an ACTIVE run forks from before it, reverting its writes."""
+    async with httpx.AsyncClient(base_url=_base_url(), timeout=60) as client:
+        aid, tid = await _setup(client)
+        p = await client.post(f"/threads/{tid}/runs", json=_marker_body(aid, "PRIOR"))
+        p.raise_for_status()
+        assert await _wait_terminal(client, tid, p.json()["run_id"]) == "success"
+
+        a = await client.post(f"/threads/{tid}/runs", json=_slow_marker_body(aid, "ACTIVE-A"))
+        a.raise_for_status()
+        await asyncio.sleep(1.0)  # A is running
+        b = await client.post(f"/threads/{tid}/runs", json=_marker_body(aid, "NEW", "rollback"))
+        b.raise_for_status()
+
+        assert await _wait_terminal(client, tid, a.json()["run_id"]) == "interrupted"
+        assert await _wait_terminal(client, tid, b.json()["run_id"]) == "success"
+        raw = str((await client.get(f"/threads/{tid}/state")).json().get("values", {}).get("messages", []))
+        assert "PRIOR" in raw
+        assert "NEW" in raw
+        assert "ACTIVE-A" not in raw  # the cancelled run's writes are reverted
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_two_sequential_rollbacks_do_not_resurrect_e2e() -> None:
+    """A second rollback must anchor by lineage, not resurrect the first-rolled-back run.
+
+    GEN1/GEN2 are errored (non-success) so each idle rollback engages: GEN2 reverts GEN1
+    and GEN3 must fork from PRIOR (GEN2's lineage parent), not GEN1's abandoned sibling.
+    """
+    async with httpx.AsyncClient(base_url=_base_url(), timeout=60) as client:
+        aid, tid = await _setup(client)
+        p = await client.post(f"/threads/{tid}/runs", json=_marker_body(aid, "PRIOR"))
+        p.raise_for_status()
+        assert await _wait_terminal(client, tid, p.json()["run_id"]) == "success"
+
+        gen1 = await client.post(f"/threads/{tid}/runs", json=_fail_marker_body(aid, "GEN1"))
+        gen1.raise_for_status()
+        assert await _wait_terminal(client, tid, gen1.json()["run_id"]) == "error"
+
+        gen2 = await client.post(f"/threads/{tid}/runs", json=_fail_marker_body(aid, "GEN2", "rollback"))
+        gen2.raise_for_status()
+        assert await _wait_terminal(client, tid, gen2.json()["run_id"]) == "error"
+
+        gen3 = await client.post(f"/threads/{tid}/runs", json=_marker_body(aid, "GEN3", "rollback"))
+        gen3.raise_for_status()
+        assert await _wait_terminal(client, tid, gen3.json()["run_id"]) == "success"
+
+        raw = str((await client.get(f"/threads/{tid}/state")).json().get("values", {}).get("messages", []))
+        assert "PRIOR" in raw  # original state survives both rollbacks
+        assert "GEN3" in raw  # the latest run ran
+        assert "GEN1" not in raw  # first-rolled-back run not resurrected by the second rollback
+        assert "GEN2" not in raw  # second-rolled-back run reverted
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_fresh_run_on_hitl_pause_rejected_e2e() -> None:
+    """A fresh run on a HITL-paused thread is rejected (409); the pause stays pending and resumable."""
+    async with httpx.AsyncClient(base_url=_base_url(), timeout=60) as client:
+        aid, tid = await _setup(client)
+
+        # A run that pauses on interrupt() ends 'interrupted' with a pending interrupt.
+        paused = await client.post(f"/threads/{tid}/runs", json=_interrupt_marker_body(aid, "PAUSED"))
+        paused.raise_for_status()
+        assert await _wait_terminal(client, tid, paused.json()["run_id"]) == "interrupted"
+        assert (await client.get(f"/threads/{tid}/state")).json().get("interrupts")  # pending interrupt present
+
+        # A fresh rollback run must be REFUSED, not silently consume the pause.
+        b = await client.post(f"/threads/{tid}/runs", json=_marker_body(aid, "NEW", "rollback"))
+        assert b.status_code == 409
+
+        # The pause is intact and still resumable via a command.
+        assert (await client.get(f"/threads/{tid}/state")).json().get("interrupts")  # still pending, not consumed
+        resume = await client.post(f"/threads/{tid}/runs", json={"assistant_id": aid, "command": {"resume": "ok"}})
+        resume.raise_for_status()
+        assert await _wait_terminal(client, tid, resume.json()["run_id"]) == "success"
+        raw = str((await client.get(f"/threads/{tid}/state")).json().get("values", {}).get("messages", []))
+        assert "PAUSED" in raw  # the original paused turn ran to completion after resume
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_queued_run_not_promoted_onto_hitl_pause_e2e() -> None:
+    """A run enqueued BEFORE a thread pauses on interrupt() must not be auto-promoted onto the pause."""
+    async with httpx.AsyncClient(base_url=_base_url(), timeout=60) as client:
+        aid, tid = await _setup(client)
+
+        # A runs a busy window, then pauses on interrupt(); B enqueues while A is still running.
+        a = await client.post(f"/threads/{tid}/runs", json=_interrupt_marker_body(aid, "PAUSED", delay=2.0))
+        a.raise_for_status()
+        await asyncio.sleep(0.8)  # A is running (busy), not yet paused
+        b = await client.post(f"/threads/{tid}/runs", json=_marker_body(aid, "QUEUED-B", "enqueue"))
+        b.raise_for_status()
+        rid_b = b.json()["run_id"]
+        assert b.json()["status"] == "pending"  # internal 'queued'
+
+        assert await _wait_terminal(client, tid, a.json()["run_id"]) == "interrupted"
+        await asyncio.sleep(1.5)  # let finalize-dispatch + the stranded sweep run
+
+        # B must NOT have been promoted onto the pause; the pending interrupt is intact
+        # (still parked: wire status stays 'pending' and no output has been produced).
+        parked = (await client.get(f"/threads/{tid}/runs/{rid_b}")).json()
+        assert parked["status"] == "pending"
+        assert parked["output"] is None
+        assert (await client.get(f"/threads/{tid}/state")).json().get("interrupts")  # pause preserved
+
+        # After resuming, the pause clears and the parked run finally executes (not lost).
+        resume = await client.post(f"/threads/{tid}/runs", json={"assistant_id": aid, "command": {"resume": "ok"}})
+        resume.raise_for_status()
+        assert await _wait_terminal(client, tid, resume.json()["run_id"]) == "success"
+        assert await _wait_terminal(client, tid, rid_b) == "success"
+        raw = str((await client.get(f"/threads/{tid}/state")).json().get("values", {}).get("messages", []))
+        assert "QUEUED-B" in raw  # parked run ran after the pause resolved — parked, not consumed or lost
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_concurrent_reject_creates_exactly_one_409_e2e() -> None:
+    """Two truly concurrent creates with strategy=reject: the FOR UPDATE admission
+    gate must serialize them so exactly one wins and exactly one gets 409."""
+    async with httpx.AsyncClient(base_url=_base_url(), timeout=60) as client:
+        aid, tid = await _setup(client)
+        # Warm the thread row so both racers hit the same locked row.
+        warm = await client.post(f"/threads/{tid}/runs", json=_marker_body(aid, "WARM"))
+        warm.raise_for_status()
+        assert await _wait_terminal(client, tid, warm.json()["run_id"]) == "success"
+
+        results = await asyncio.gather(
+            client.post(f"/threads/{tid}/runs", json=_body(aid, "reject")),
+            client.post(f"/threads/{tid}/runs", json=_body(aid, "reject")),
+        )
+        codes = sorted(r.status_code for r in results)
+
+        assert codes == [200, 409], f"gate must admit exactly one racer, got {codes}"
+        winner = next(r for r in results if r.status_code == 200)
+        assert await _wait_terminal(client, tid, winner.json()["run_id"]) == "success"
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_two_queued_runs_promote_fifo_e2e() -> None:
+    """Two runs enqueued behind an active one must execute in creation order (FIFO)."""
+    async with httpx.AsyncClient(base_url=_base_url(), timeout=60) as client:
+        aid, tid = await _setup(client)
+        a = await client.post(f"/threads/{tid}/runs", json=_slow_marker_body(aid, "HEAD"))
+        a.raise_for_status()
+        await asyncio.sleep(1.0)  # HEAD is running
+        b = await client.post(f"/threads/{tid}/runs", json=_marker_body(aid, "FIRST", "enqueue"))
+        b.raise_for_status()
+        await asyncio.sleep(0.3)  # order the two queued runs by created_at
+        c = await client.post(f"/threads/{tid}/runs", json=_marker_body(aid, "SECOND", "enqueue"))
+        c.raise_for_status()
+
+        assert await _wait_terminal(client, tid, a.json()["run_id"]) == "success"
+        assert await _wait_terminal(client, tid, b.json()["run_id"]) == "success"
+        assert await _wait_terminal(client, tid, c.json()["run_id"]) == "success"
+
+        # FIFO: the echo transcript must show FIRST before SECOND.
+        raw = str((await client.get(f"/threads/{tid}/state")).json().get("values", {}).get("messages", []))
+        assert "FIRST" in raw and "SECOND" in raw
+        assert raw.index("FIRST") < raw.index("SECOND"), "queued runs must promote oldest-first"
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_cancel_endpoint_resets_thread_and_promotes_queue_e2e() -> None:
+    """POST .../cancel on the active run must not strand the thread 'busy' —
+    the queued double-text behind it is promoted and the thread settles."""
+    async with httpx.AsyncClient(base_url=_base_url(), timeout=60) as client:
+        aid, tid = await _setup(client)
+        a = await client.post(f"/threads/{tid}/runs", json=_slow_marker_body(aid, "CANCELLED"))
+        a.raise_for_status()
+        rid_a = a.json()["run_id"]
+        await asyncio.sleep(1.0)  # A is running
+        b = await client.post(f"/threads/{tid}/runs", json=_marker_body(aid, "QUEUED", "enqueue"))
+        b.raise_for_status()
+
+        (await client.post(f"/threads/{tid}/runs/{rid_a}/cancel")).raise_for_status()
+
+        assert await _wait_terminal(client, tid, rid_a) == "interrupted"
+        # The queued run is promoted promptly (no reliance on the 15-30s sweeps).
+        assert await _wait_terminal(client, tid, b.json()["run_id"], timeout=20.0) == "success"
+        thread = await client.get(f"/threads/{tid}")
+        assert thread.json()["status"] == "idle"  # not stranded 'busy'

--- a/libs/aegra-api/tests/integration/test_api/test_event_streaming.py
+++ b/libs/aegra-api/tests/integration/test_api/test_event_streaming.py
@@ -62,7 +62,9 @@ def _make_app(
     app.dependency_overrides[get_current_user] = lambda: user
     # Routes open short-lived sessions via _get_session_maker(); patch it (per
     # test, auto-restored) to return a maker yielding the in-memory test session.
+    # commands.py polls fresh sessions in its interrupt settle check — same double.
     monkeypatch.setattr(es_module, "_get_session_maker", lambda: lambda: _Session(owner=owner, run_ids=run_ids))
+    monkeypatch.setattr(cmd_module, "_get_session_maker", lambda: lambda: _Session(owner=owner, run_ids=run_ids))
     app.include_router(es_module.router)
     return app
 

--- a/libs/aegra-api/tests/integration/test_api/test_runs_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_runs_crud.py
@@ -317,6 +317,9 @@ class TestCancelRun:
         run = _run_row(status="running")
 
         class Session(DummySessionBase):
+            def expire_all(self) -> None:
+                pass
+
             async def scalar(self, _stmt):
                 return run
 
@@ -329,12 +332,17 @@ class TestCancelRun:
         override_session_dependency(app, Session)
         client = make_client(app)
 
-        with patch("aegra_api.api.runs.streaming_service") as mock_streaming:
+        with (
+            patch("aegra_api.api.runs.streaming_service") as mock_streaming,
+            patch("aegra_api.api.runs.terminalize_user_cancel", new_callable=AsyncMock) as mock_terminalize,
+        ):
             mock_streaming.cancel_run = AsyncMock()
 
             resp = client.post("/threads/test-thread-123/runs/test-run-123/cancel")
 
             assert resp.status_code == 200
+            # Terminal-state convergence (thread reset + queued dispatch) is delegated.
+            mock_terminalize.assert_awaited_once_with("test-run-123", "test-thread-123")
 
 
 class TestDeleteRun:
@@ -396,6 +404,56 @@ class TestDeleteRun:
         resp = client.delete("/threads/test-thread-123/runs/test-run-123")
 
         assert resp.status_code == 204
+
+    def test_delete_run_queued_not_allowed(self):
+        """A queued run is active; deleting without force returns 409."""
+        app = create_test_app(include_runs=True, include_threads=False)
+
+        run = _run_row(status="queued")
+
+        class Session(DummySessionBase):
+            async def scalar(self, _stmt):
+                return run
+
+        override_session_dependency(app, Session)
+        client = make_client(app)
+
+        resp = client.delete("/threads/test-thread-123/runs/test-run-123")
+
+        assert resp.status_code == 409
+        assert "active" in resp.json()["detail"].lower()
+
+    def test_delete_run_force_queued_succeeds_without_cancel(self):
+        """Force-deleting a queued run removes the row but does not cancel (no task)."""
+        app = create_test_app(include_runs=True, include_threads=False)
+
+        run = _run_row(status="queued")
+        executed: list[str] = []
+
+        class Session(DummySessionBase):
+            async def scalar(self, _stmt):
+                return run
+
+            async def execute(self, _stmt):
+                executed.append(str(_stmt))
+
+            async def commit(self):
+                pass
+
+        with (
+            patch("aegra_api.api.runs.streaming_service.cancel_run", new_callable=AsyncMock) as mock_cancel,
+            patch("aegra_api.api.runs.terminalize_user_cancel", new_callable=AsyncMock) as mock_terminalize,
+        ):
+            override_session_dependency(app, Session)
+            client = make_client(app)
+            resp = client.delete("/threads/test-thread-123/runs/test-run-123?force=1")
+
+        assert resp.status_code == 204
+        mock_cancel.assert_not_awaited()  # queued run has no task to cancel
+        # Convergence still runs BEFORE the delete: if this run headed a stranded
+        # queue, the runs parked behind it are promoted rather than left waiting.
+        mock_terminalize.assert_awaited_once_with("test-run-123", "test-thread-123")
+        assert any("DELETE FROM runs" in stmt for stmt in executed)  # row actually removed
 
 
 class TestJoinRun:

--- a/libs/aegra-api/tests/integration/test_api/test_runs_multitask.py
+++ b/libs/aegra-api/tests/integration/test_api/test_runs_multitask.py
@@ -1,0 +1,127 @@
+"""Integration tests for the multitask_strategy field at the HTTP boundary.
+
+Stateful behaviors (409 reject, queue ordering, interrupt/rollback) are
+covered by the e2e suite against a real database; here we assert the
+request-validation contract the tightened enum now enforces.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from aegra_api.services import run_preparation as run_preparation_mod
+from tests.fixtures.clients import create_test_app, make_client
+from tests.fixtures.session_fixtures import BasicSession, override_session_dependency
+
+
+def _client() -> TestClient:
+    app = create_test_app(include_runs=True, include_threads=False)
+    override_session_dependency(app, BasicSession)
+    return make_client(app)
+
+
+class TestMultitaskValidation:
+    def test_invalid_strategy_returns_422(self) -> None:
+        client = _client()
+
+        resp = client.post(
+            "/threads/test-thread-123/runs",
+            json={"assistant_id": "asst-123", "input": {"messages": []}, "multitask_strategy": "banana"},
+        )
+
+        assert resp.status_code == 422
+
+    @pytest.mark.parametrize("strategy", ["reject", "interrupt", "rollback", "enqueue"])
+    def test_valid_strategy_passes_validation(self, strategy: str) -> None:
+        # A valid enum value must be accepted at validation — reaching the SAME outcome
+        # as omitting the field (never 422). Fresh clients keep the two posts independent.
+        # (Over-loosening is pinned by test_invalid_strategy_returns_422 above.)
+        body = {"assistant_id": "asst-123", "input": {"messages": []}}
+        baseline = _client().post("/threads/test-thread-123/runs", json=body)
+        resp = _client().post("/threads/test-thread-123/runs", json={**body, "multitask_strategy": strategy})
+
+        assert resp.status_code != 422
+        assert resp.status_code == baseline.status_code
+
+
+class _InterruptedThreadSession(BasicSession):
+    """Session whose thread lookup returns a HITL-paused thread owned by the test user."""
+
+    async def scalar(self, _stmt: object) -> object:
+        thread = MagicMock()
+        thread.status = "interrupted"
+        thread.user_id = "test-user"
+        return thread
+
+
+class _IdleThreadSession(BasicSession):
+    async def scalar(self, _stmt: object) -> object:
+        thread = MagicMock()
+        thread.status = "idle"
+        thread.user_id = "test-user"
+        return thread
+
+
+class TestResumeValidationAtHttpBoundary:
+    """The admission-time input-mode gate, exercised through the full route stack."""
+
+    def test_malformed_command_returns_422(self) -> None:
+        # {'goto': [0]} cannot map to a LangGraph Command; it must be rejected at
+        # admission instead of crashing mid-run (which would corrupt a HITL pause).
+        app = create_test_app(include_runs=True, include_threads=False)
+        override_session_dependency(app, _InterruptedThreadSession)
+        client = make_client(app)
+
+        resp = client.post(
+            "/threads/test-thread-123/runs",
+            json={"assistant_id": "asst-123", "command": {"goto": [0]}},
+        )
+
+        assert resp.status_code == 422
+        assert "Invalid command" in resp.json()["detail"]
+
+    def test_fresh_input_on_paused_thread_returns_409(self) -> None:
+        app = create_test_app(include_runs=True, include_threads=False)
+        override_session_dependency(app, _InterruptedThreadSession)
+        client = make_client(app)
+
+        resp = client.post(
+            "/threads/test-thread-123/runs",
+            json={"assistant_id": "asst-123", "input": {"messages": []}},
+        )
+
+        assert resp.status_code == 409
+        assert "resume" in resp.json()["detail"]
+
+    def test_null_resume_on_paused_thread_returns_409(self) -> None:
+        # map_command drops a None resume — running it would crash the pause to 'error'.
+        app = create_test_app(include_runs=True, include_threads=False)
+        override_session_dependency(app, _InterruptedThreadSession)
+        client = make_client(app)
+
+        resp = client.post(
+            "/threads/test-thread-123/runs",
+            json={"assistant_id": "asst-123", "command": {"resume": None}},
+        )
+
+        assert resp.status_code == 409
+
+    def test_resume_on_idle_thread_returns_400(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Collapse the settle poll (no DB in integration tests) — idle stays idle.
+        monkeypatch.setattr(run_preparation_mod, "_RESUME_SETTLE_INTERVAL_SECONDS", 0)
+        ctx = MagicMock()
+        ctx.__aenter__ = AsyncMock(return_value=_IdleThreadSession())
+        ctx.__aexit__ = AsyncMock(return_value=False)
+        monkeypatch.setattr(run_preparation_mod, "_get_session_maker", lambda: MagicMock(return_value=ctx))
+        app = create_test_app(include_runs=True, include_threads=False)
+        override_session_dependency(app, _IdleThreadSession)
+        client = make_client(app)
+
+        resp = client.post(
+            "/threads/test-thread-123/runs",
+            json={"assistant_id": "asst-123", "command": {"resume": "go"}},
+        )
+
+        assert resp.status_code == 400
+        assert "not in interrupted state" in resp.json()["detail"]

--- a/libs/aegra-api/tests/integration/test_api/test_threads_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_threads_crud.py
@@ -381,6 +381,44 @@ class TestDeleteThread:
         assert resp.status_code == 200
         assert resp.json()["status"] == "deleted"
 
+    def test_delete_thread_cancels_queued_run(self):
+        """A queued run on the thread is included in cleanup and signalled."""
+        app = create_test_app(include_runs=False, include_threads=True)
+
+        thread = _thread_row("test-123")
+        queued_run = MagicMock()
+        queued_run.run_id = "q1"
+
+        class Session(DummySessionBase):
+            async def scalar(self, _stmt):
+                return thread
+
+            async def scalars(self, _stmt):
+                # Only surface the queued run if the cleanup query's status filter
+                # actually includes 'queued' — so dropping it from threads.py reds this test.
+                compiled = str(_stmt.compile(compile_kwargs={"literal_binds": True}))
+                rows = [queued_run] if "queued" in compiled else []
+
+                class Result:
+                    def all(self):
+                        return rows
+
+                return Result()
+
+            async def delete(self, obj):
+                pass
+
+            async def commit(self):
+                pass
+
+        with patch("aegra_api.api.threads.streaming_service.cancel_run", new_callable=AsyncMock) as mock_cancel:
+            app.dependency_overrides[core_get_session] = override_get_session_dep(Session)
+            client = make_client(app)
+            resp = client.delete("/threads/test-123")
+
+        assert resp.status_code == 200
+        mock_cancel.assert_awaited_once_with("q1")
+
 
 class TestSearchThreads:
     """Test POST /threads/search endpoint"""

--- a/libs/aegra-api/tests/integration/test_streaming_errors.py
+++ b/libs/aegra-api/tests/integration/test_streaming_errors.py
@@ -68,7 +68,7 @@ class TestStreamingErrorHandling:
                 "aegra_api.services.run_executor.stream_graph_events",
                 return_value=failing_stream(),
             ),
-            patch("aegra_api.services.run_executor.update_run_status", new_callable=AsyncMock),
+            patch("aegra_api.services.run_executor.try_mark_run_running", new_callable=AsyncMock, return_value=True),
             patch("aegra_api.services.run_executor.finalize_run", new_callable=AsyncMock),
         ):
             mock_lg_service.return_value.get_graph.return_value.__aenter__ = AsyncMock(return_value=mock_graph)
@@ -134,7 +134,7 @@ class TestStreamingErrorHandling:
                 "aegra_api.services.run_executor.stream_graph_events",
                 return_value=failing_stream(),
             ),
-            patch("aegra_api.services.run_executor.update_run_status", new_callable=AsyncMock),
+            patch("aegra_api.services.run_executor.try_mark_run_running", new_callable=AsyncMock, return_value=True),
             patch("aegra_api.services.run_executor.finalize_run", new_callable=AsyncMock),
         ):
             mock_graph = MagicMock()
@@ -183,7 +183,7 @@ class TestStreamingErrorHandling:
             patch(
                 "aegra_api.services.run_executor.stream_graph_events",
             ) as mock_stream_graph,
-            patch("aegra_api.services.run_executor.update_run_status", new_callable=AsyncMock),
+            patch("aegra_api.services.run_executor.try_mark_run_running", new_callable=AsyncMock, return_value=True),
             patch("aegra_api.services.run_executor.finalize_run", new_callable=AsyncMock),
         ):
             # Set up the mock to return the async generator
@@ -243,7 +243,7 @@ class TestStreamingErrorHandling:
                 "aegra_api.services.run_executor.stream_graph_events",
                 return_value=failing_stream(),
             ),
-            patch("aegra_api.services.run_executor.update_run_status", new_callable=AsyncMock),
+            patch("aegra_api.services.run_executor.try_mark_run_running", new_callable=AsyncMock, return_value=True),
             patch("aegra_api.services.run_executor.finalize_run", new_callable=AsyncMock),
         ):
             mock_graph = MagicMock()

--- a/libs/aegra-api/tests/unit/test_api/test_runs.py
+++ b/libs/aegra-api/tests/unit/test_api/test_runs.py
@@ -82,6 +82,10 @@ class TestRunsEndpoints:
 
             # DB setup: first scalar = thread ownership check (None = new thread), second = assistant
             mock_session.scalar.side_effect = [None, sample_assistant]
+            # No in-flight run on the thread → multitask gate lets this run start now.
+            no_active = MagicMock()
+            no_active.all.return_value = []
+            mock_session.scalars.return_value = no_active
 
             result = await create_run(thread_id, request, mock_user, mock_session)
 
@@ -273,10 +277,16 @@ class TestRunsEndpoints:
         # scalar called twice: first to find for update, second to return
         mock_session.scalar.side_effect = [run_orm, run_orm]
 
-        with patch(
-            "aegra_api.api.runs.streaming_service.interrupt_run",
-            new_callable=AsyncMock,
-        ) as mock_interrupt:
+        with (
+            patch(
+                "aegra_api.api.runs.streaming_service.interrupt_run",
+                new_callable=AsyncMock,
+            ) as mock_interrupt,
+            patch(
+                "aegra_api.api.runs.terminalize_user_cancel",
+                new_callable=AsyncMock,
+            ) as mock_terminalize,
+        ):
             result = await update_run(
                 thread_id,
                 run_id,
@@ -286,8 +296,9 @@ class TestRunsEndpoints:
             )
 
             mock_interrupt.assert_called_once_with(run_id)
-            mock_session.execute.assert_called_once()  # Update statement
-            mock_session.commit.assert_called_once()
+            # The endpoint converges through terminalize_user_cancel (thread reset +
+            # queued dispatch happen there), not through a raw status UPDATE.
+            mock_terminalize.assert_awaited_once_with(run_id, thread_id)
             assert result.run_id == run_id
 
     @pytest.mark.asyncio

--- a/libs/aegra-api/tests/unit/test_api/test_runs_streaming.py
+++ b/libs/aegra-api/tests/unit/test_api/test_runs_streaming.py
@@ -83,6 +83,10 @@ class TestRunsStreamingEndpoints:
 
             # DB setup: first scalar = thread ownership check (None = new thread), second = assistant
             mock_session.scalar.side_effect = [None, sample_assistant]
+            # No in-flight run on the thread → multitask gate lets this run start now.
+            no_active = MagicMock()
+            no_active.all.return_value = []
+            mock_session.scalars.return_value = no_active
 
             # Mock generator for streaming response
             async def mock_generator() -> AsyncGenerator:
@@ -157,11 +161,13 @@ class TestRunsStreamingEndpoints:
             patch("aegra_api.api.runs.active_runs", {}),
             patch("aegra_api.api.runs.streaming_service.stream_run_execution", return_value=_fake_stream()),
             patch("aegra_api.api.runs.broker_manager.request_cancel", new_callable=AsyncMock) as mock_cancel,
+            patch("aegra_api.api.runs.terminalize_user_cancel", new_callable=AsyncMock) as mock_terminalize,
             patch("aegra_api.api.runs._get_session_maker", return_value=_make_session_maker(mock_session)),
         ):
             mock_lg_service.return_value.list_graphs.return_value = ["test-graph"]
             # First scalar = thread ownership check (None = new thread); second = assistant
             mock_session.scalar.side_effect = [None, sample_assistant]
+            mock_session.scalars.return_value = MagicMock(all=MagicMock(return_value=[]))  # no in-flight run
 
             response = await create_and_stream_run(thread_id, request, mock_user)
 
@@ -174,6 +180,7 @@ class TestRunsStreamingEndpoints:
             await handler({"type": "http.disconnect"})
             if expect_request_cancel:
                 mock_cancel.assert_awaited_once_with(run_id, "cancel")
+                mock_terminalize.assert_awaited_once_with(run_id, thread_id)
             else:
                 mock_cancel.assert_not_awaited()
 
@@ -217,12 +224,60 @@ class TestRunsStreamingEndpoints:
             mock_lg_service.return_value.list_graphs.return_value = ["test-graph"]
             # First scalar = thread ownership check (None = new thread); second = assistant
             mock_session.scalar.side_effect = [None, sample_assistant]
+            mock_session.scalars.return_value = MagicMock(all=MagicMock(return_value=[]))  # no in-flight run
 
             response = await create_and_stream_run(thread_id, request, mock_user)
             handler = response.client_close_handler_callable
             assert handler is not None
             # Must not raise even though the broker side-effect blows up
             await handler({"type": "http.disconnect"})
+
+    @pytest.mark.asyncio
+    async def test_disconnect_interrupts_queued_run(
+        self, mock_user: User, mock_session: AsyncMock, sample_assistant: AssistantORM
+    ) -> None:
+        """On disconnect, the handler converges the queued run via terminalize_user_cancel."""
+        thread_id = "t"
+        run_id = str(uuid4())
+        request = RunCreate(assistant_id="test-assistant", input={})  # default enqueue
+
+        async def _fake_stream() -> AsyncGenerator:
+            yield "data"
+
+        with (
+            patch("aegra_api.services.run_preparation._validate_resume_command", new_callable=AsyncMock),
+            patch("aegra_api.services.run_preparation.get_langgraph_service") as mock_lg_service,
+            patch("aegra_api.services.run_preparation.resolve_assistant_id", return_value="test-assistant"),
+            patch("aegra_api.services.run_preparation.update_thread_metadata", new_callable=AsyncMock),
+            patch("aegra_api.services.run_preparation.set_thread_status", new_callable=AsyncMock),
+            patch("aegra_api.services.run_preparation.uuid4", return_value=run_id),
+            patch("aegra_api.api.runs.active_runs", {}),
+            patch("aegra_api.api.runs.streaming_service.stream_run_execution", return_value=_fake_stream()),
+            patch("aegra_api.api.runs.broker_manager.request_cancel", new_callable=AsyncMock) as mock_cancel,
+            patch("aegra_api.api.runs.terminalize_user_cancel", new_callable=AsyncMock) as mock_terminalize,
+            patch("aegra_api.api.runs._get_session_maker", return_value=_make_session_maker(mock_session)),
+        ):
+            mock_lg_service.return_value.list_graphs.return_value = ["test-graph"]
+            mock_session.scalar.side_effect = [None, sample_assistant]
+            # An active run already holds the thread → the new run is queued (default enqueue).
+            active = MagicMock()
+            active.status = "running"
+            active.run_id = "other"
+            active.execution_params = {"execution": {"command": None}}
+            active_res = MagicMock()
+            active_res.all.return_value = [active]
+            mock_session.scalars.return_value = active_res
+
+            response = await create_and_stream_run(thread_id, request, mock_user)
+            handler = response.client_close_handler_callable
+            assert handler is not None
+
+            await handler({"type": "http.disconnect"})
+
+            mock_cancel.assert_awaited_once_with(run_id, "cancel")
+            # Convergence (queued unpark, or CAS-finalize if already promoted) is
+            # delegated to terminalize_user_cancel, closing the promotion race.
+            mock_terminalize.assert_awaited_once_with(run_id, thread_id)
 
     @pytest.mark.asyncio
     async def test_stream_run_success(self, mock_user: User, mock_session: AsyncMock) -> None:
@@ -364,7 +419,7 @@ class TestRunsStreamingEndpoints:
                 "aegra_api.services.run_executor.stream_graph_events",
                 return_value=failing_stream(),
             ),
-            patch("aegra_api.services.run_executor.update_run_status", new_callable=AsyncMock),
+            patch("aegra_api.services.run_executor.try_mark_run_running", new_callable=AsyncMock, return_value=True),
             patch("aegra_api.services.run_executor.finalize_run", new_callable=AsyncMock),
         ):
             mock_graph = MagicMock()

--- a/libs/aegra-api/tests/unit/test_api/test_runs_wait.py
+++ b/libs/aegra-api/tests/unit/test_api/test_runs_wait.py
@@ -124,6 +124,9 @@ class TestWaitForRunExceptionPaths:
         session_1 = AsyncMock()
         session_1.add = MagicMock()
         session_1.scalar.side_effect = [None, _make_assistant()]
+        session_1.scalars.return_value = MagicMock(
+            all=MagicMock(return_value=[])
+        )  # no in-flight run → multitask gate runs now
 
         # Post-wait session (for _fetch_run_output)
         session_2 = AsyncMock()
@@ -169,6 +172,9 @@ class TestWaitForRunExceptionPaths:
         session_1 = AsyncMock()
         session_1.add = MagicMock()
         session_1.scalar.side_effect = [None, _make_assistant()]
+        session_1.scalars.return_value = MagicMock(
+            all=MagicMock(return_value=[])
+        )  # no in-flight run → multitask gate runs now
 
         session_2 = AsyncMock()
         session_2.scalar.return_value = _make_run_orm(run_id, thread_id, output={"result": "success"})
@@ -210,6 +216,9 @@ class TestWaitForRunExceptionPaths:
         session_1 = AsyncMock()
         session_1.add = MagicMock()
         session_1.scalar.side_effect = [None, _make_assistant()]
+        session_1.scalars.return_value = MagicMock(
+            all=MagicMock(return_value=[])
+        )  # no in-flight run → multitask gate runs now
 
         session_2 = AsyncMock()
         session_2.scalar.return_value = _make_run_orm(
@@ -258,6 +267,9 @@ class TestWaitForRunExceptionPaths:
         session_1 = AsyncMock()
         session_1.add = MagicMock()
         session_1.scalar.side_effect = [None, _make_assistant()]
+        session_1.scalars.return_value = MagicMock(
+            all=MagicMock(return_value=[])
+        )  # no in-flight run → multitask gate runs now
 
         session_2 = AsyncMock()
         session_2.scalar.return_value = _make_run_orm(
@@ -337,6 +349,9 @@ class TestWaitForRunExceptionPaths:
         session_1 = AsyncMock()
         session_1.add = MagicMock()
         session_1.scalar.side_effect = [None, _make_assistant()]
+        session_1.scalars.return_value = MagicMock(
+            all=MagicMock(return_value=[])
+        )  # no in-flight run → multitask gate runs now
 
         session_2 = AsyncMock()
         session_2.scalar.return_value = _make_run_orm(run_id, thread_id, output={"ok": True})

--- a/libs/aegra-api/tests/unit/test_api/test_stateless_runs.py
+++ b/libs/aegra-api/tests/unit/test_api/test_stateless_runs.py
@@ -325,6 +325,7 @@ class TestCleanupAfterBackgroundRun:
 
         with (
             patch("aegra_api.services.run_cleanup.active_runs", {run_id: task}),
+            patch("aegra_api.services.run_cleanup.executor.wait_for_completion", new_callable=AsyncMock),
             patch(
                 "aegra_api.services.run_cleanup.delete_thread_by_id",
                 new_callable=AsyncMock,
@@ -344,6 +345,7 @@ class TestCleanupAfterBackgroundRun:
 
         with (
             patch("aegra_api.services.run_cleanup.active_runs", {}),
+            patch("aegra_api.services.run_cleanup.executor.wait_for_completion", new_callable=AsyncMock),
             patch(
                 "aegra_api.services.run_cleanup.delete_thread_by_id",
                 new_callable=AsyncMock,

--- a/libs/aegra-api/tests/unit/test_main.py
+++ b/libs/aegra-api/tests/unit/test_main.py
@@ -38,6 +38,7 @@ async def test_lifespan_registers_otel_provider(monkeypatch):
     # Mock all the dependencies
     with (
         patch("aegra_api.main.run_migrations_async", new_callable=AsyncMock),
+        patch("aegra_api.main.executor", new_callable=AsyncMock),
         patch("aegra_api.main.db_manager") as mock_db_manager,
         patch("aegra_api.main.get_langgraph_service") as mock_get_langgraph_service,
     ):
@@ -73,6 +74,7 @@ async def test_lifespan_calls_required_initialization():
 
     with (
         patch("aegra_api.main.run_migrations_async", new_callable=AsyncMock) as mock_migrations,
+        patch("aegra_api.main.executor", new_callable=AsyncMock),
         patch("aegra_api.main.db_manager") as mock_db_manager,
         patch("aegra_api.main.get_langgraph_service") as mock_get_langgraph_service,
         patch("aegra_api.main.setup_observability") as mock_setup_observability,
@@ -116,6 +118,7 @@ async def test_lifespan_skips_migrations_when_disabled(monkeypatch):
 
     with (
         patch("aegra_api.main.run_migrations_async", new_callable=AsyncMock) as mock_migrations,
+        patch("aegra_api.main.executor", new_callable=AsyncMock),
         patch("aegra_api.main.db_manager") as mock_db_manager,
         patch("aegra_api.main.get_langgraph_service") as mock_get_langgraph_service,
         patch("aegra_api.main.setup_observability"),
@@ -149,6 +152,7 @@ async def test_lifespan_runs_migrations_when_enabled(monkeypatch):
 
     with (
         patch("aegra_api.main.run_migrations_async", new_callable=AsyncMock) as mock_migrations,
+        patch("aegra_api.main.executor", new_callable=AsyncMock),
         patch("aegra_api.main.db_manager") as mock_db_manager,
         patch("aegra_api.main.get_langgraph_service") as mock_get_langgraph_service,
         patch("aegra_api.main.setup_observability"),

--- a/libs/aegra-api/tests/unit/test_services/test_cron_scheduler.py
+++ b/libs/aegra-api/tests/unit/test_services/test_cron_scheduler.py
@@ -11,7 +11,7 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 from fastapi import HTTPException
 
-from aegra_api.services.cron_scheduler import CronScheduler
+from aegra_api.services.cron_scheduler import CronScheduler, _build_run_create
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -588,3 +588,22 @@ class TestSchedulerLoop:
             await scheduler._loop()
 
         assert call_count == 2
+
+
+class TestBuildRunCreateMultitask:
+    """_build_run_create must neutralize legacy/invalid stored strategies."""
+
+    def test_coerces_invalid_multitask_strategy_to_none(self) -> None:
+        cron = _make_cron_orm(payload={"input": {"m": "x"}, "multitask_strategy": "legacy_bad"})
+        rc = _build_run_create(cron)
+        assert rc.multitask_strategy is None
+
+    def test_keeps_valid_multitask_strategy(self) -> None:
+        cron = _make_cron_orm(payload={"input": {"m": "x"}, "multitask_strategy": "reject"})
+        rc = _build_run_create(cron)
+        assert rc.multitask_strategy == "reject"
+
+    def test_none_when_strategy_absent(self) -> None:
+        cron = _make_cron_orm(payload={"input": {"m": "x"}})
+        rc = _build_run_create(cron)
+        assert rc.multitask_strategy is None

--- a/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_commands.py
+++ b/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_commands.py
@@ -1,7 +1,7 @@
 """Tests for v2 command dispatch (run.start, input.respond, errors)."""
 
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -23,7 +23,12 @@ def prepared_run(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
 
 
 async def _dispatch(payload: dict[str, Any], user: User, *, session: Any = None) -> tuple[dict, str | None]:
-    return await cmd.handle_command(payload, session=session or AsyncMock(), thread_id="t1", user=user)
+    if session is None:
+        # Default session: no thread row and no in-flight run, so the run.start
+        # interrupt classification neither converts to a resume nor settle-polls.
+        session = AsyncMock()
+        session.scalar = AsyncMock(return_value=None)
+    return await cmd.handle_command(payload, session=session, thread_id="t1", user=user)
 
 
 class TestRunStart:
@@ -292,3 +297,78 @@ class TestErrors:
         assert resp["type"] == "error"
         assert resp["error"] == "invalid_argument"
         assert run_id is None
+
+
+class TestRunStartInterruptSettle:
+    """run.start's interrupt classification must tolerate the event-before-commit race:
+    the interrupt reaches the client before finalize commits thread='interrupted'."""
+
+    def _settle_session(self, statuses: list[str | None]) -> Any:
+        """Replacement for _get_session_maker: each fresh session's scalar returns
+        the next status in sequence (the last one repeats)."""
+        seq = list(statuses)
+
+        def _new_ctx() -> Any:
+            fresh = AsyncMock()
+            fresh.scalar = AsyncMock(return_value=seq.pop(0) if len(seq) > 1 else seq[0])
+            ctx = MagicMock()
+            ctx.__aenter__ = AsyncMock(return_value=fresh)
+            ctx.__aexit__ = AsyncMock(return_value=False)
+            return ctx
+
+        def _get_maker() -> Any:
+            return lambda: _new_ctx()
+
+        return _get_maker
+
+    async def test_answer_racing_finalize_commit_still_resumes(
+        self, prepared_run: AsyncMock, user: User, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Request session: thread 'busy' (finalize not committed yet), one in-flight run.
+        session = AsyncMock()
+        session.scalar = AsyncMock(side_effect=["busy", "run-in-flight"])
+        monkeypatch.setattr(cmd, "_RESUME_SETTLE_INTERVAL_SECONDS", 0)
+        monkeypatch.setattr(cmd, "_get_session_maker", self._settle_session(["busy", "interrupted"]))
+
+        await _dispatch(
+            {"id": 1, "method": "run.start", "params": {"assistant_id": "agent", "input": {"answer": 42}}},
+            user,
+            session=session,
+        )
+
+        # The settle poll saw the commit land: the input is a resume, not a fresh turn.
+        request = prepared_run.call_args.args[2]
+        assert request.command == {"resume": {"answer": 42}}
+        assert request.input is None
+
+    async def test_genuine_double_text_stays_fresh_input(
+        self, prepared_run: AsyncMock, user: User, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        session = AsyncMock()
+        session.scalar = AsyncMock(side_effect=["busy", "run-in-flight"])
+        monkeypatch.setattr(cmd, "_RESUME_SETTLE_INTERVAL_SECONDS", 0)
+        monkeypatch.setattr(cmd, "_get_session_maker", self._settle_session(["busy"]))
+
+        await _dispatch(
+            {"id": 1, "method": "run.start", "params": {"assistant_id": "agent", "input": {"q": "hi"}}},
+            user,
+            session=session,
+        )
+
+        request = prepared_run.call_args.args[2]
+        assert request.command is None
+        assert request.input == {"q": "hi"}
+
+    async def test_no_in_flight_run_skips_the_poll(self, prepared_run: AsyncMock, user: User) -> None:
+        # Idle thread: no interrupt can be in flight, so no settle latency is added.
+        session = AsyncMock()
+        session.scalar = AsyncMock(side_effect=["idle", None])
+
+        await _dispatch(
+            {"id": 1, "method": "run.start", "params": {"assistant_id": "agent", "input": {"q": "hi"}}},
+            user,
+            session=session,
+        )
+
+        request = prepared_run.call_args.args[2]
+        assert request.input == {"q": "hi"}

--- a/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_session.py
+++ b/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_session.py
@@ -707,3 +707,42 @@ class TestValidateChannels:
     def test_non_list_is_error(self) -> None:
         valid, invalid = validate_channels("messages")
         assert invalid
+
+
+class TestQueuedRunHandling:
+    """A parked (queued) double-text publishes no broker events and has no task:
+    draining it would emit a false 'running' lifecycle and wedge on an empty broker."""
+
+    async def test_queued_run_is_deferred_not_drained(self, manager: BrokerManager) -> None:
+        session = _make_session("t1", channels={"lifecycle"}, run_ids=("q1",), statuses={"q1": "queued"})
+
+        async with asyncio.timeout(5):  # pre-fix behavior blocks forever in broker.aiter()
+            events = await _collect(session)
+
+        assert events == []  # no false lifecycle seed, session ends via idle grace
+
+    async def test_dropped_queued_run_drains_terminal_on_a_later_tick(self, manager: BrokerManager) -> None:
+        # Tick 1 sees the run queued (skipped); a multitask gate then drops it to
+        # 'interrupted' — tick 2 must treat it as terminal instead of tailing it.
+        statuses = {"q1": "queued"}
+        calls = 0
+
+        async def list_run_ids() -> list[tuple[str, str | None, str | None]]:
+            nonlocal calls
+            calls += 1
+            if calls > 1:
+                statuses["q1"] = "interrupted"
+            return [("q1", statuses["q1"], None)]
+
+        session = ThreadEventSession(
+            "t1",
+            channels={"lifecycle"},
+            list_run_ids=list_run_ids,
+            idle_grace_seconds=0.0,
+        )
+
+        async with asyncio.timeout(5):
+            events = await _collect(session)
+
+        assert events == []  # empty replay + terminal status → silent drain, no wedge
+        assert "q1" in session._drained

--- a/libs/aegra-api/tests/unit/test_services/test_executor.py
+++ b/libs/aegra-api/tests/unit/test_services/test_executor.py
@@ -63,8 +63,9 @@ class TestLocalExecutor:
     @pytest.mark.asyncio
     async def test_wait_for_completion_returns_on_missing_run(self) -> None:
         executor = LocalExecutor()
-        # Should return immediately, not raise
-        await executor.wait_for_completion("nonexistent", timeout=1.0)
+        # Absent from active_runs and terminal/absent in DB → returns, not hang/raise.
+        with patch("aegra_api.services.local_executor._is_run_terminal", new_callable=AsyncMock, return_value=True):
+            await executor.wait_for_completion("nonexistent", timeout=1.0)
 
     @pytest.mark.asyncio
     async def test_stop_cancels_active_tasks(self) -> None:
@@ -111,7 +112,7 @@ class TestRunExecutorBoundaryConditions:
 
         with (
             patch("aegra_api.services.run_executor.get_langgraph_service", return_value=mock_service),
-            patch("aegra_api.services.run_executor.update_run_status", new_callable=AsyncMock),
+            patch("aegra_api.services.run_executor.try_mark_run_running", new_callable=AsyncMock, return_value=True),
             patch("aegra_api.services.run_executor.finalize_run", new_callable=AsyncMock),
             patch("aegra_api.services.run_executor.streaming_service") as mock_streaming,
             patch("aegra_api.services.run_executor.stream_graph_events", return_value=_empty_async_gen()),
@@ -147,3 +148,147 @@ class TestExecutorFactory:
 
             result = _create_executor()
             assert isinstance(result, WorkerExecutor)
+
+
+class TestRecoverOrphanedQueue:
+    """LocalExecutor restart recovery for queued/orphaned runs (dev mode)."""
+
+    @staticmethod
+    def _maker(session: AsyncMock) -> MagicMock:
+        ctx = AsyncMock()
+        ctx.__aenter__ = AsyncMock(return_value=session)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+        return MagicMock(return_value=ctx)
+
+    @pytest.mark.asyncio
+    async def test_errors_orphans_and_dispatches_per_affected_thread(self) -> None:
+        executor = LocalExecutor()
+        session = AsyncMock()
+        affected = MagicMock()
+        affected.all.return_value = [("t1",)]
+        affected.rowcount = 1  # the orphan-error UPDATE reports a matched run
+        session.execute = AsyncMock(return_value=affected)
+        session.commit = AsyncMock()
+
+        with (
+            patch(
+                "aegra_api.services.local_executor._get_session_maker",
+                return_value=TestRecoverOrphanedQueue._maker(session),
+            ),
+            patch.object(executor, "dispatch_next_for_thread", new_callable=AsyncMock) as mock_dispatch,
+        ):
+            await executor._recover_orphaned_queue()
+
+        mock_dispatch.assert_awaited_once_with("t1")
+        assert session.execute.await_count >= 2  # distinct SELECT + orphan-error UPDATE
+        session.commit.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_orphaned_thread_status_reset_to_error(self) -> None:
+        # The orphans' finalizes never ran — recovery must reset the thread the way an
+        # error finalize would, so it is not left 'busy' forever with no active run.
+        executor = LocalExecutor()
+        session = AsyncMock()
+        statements: list[str] = []
+
+        async def _exec(stmt: object, *a: object, **k: object) -> MagicMock:
+            statements.append(str(stmt))
+            result = MagicMock()
+            result.all.return_value = [("t1",)]
+            result.rowcount = 1  # the orphan-error UPDATE matched a run
+            return result
+
+        session.execute = _exec
+        session.commit = AsyncMock()
+
+        with (
+            patch(
+                "aegra_api.services.local_executor._get_session_maker",
+                return_value=TestRecoverOrphanedQueue._maker(session),
+            ),
+            patch.object(executor, "dispatch_next_for_thread", new_callable=AsyncMock),
+        ):
+            await executor._recover_orphaned_queue()
+
+        thread_updates = [s for s in statements if s.startswith("UPDATE thread ")]
+        assert len(thread_updates) == 1
+        assert "status" in thread_updates[0]
+
+    @pytest.mark.asyncio
+    async def test_queued_only_thread_status_untouched(self) -> None:
+        # A thread with only parked (queued) runs has no orphan to error; its status —
+        # possibly a HITL 'interrupted' pause — must not be overwritten by recovery.
+        executor = LocalExecutor()
+        session = AsyncMock()
+        statements: list[str] = []
+
+        async def _exec(stmt: object, *a: object, **k: object) -> MagicMock:
+            statements.append(str(stmt))
+            result = MagicMock()
+            result.all.return_value = [("t1",)]
+            result.rowcount = 0  # no running/pending orphan matched
+            return result
+
+        session.execute = _exec
+        session.commit = AsyncMock()
+
+        with (
+            patch(
+                "aegra_api.services.local_executor._get_session_maker",
+                return_value=TestRecoverOrphanedQueue._maker(session),
+            ),
+            patch.object(executor, "dispatch_next_for_thread", new_callable=AsyncMock) as mock_dispatch,
+        ):
+            await executor._recover_orphaned_queue()
+
+        assert not any(s.startswith("UPDATE thread ") for s in statements)
+        mock_dispatch.assert_awaited_once_with("t1")  # queued run still gets promoted
+
+    @pytest.mark.asyncio
+    async def test_noop_when_no_affected_threads(self) -> None:
+        executor = LocalExecutor()
+        session = AsyncMock()
+        empty = MagicMock()
+        empty.all.return_value = []
+        session.execute = AsyncMock(return_value=empty)
+
+        with (
+            patch(
+                "aegra_api.services.local_executor._get_session_maker",
+                return_value=TestRecoverOrphanedQueue._maker(session),
+            ),
+            patch.object(executor, "dispatch_next_for_thread", new_callable=AsyncMock) as mock_dispatch,
+        ):
+            await executor._recover_orphaned_queue()
+
+        mock_dispatch.assert_not_awaited()
+
+
+class TestStrandedQueueSweep:
+    """Dev periodic stranded-queue recovery must survive a bad row (mirrors the prod reaper)."""
+
+    @pytest.mark.asyncio
+    async def test_sweep_survives_non_sqlalchemy_error(self) -> None:
+        # A corrupt-params queued row makes dispatch raise ValueError (not SQLAlchemyError);
+        # per-thread isolation must keep the sweep alive and still attempt the other threads.
+        executor = LocalExecutor()
+        session = AsyncMock()
+        threads = MagicMock()
+        threads.all.return_value = [("t1",), ("t2",)]
+        session.execute = AsyncMock(return_value=threads)
+
+        with (
+            patch(
+                "aegra_api.services.local_executor._get_session_maker",
+                return_value=TestRecoverOrphanedQueue._maker(session),
+            ),
+            patch.object(
+                executor,
+                "dispatch_next_for_thread",
+                new_callable=AsyncMock,
+                side_effect=ValueError("corrupt execution_params"),
+            ) as mock_dispatch,
+        ):
+            await executor._sweep_stranded_queues()  # must NOT raise
+
+        assert mock_dispatch.await_count == 2  # both threads attempted despite the first raising

--- a/libs/aegra-api/tests/unit/test_services/test_lease_reaper.py
+++ b/libs/aegra-api/tests/unit/test_services/test_lease_reaper.py
@@ -48,6 +48,27 @@ class TestFindRecoverable:
         assert crashed == []
         assert stuck == []
 
+    @pytest.mark.asyncio
+    async def test_stuck_pending_predicate_keys_on_updated_at_not_created_at(self) -> None:
+        # A queued run promoted to pending keeps its old created_at, so the stuck-pending
+        # check must filter on updated_at — else fresh promotions get falsely reaped.
+        captured: list[str] = []
+        session = AsyncMock()
+
+        async def _exec(stmt: object) -> MagicMock:
+            captured.append(str(stmt))
+            result = MagicMock()
+            result.fetchall.return_value = []
+            return result
+
+        session.execute = _exec
+        with patch("aegra_api.services.lease_reaper._get_session_maker", return_value=_make_session_maker(session)):
+            await LeaseReaper._find_recoverable()
+
+        stuck_sql = captured[1]  # second query is the stuck-pending scan
+        assert "updated_at" in stuck_sql
+        assert "created_at" not in stuck_sql
+
 
 class TestResetToPending:
     @pytest.mark.asyncio
@@ -135,6 +156,7 @@ class TestReap:
             patch.object(
                 LeaseReaper, "_find_recoverable", new_callable=AsyncMock, return_value=(["run-1", "run-2"], [])
             ),
+            patch.object(LeaseReaper, "_find_stranded_queued_threads", new_callable=AsyncMock, return_value=[]),
             patch.object(
                 LeaseReaper, "_reset_to_pending", new_callable=AsyncMock, return_value=["run-1", "run-2"]
             ) as mock_reset,
@@ -160,6 +182,7 @@ class TestReap:
 
         with (
             patch.object(LeaseReaper, "_find_recoverable", new_callable=AsyncMock, return_value=([], ["run-3"])),
+            patch.object(LeaseReaper, "_find_stranded_queued_threads", new_callable=AsyncMock, return_value=[]),
             patch.object(LeaseReaper, "_check_retry_limits", new_callable=AsyncMock) as mock_retry,
             patch.object(LeaseReaper, "_reenqueue", new_callable=AsyncMock) as mock_reenqueue,
         ):
@@ -174,6 +197,7 @@ class TestReap:
 
         with (
             patch.object(LeaseReaper, "_find_recoverable", new_callable=AsyncMock, return_value=([], [])),
+            patch.object(LeaseReaper, "_find_stranded_queued_threads", new_callable=AsyncMock, return_value=[]),
             patch.object(LeaseReaper, "_reset_to_pending", new_callable=AsyncMock) as mock_reset,
             patch.object(LeaseReaper, "_reenqueue", new_callable=AsyncMock) as mock_reenqueue,
         ):
@@ -220,3 +244,84 @@ class TestStartStop:
         # Should not raise
         await reaper.stop()
         assert reaper._task is None
+
+
+class TestStrandedQueued:
+    @pytest.mark.asyncio
+    async def test_find_returns_only_threads_without_active_run(self) -> None:
+        session = AsyncMock()
+        queued_res = MagicMock()
+        queued_res.all.return_value = [("t1",), ("t2",)]
+        active_res = MagicMock()
+        active_res.all.return_value = [("t2",)]  # t2 still has a running/pending run
+        session.execute = AsyncMock(side_effect=[queued_res, active_res])
+
+        with patch("aegra_api.services.lease_reaper._get_session_maker", return_value=_make_session_maker(session)):
+            result = await LeaseReaper._find_stranded_queued_threads()
+
+        assert set(result) == {"t1"}
+
+    @pytest.mark.asyncio
+    async def test_find_short_circuits_when_no_queued(self) -> None:
+        session = AsyncMock()
+        queued_res = MagicMock()
+        queued_res.all.return_value = []
+        session.execute = AsyncMock(side_effect=[queued_res])
+
+        with patch("aegra_api.services.lease_reaper._get_session_maker", return_value=_make_session_maker(session)):
+            result = await LeaseReaper._find_stranded_queued_threads()
+
+        assert result == []
+        assert session.execute.await_count == 1  # no active-run query when nothing queued
+
+    @pytest.mark.asyncio
+    async def test_dispatch_calls_executor_per_thread(self) -> None:
+        with patch("aegra_api.services.executor.executor") as ex:
+            ex.dispatch_next_for_thread = AsyncMock()
+            await LeaseReaper._dispatch_stranded_queued(["t1", "t2"])
+
+        assert ex.dispatch_next_for_thread.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_one_thread_failure_does_not_abort_batch(self) -> None:
+        with patch("aegra_api.services.executor.executor") as ex:
+            ex.dispatch_next_for_thread = AsyncMock(side_effect=[RedisError("boom"), None])
+            await LeaseReaper._dispatch_stranded_queued(["t1", "t2"])
+
+        assert ex.dispatch_next_for_thread.await_count == 2  # second thread still attempted
+
+    @pytest.mark.asyncio
+    async def test_reap_dispatches_stranded_queued(self) -> None:
+        reaper = LeaseReaper()
+        with (
+            patch.object(LeaseReaper, "_find_recoverable", new_callable=AsyncMock, return_value=([], [])),
+            patch.object(LeaseReaper, "_find_stranded_queued_threads", new_callable=AsyncMock, return_value=["t1"]),
+            patch.object(LeaseReaper, "_dispatch_stranded_queued", new_callable=AsyncMock) as mock_dispatch,
+        ):
+            await reaper._reap()
+
+        mock_dispatch.assert_awaited_once_with(["t1"])
+
+    @pytest.mark.asyncio
+    async def test_stranded_scan_runs_after_crashed_handling(self) -> None:
+        """Stranded scan must run after mark-failed so a freshly-failed head's successor is caught."""
+        reaper = LeaseReaper()
+        order: list[str] = []
+
+        async def _mark(_ids: list[str]) -> None:
+            order.append("mark_failed")
+
+        async def _find_stranded() -> list[str]:
+            order.append("find_stranded")
+            return []
+
+        with (
+            patch.object(LeaseReaper, "_find_recoverable", new_callable=AsyncMock, return_value=(["r1"], [])),
+            patch.object(LeaseReaper, "_reset_to_pending", new_callable=AsyncMock, return_value=["r1"]),
+            patch.object(LeaseReaper, "_check_retry_limits", new_callable=AsyncMock, return_value=([], ["r1"])),
+            patch.object(LeaseReaper, "_mark_permanently_failed", side_effect=_mark),
+            patch.object(LeaseReaper, "_find_stranded_queued_threads", side_effect=_find_stranded),
+        ):
+            await reaper._reap()
+
+        assert order == ["mark_failed", "find_stranded"]

--- a/libs/aegra-api/tests/unit/test_services/test_multitask_strategy.py
+++ b/libs/aegra-api/tests/unit/test_services/test_multitask_strategy.py
@@ -1,0 +1,901 @@
+"""Unit tests for double-texting (multitask) strategy handling.
+
+Covers the admission gate (`_apply_multitask_strategy`) and the
+finalize-time dispatch (`BaseExecutor.dispatch_next_for_thread`).
+"""
+
+from collections.abc import AsyncIterator, Callable
+from datetime import datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.dialects import postgresql
+
+from aegra_api.models.auth import User
+from aegra_api.services import run_preparation as run_preparation_mod
+from aegra_api.services.base_executor import BaseExecutor
+from aegra_api.services.run_executor import _resolve_rollback_base, _rollback_fork_base
+from aegra_api.services.run_preparation import _apply_multitask_strategy, _validate_resume_command
+from aegra_api.services.run_status import finalize_run
+
+_USER = User(identity="test-user")
+
+
+def _fake_run(run_id: str = "run-1", status: str = "running") -> MagicMock:
+    run = MagicMock()
+    run.run_id = run_id
+    run.status = status
+    return run
+
+
+def _session_with_active(active: list[MagicMock], *, terminal_run: MagicMock | None = None) -> AsyncMock:
+    """Mock session whose active-run query returns ``active``.
+
+    ``terminal_run`` is the most-recent-terminal-run row the rollback no-active
+    path looks up (it reads ``.run_id`` and ``.status``); None means none exists.
+    """
+    session = AsyncMock()
+    result = MagicMock()
+    result.all.return_value = active
+    session.scalars = AsyncMock(return_value=result)
+    session.scalar = AsyncMock(return_value=terminal_run)
+    session.execute = AsyncMock()
+    session.delete = AsyncMock()
+    return session
+
+
+def _make_session_maker(session: AsyncMock) -> MagicMock:
+    maker = MagicMock()
+    ctx = AsyncMock()
+    ctx.__aenter__ = AsyncMock(return_value=session)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    maker.return_value = ctx
+    return maker
+
+
+class TestApplyMultitaskStrategy:
+    @pytest.mark.asyncio
+    async def test_no_active_run_runs_immediately(self) -> None:
+        session = _session_with_active([])
+
+        should_run, cancel_ids, target = await _apply_multitask_strategy(session, "thread-1", "enqueue", _USER)
+
+        assert should_run is True
+        assert cancel_ids == []
+        assert target is None
+        session.delete.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_reject_with_active_raises_409(self) -> None:
+        session = _session_with_active([_fake_run()])
+
+        with pytest.raises(HTTPException) as exc:
+            await _apply_multitask_strategy(session, "thread-1", "reject", _USER)
+
+        assert exc.value.status_code == 409
+
+    @pytest.mark.asyncio
+    async def test_enqueue_with_active_queues(self) -> None:
+        session = _session_with_active([_fake_run()])
+
+        should_run, cancel_ids, target = await _apply_multitask_strategy(session, "thread-1", "enqueue", _USER)
+
+        assert should_run is False
+        assert cancel_ids == []
+        assert target is None
+        session.delete.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_interrupt_marks_active_and_returns_cancel_id(self) -> None:
+        active = _fake_run(status="running")
+        session = _session_with_active([active])
+
+        should_run, cancel_ids, target = await _apply_multitask_strategy(session, "thread-1", "interrupt", _USER)
+
+        assert should_run is True
+        assert cancel_ids == ["run-1"]  # caller cancels post-commit to avoid deadlock
+        assert active.status == "interrupted"
+        assert target is None  # interrupt does not revert checkpoints
+        session.delete.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rollback_marks_active_and_returns_target_without_delete(self) -> None:
+        active = _fake_run(status="running")
+        session = _session_with_active([active])
+
+        should_run, cancel_ids, target = await _apply_multitask_strategy(session, "thread-1", "rollback", _USER)
+
+        assert should_run is True
+        assert cancel_ids == ["run-1"]
+        assert target == "run-1"  # worker forks the new run from before this run
+        assert active.status == "interrupted"
+        session.delete.assert_not_called()  # rollback reverts via fork, never deletes
+
+    @pytest.mark.asyncio
+    async def test_rollback_no_active_reverts_broken_terminal_run(self) -> None:
+        # #191: the dirtying run was already interrupted to a terminal state — repair it.
+        session = _session_with_active([], terminal_run=_fake_run("old-interrupted", "interrupted"))
+
+        should_run, cancel_ids, target = await _apply_multitask_strategy(session, "thread-1", "rollback", _USER)
+
+        assert should_run is True
+        assert cancel_ids == []
+        assert target == "old-interrupted"
+
+    @pytest.mark.asyncio
+    async def test_rollback_no_active_ignores_successful_last_run(self) -> None:
+        # A cleanly completed last turn must NOT be silently reverted (no undo-last-turn footgun).
+        session = _session_with_active([], terminal_run=_fake_run("done", "success"))
+
+        should_run, cancel_ids, target = await _apply_multitask_strategy(session, "thread-1", "rollback", _USER)
+
+        assert should_run is True
+        assert target is None
+
+    @pytest.mark.asyncio
+    async def test_rollback_no_prior_run_has_no_target(self) -> None:
+        session = _session_with_active([], terminal_run=None)
+
+        should_run, cancel_ids, target = await _apply_multitask_strategy(session, "thread-1", "rollback", _USER)
+
+        assert should_run is True
+        assert target is None
+
+    @pytest.mark.asyncio
+    async def test_queued_run_is_dropped_on_interrupt(self) -> None:
+        # interrupt/rollback abandons in-flight work: a parked 'queued' double-text is
+        # dropped from the queue (marked interrupted) but has no task, so no cancel id.
+        queued = _fake_run(run_id="queued-1", status="queued")
+        session = _session_with_active([queued])
+
+        should_run, cancel_ids, target = await _apply_multitask_strategy(session, "thread-1", "interrupt", _USER)
+
+        assert should_run is True
+        assert cancel_ids == []
+        assert queued.status == "interrupted"
+
+    @pytest.mark.asyncio
+    async def test_interrupt_drops_queued_behind_active(self) -> None:
+        running = _fake_run(run_id="r1", status="running")
+        queued = _fake_run(run_id="q1", status="queued")
+        session = _session_with_active([running, queued])
+
+        should_run, cancel_ids, target = await _apply_multitask_strategy(session, "thread-1", "interrupt", _USER)
+
+        assert should_run is True
+        assert cancel_ids == ["r1"]  # only the running run holds a task to cancel
+        assert running.status == "interrupted"
+        assert queued.status == "interrupted"  # the stale double-text is dropped, not run later
+
+    @pytest.mark.asyncio
+    async def test_rollback_targets_running_not_queued(self) -> None:
+        running = _fake_run(run_id="r1", status="running")
+        queued = _fake_run(run_id="q1", status="queued")
+        session = _session_with_active([running, queued])
+
+        _should_run, cancel_ids, target = await _apply_multitask_strategy(session, "thread-1", "rollback", _USER)
+
+        assert cancel_ids == ["r1"]
+        assert target == "r1"  # revert the run that executed, never a queued one
+        assert queued.status == "interrupted"
+
+    @pytest.mark.asyncio
+    async def test_resume_runs_immediately_jumping_queue(self) -> None:
+        # A resume must run NOW even with a run queued ahead — it is the only run that can
+        # clear a HITL pause. The queued run is left parked, promoted after the resume ends.
+        queued = _fake_run(run_id="q1", status="queued")
+        session = _session_with_active([queued])
+
+        should_run, cancel_ids, target = await _apply_multitask_strategy(
+            session, "thread-1", "enqueue", _USER, is_resume=True
+        )
+
+        assert should_run is True
+        assert cancel_ids == []
+        assert target is None
+        assert queued.status == "queued"  # untouched — stays parked, not dropped
+
+    @pytest.mark.asyncio
+    async def test_resume_rejected_when_a_run_is_active(self) -> None:
+        # Two concurrent resumes must not double-execute: the second, unblocking after the first
+        # commits its pending run, sees that running/pending run under the lock and is 409'd.
+        running = _fake_run(run_id="r1", status="running")
+        session = _session_with_active([running])
+
+        with pytest.raises(HTTPException) as exc:
+            await _apply_multitask_strategy(session, "thread-1", "enqueue", _USER, is_resume=True)
+
+        assert exc.value.status_code == 409
+
+
+class _RecordingExecutor(BaseExecutor):
+    """Concrete executor that records submitted jobs."""
+
+    def __init__(self) -> None:
+        self.submitted: list[object] = []
+
+    async def submit(self, job: object) -> None:
+        self.submitted.append(job)
+
+    async def wait_for_completion(self, run_id: str, *, timeout: float = 300.0) -> None:
+        return None
+
+    async def start(self) -> None:
+        return None
+
+    async def stop(self) -> None:
+        return None
+
+
+class TestDispatchNextForThread:
+    @pytest.mark.asyncio
+    async def test_noop_when_not_accepting(self) -> None:
+        ex = _RecordingExecutor()
+        ex._accepting = False
+
+        await ex.dispatch_next_for_thread("thread-1")
+
+        assert ex.submitted == []
+
+    @pytest.mark.asyncio
+    async def test_noop_when_thread_interrupted(self) -> None:
+        # A HITL-paused thread must NOT have a queued fresh-input run promoted onto it.
+        # side_effect is padded with the occupying + queued lookups so that REMOVING the
+        # guard reaches the promotion and fails on `submitted == []` (a behavioral failure),
+        # not on StopAsyncIteration.
+        ex = _RecordingExecutor()
+        queued = _fake_run(run_id="queued-1", status="queued")
+        session = AsyncMock()
+        session.execute = AsyncMock()
+        session.commit = AsyncMock()
+        session.scalar = AsyncMock(side_effect=[MagicMock(status="interrupted"), None, queued])
+
+        fake_job = MagicMock()
+        fake_job.identity.run_id = "queued-1"
+        with (
+            patch("aegra_api.services.base_executor._get_session_maker", return_value=_make_session_maker(session)),
+            patch("aegra_api.services.base_executor.RunJob.from_run_orm", return_value=fake_job),
+        ):
+            await ex.dispatch_next_for_thread("thread-1")
+
+        assert ex.submitted == []
+
+    @pytest.mark.asyncio
+    async def test_noop_when_thread_occupied(self) -> None:
+        ex = _RecordingExecutor()
+        session = AsyncMock()
+        session.execute = AsyncMock()
+        # thread (not interrupted), then the occupying check hits.
+        session.scalar = AsyncMock(side_effect=[MagicMock(status="busy"), "some-active-run-id"])
+
+        with patch("aegra_api.services.base_executor._get_session_maker", return_value=_make_session_maker(session)):
+            await ex.dispatch_next_for_thread("thread-1")
+
+        assert ex.submitted == []
+
+    @pytest.mark.asyncio
+    async def test_noop_when_no_queued(self) -> None:
+        ex = _RecordingExecutor()
+        session = AsyncMock()
+        session.execute = AsyncMock()
+        # thread (not interrupted), not occupied, nothing queued.
+        session.scalar = AsyncMock(side_effect=[MagicMock(status="busy"), None, None])
+
+        with patch("aegra_api.services.base_executor._get_session_maker", return_value=_make_session_maker(session)):
+            await ex.dispatch_next_for_thread("thread-1")
+
+        assert ex.submitted == []
+
+    @pytest.mark.asyncio
+    async def test_promotes_and_submits_oldest_queued(self) -> None:
+        ex = _RecordingExecutor()
+        queued = _fake_run(run_id="queued-1", status="queued")
+        session = AsyncMock()
+        session.execute = AsyncMock()
+        session.commit = AsyncMock()
+        # thread (not interrupted), not occupied, one queued.
+        session.scalar = AsyncMock(side_effect=[MagicMock(status="busy"), None, queued])
+
+        fake_job = MagicMock()
+        fake_job.identity.run_id = "queued-1"
+        with (
+            patch("aegra_api.services.base_executor._get_session_maker", return_value=_make_session_maker(session)),
+            patch("aegra_api.services.base_executor.RunJob.from_run_orm", return_value=fake_job),
+        ):
+            await ex.dispatch_next_for_thread("thread-1")
+
+        assert queued.status == "pending"
+        assert isinstance(queued.updated_at, datetime)  # stamped at promotion (stuck-pending reaper)
+        assert ex.submitted == [fake_job]
+
+
+class _FakeSnap:
+    """Minimal LangGraph StateSnapshot stand-in for rollback-base resolution."""
+
+    def __init__(self, run_id: str | None, checkpoint_id: str, parent_checkpoint_id: str | None = None) -> None:
+        self.metadata = {"run_id": run_id} if run_id is not None else {}
+        self.config = {"configurable": {"checkpoint_id": checkpoint_id}}
+        self.parent_config = (
+            {"configurable": {"checkpoint_id": parent_checkpoint_id}} if parent_checkpoint_id is not None else None
+        )
+
+
+def _history(*snaps: _FakeSnap) -> Callable[..., AsyncIterator[_FakeSnap]]:
+    # Mirror aget_state_history's keyword-only ``limit`` and its SQL LIMIT semantics
+    # so the scan-cap / fail-loud path can be exercised deterministically.
+    async def _gen(config: object, *, limit: int | None = None) -> AsyncIterator[_FakeSnap]:
+        for i, s in enumerate(snaps):
+            if limit is not None and i >= limit:
+                return
+            yield s
+
+    return _gen
+
+
+class TestResolveRollbackBase:
+    """Worker-side resolution of the pre-target checkpoint to fork from (by lineage)."""
+
+    @staticmethod
+    async def _resolve(graph: MagicMock, target: str) -> str | None:
+        with patch("aegra_api.services.run_executor.create_thread_config", return_value={"configurable": {}}):
+            return await _resolve_rollback_base(graph, "t", User(identity="u"), target)
+
+    @pytest.mark.asyncio
+    async def test_returns_parent_of_oldest_target_checkpoint(self) -> None:
+        graph = MagicMock()
+        # target wrote cp-3 (parent cp-2) and cp-2 (input, parent cp-1=base); cp-1 is a prior run.
+        graph.aget_state_history = _history(
+            _FakeSnap("target", "cp-3", parent_checkpoint_id="cp-2"),
+            _FakeSnap("target", "cp-2", parent_checkpoint_id="cp-1"),
+            _FakeSnap("prev", "cp-1", parent_checkpoint_id="cp-0"),
+        )
+        assert await self._resolve(graph, "target") == "cp-1"
+
+    @pytest.mark.asyncio
+    async def test_second_rollback_anchors_to_lineage_not_sibling(self) -> None:
+        # After P -> A(rolled back) -> B(forked from cp-P): history DESC interleaves the
+        # abandoned A branch. A second rollback targeting B must fork from cp-P (B's parent),
+        # NOT cp-A — the flat "first different run_id" scan would wrongly pick cp-A.
+        graph = MagicMock()
+        graph.aget_state_history = _history(
+            _FakeSnap("B", "cp-B", parent_checkpoint_id="cp-P"),
+            _FakeSnap("A", "cp-A", parent_checkpoint_id="cp-P"),
+            _FakeSnap("P", "cp-P", parent_checkpoint_id=None),
+        )
+        assert await self._resolve(graph, "B") == "cp-P"
+
+    @pytest.mark.asyncio
+    async def test_retry_skips_own_partial_checkpoints(self) -> None:
+        # Retry of crashed run B (target still A): B's own newer partial must be skipped;
+        # base is A's oldest checkpoint's parent (cp-P), never B's partial.
+        graph = MagicMock()
+        graph.aget_state_history = _history(
+            _FakeSnap("B", "cp-Bpart", parent_checkpoint_id="cp-P"),  # newer, current run's own partial
+            _FakeSnap("A", "cp-A2", parent_checkpoint_id="cp-A1"),
+            _FakeSnap("A", "cp-A1", parent_checkpoint_id="cp-P"),
+            _FakeSnap("P", "cp-P", parent_checkpoint_id=None),
+        )
+        assert await self._resolve(graph, "A") == "cp-P"
+
+    @pytest.mark.asyncio
+    async def test_first_run_target_has_no_parent(self) -> None:
+        # Target was the thread's first run: its oldest checkpoint has no parent -> None.
+        graph = MagicMock()
+        graph.aget_state_history = _history(
+            _FakeSnap("target", "cp-1", parent_checkpoint_id="cp-0"),
+            _FakeSnap("target", "cp-0", parent_checkpoint_id=None),
+        )
+        assert await self._resolve(graph, "target") is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_target_has_no_checkpoints(self) -> None:
+        graph = MagicMock()
+        graph.aget_state_history = _history(_FakeSnap("other", "cp-1", parent_checkpoint_id=None))
+        assert await self._resolve(graph, "target") is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_empty_history(self) -> None:
+        graph = MagicMock()
+        graph.aget_state_history = _history()
+        assert await self._resolve(graph, "target") is None
+
+    @pytest.mark.asyncio
+    async def test_ignores_straggler_from_cancelled_target(self) -> None:
+        # The cancelled target writes a late 'straggler' checkpoint after the new run forked
+        # and wrote its own. The base must still be the target's ORIGINAL oldest parent (cp-P),
+        # not the straggler's parent. The order-independent full scan handles this; the old
+        # early-break version would mis-anchor on the straggler.
+        graph = MagicMock()
+        graph.aget_state_history = _history(
+            _FakeSnap("A", "cp-straggler", parent_checkpoint_id="cp-Bnew"),  # newest: A's late write
+            _FakeSnap("B", "cp-Bnew", parent_checkpoint_id="cp-P"),  # the new run's own checkpoint
+            _FakeSnap("A", "cp-A1", parent_checkpoint_id="cp-P"),  # A's original (oldest) checkpoint
+            _FakeSnap("P", "cp-P", parent_checkpoint_id=None),
+        )
+        assert await self._resolve(graph, "A") == "cp-P"
+
+    @pytest.mark.asyncio
+    async def test_raises_when_target_block_exceeds_scan_cap(self) -> None:
+        # Pathological: the target run has more checkpoints than the scan cap and the
+        # window never exits its block. Fail loud rather than fork a mid-turn checkpoint.
+        graph = MagicMock()
+        graph.aget_state_history = _history(
+            _FakeSnap("target", "cp-3", parent_checkpoint_id="cp-2"),
+            _FakeSnap("target", "cp-2", parent_checkpoint_id="cp-1"),
+            _FakeSnap("target", "cp-1", parent_checkpoint_id="cp-0"),
+        )
+        with (
+            patch("aegra_api.services.run_executor._ROLLBACK_HISTORY_LIMIT", 3),
+            pytest.raises(RuntimeError, match="exceeds 3 checkpoints"),
+        ):
+            await self._resolve(graph, "target")
+
+    @pytest.mark.asyncio
+    async def test_raises_when_cap_ends_on_non_target_row(self) -> None:
+        # The window fills with interleaved sibling rows ending on a NON-target row while
+        # older target checkpoints lie beyond it — the in-window "oldest" target is really
+        # mid-run, so resolution must fail loud instead of forking from it.
+        graph = MagicMock()
+        graph.aget_state_history = _history(
+            _FakeSnap("target", "cp-9", parent_checkpoint_id="cp-8"),
+            _FakeSnap("sibling", "cp-8", parent_checkpoint_id="cp-7"),
+            _FakeSnap("sibling", "cp-7", parent_checkpoint_id="cp-6"),
+            _FakeSnap("target", "cp-6", parent_checkpoint_id="cp-5"),  # older target beyond the cap
+        )
+        with (
+            patch("aegra_api.services.run_executor._ROLLBACK_HISTORY_LIMIT", 3),
+            pytest.raises(RuntimeError, match="exceeds 3 checkpoints"),
+        ):
+            await self._resolve(graph, "target")
+
+    @pytest.mark.asyncio
+    async def test_first_run_at_scan_cap_returns_none_not_raise(self) -> None:
+        # Target is the thread's first run and fills the scan cap; its oldest checkpoint has no
+        # parent, so it is provably the root — return None (fork fresh), not a fail-loud error.
+        graph = MagicMock()
+        graph.aget_state_history = _history(
+            _FakeSnap("target", "cp-1", parent_checkpoint_id="cp-0"),
+            _FakeSnap("target", "cp-0", parent_checkpoint_id=None),  # root, no parent
+        )
+        with patch("aegra_api.services.run_executor._ROLLBACK_HISTORY_LIMIT", 2):
+            assert await self._resolve(graph, "target") is None
+
+
+class TestRollbackForkBase:
+    """Worker re-reads the target's status so a run that raced to success is never reverted."""
+
+    @staticmethod
+    def _job() -> MagicMock:
+        job = MagicMock()
+        job.execution.rollback_target_run_id = "target"
+        job.identity.run_id = "new"
+        job.identity.thread_id = "thread"
+        job.user = User(identity="u")
+        return job
+
+    @pytest.mark.asyncio
+    async def test_skips_revert_when_target_succeeded(self) -> None:
+        # A non-empty history would resolve to cp-0; base is None only because we skipped.
+        graph = MagicMock()
+        graph.aget_state_history = _history(_FakeSnap("target", "cp-1", parent_checkpoint_id="cp-0"))
+        with patch("aegra_api.services.run_executor.get_run_status", new=AsyncMock(return_value="success")):
+            assert await _rollback_fork_base(graph, self._job()) is None
+
+    @pytest.mark.asyncio
+    async def test_resolves_base_when_target_not_success(self) -> None:
+        graph = MagicMock()
+        graph.aget_state_history = _history(
+            _FakeSnap("target", "cp-1", parent_checkpoint_id="cp-0"),
+            _FakeSnap("target", "cp-0", parent_checkpoint_id="cp-prev"),
+        )
+        with (
+            patch("aegra_api.services.run_executor.get_run_status", new=AsyncMock(return_value="interrupted")),
+            patch("aegra_api.services.run_executor.create_thread_config", return_value={"configurable": {}}),
+        ):
+            assert await _rollback_fork_base(graph, self._job()) == "cp-prev"
+
+
+def _session_with_thread(status: str | None) -> AsyncMock:
+    """Mock session whose thread lookup returns a thread row with ``status`` (None = no thread)."""
+    session = AsyncMock()
+    thread = MagicMock(status=status) if status is not None else None
+    session.scalar = AsyncMock(return_value=thread)
+    return session
+
+
+def _collapse_settle(monkeypatch: pytest.MonkeyPatch, status: str | None) -> None:
+    """Zero the resume-settle poll interval; every fresh session sees ``status``."""
+    monkeypatch.setattr(run_preparation_mod, "_RESUME_SETTLE_INTERVAL_SECONDS", 0)
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=_session_with_thread(status))
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    monkeypatch.setattr(run_preparation_mod, "_get_session_maker", lambda: MagicMock(return_value=ctx))
+
+
+class TestValidateResumeCommand:
+    """Admission-time guard tying a run's input mode to the thread's interrupt state."""
+
+    @pytest.mark.asyncio
+    async def test_fresh_input_on_paused_thread_rejected_409(self) -> None:
+        # A plain fresh-input run on a HITL-paused thread would silently consume the
+        # pending interrupt — it must be rejected so the pause stays resumable.
+        session = _session_with_thread("interrupted")
+
+        with pytest.raises(HTTPException) as exc:
+            await _validate_resume_command(session, "thread-1", None, _USER)
+
+        assert exc.value.status_code == 409
+
+    @pytest.mark.asyncio
+    async def test_fresh_input_on_idle_thread_allowed(self) -> None:
+        session = _session_with_thread("idle")
+        await _validate_resume_command(session, "thread-1", None, _USER)  # no raise
+
+    @pytest.mark.asyncio
+    async def test_fresh_input_on_new_thread_allowed(self) -> None:
+        session = _session_with_thread(None)  # thread does not exist yet
+        await _validate_resume_command(session, "thread-1", None, _USER)  # no raise
+
+    @pytest.mark.asyncio
+    async def test_resume_requires_interrupted_thread(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # The settle poll re-reads fresh sessions before rejecting; keep them idle here.
+        _collapse_settle(monkeypatch, "idle")
+        session = _session_with_thread("idle")
+        with pytest.raises(HTTPException) as exc:
+            await _validate_resume_command(session, "thread-1", {"resume": "go"}, _USER)
+        assert exc.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_resume_on_paused_thread_allowed(self) -> None:
+        session = _session_with_thread("interrupted")
+        await _validate_resume_command(session, "thread-1", {"resume": "go"}, _USER)  # no raise
+
+    @pytest.mark.asyncio
+    async def test_non_resume_command_skips_interrupt_check(self) -> None:
+        # An update/goto command on a paused thread is a deliberate state edit, not a
+        # naive fresh run — it is allowed and must not even query the thread.
+        session = _session_with_thread("interrupted")
+        await _validate_resume_command(session, "thread-1", {"update": {"k": "v"}}, _USER)
+        session.scalar.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_null_resume_command_on_paused_thread_rejected(self) -> None:
+        # command={'resume': None} must NOT slip past as a state op and error out on a paused
+        # thread (flipping it to 'error'); it is gated like fresh input -> 409, pause intact.
+        session = _session_with_thread("interrupted")
+        with pytest.raises(HTTPException) as exc:
+            await _validate_resume_command(session, "thread-1", {"resume": None}, _USER)
+        assert exc.value.status_code == 409
+
+    @pytest.mark.parametrize("command", [{"update": {}}, {"goto": []}, {"resume": None, "update": {}}])
+    @pytest.mark.asyncio
+    async def test_empty_container_command_on_paused_thread_rejected(self, command: dict[str, object]) -> None:
+        # Empty update/goto produce no LangGraph writes and would crash a paused thread to
+        # 'error'; truthiness classification routes them to the 409 gate, keeping the pause.
+        session = _session_with_thread("interrupted")
+        with pytest.raises(HTTPException) as exc:
+            await _validate_resume_command(session, "thread-1", command, _USER)
+        assert exc.value.status_code == 409
+
+    @pytest.mark.asyncio
+    async def test_truthy_update_command_still_allowed(self) -> None:
+        session = _session_with_thread("interrupted")
+        await _validate_resume_command(session, "thread-1", {"update": {"k": "v"}}, _USER)
+        session.scalar.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_malformed_command_rejected_422(self) -> None:
+        # {'goto': [0]} can't be mapped to a LangGraph Command (0['node'] -> TypeError); reject it
+        # at admission so it can't bypass the gate and crash a paused thread to 'error'.
+        session = _session_with_thread("interrupted")
+        with pytest.raises(HTTPException) as exc:
+            await _validate_resume_command(session, "thread-1", {"goto": [0]}, _USER)
+        assert exc.value.status_code == 422
+
+
+class TestFinalizeRunGuard:
+    """finalize must not resurrect a run a multitask pre-emption already terminated."""
+
+    @pytest.mark.asyncio
+    async def test_run_update_is_guarded_by_active_status(self) -> None:
+        # The run UPDATE filters status IN (running, pending), so a target the gate moved to
+        # 'interrupted' cannot be flipped to 'success' by its own late finalize.
+        captured: list[str] = []
+        session = AsyncMock()
+
+        async def _exec(stmt: object, *a: object, **k: object) -> MagicMock:
+            captured.append(str(stmt))
+            return MagicMock()
+
+        session.execute = _exec
+        session.commit = AsyncMock()
+        with patch("aegra_api.services.run_status._get_session_maker", return_value=_make_session_maker(session)):
+            await finalize_run("run-1", "thread-1", status="success", thread_status="idle")
+
+        run_update = next(s for s in captured if s.startswith("UPDATE runs"))
+        assert "runs.status IN" in run_update
+
+    @pytest.mark.asyncio
+    async def test_skips_thread_update_and_dispatch_when_run_not_owned(self) -> None:
+        # rowcount 0 => the run was already terminalized by a pre-emption gate; finalize must
+        # not clobber the thread (e.g. stomp a HITL pause to 'idle') nor dispatch the queue.
+        executed: list[str] = []
+        session = AsyncMock()
+
+        async def _exec(stmt: object, *a: object, **k: object) -> MagicMock:
+            text = str(stmt)
+            executed.append(text)
+            result = MagicMock()
+            result.rowcount = 0 if text.startswith("UPDATE runs") else 1
+            return result
+
+        session.execute = _exec
+        session.commit = AsyncMock()
+        dispatched = AsyncMock()
+        fake_executor = MagicMock()
+        fake_executor.dispatch_next_for_thread = dispatched
+        with (
+            patch("aegra_api.services.run_status._get_session_maker", return_value=_make_session_maker(session)),
+            patch("aegra_api.services.executor.executor", fake_executor),
+        ):
+            await finalize_run("run-1", "thread-1", status="success", thread_status="idle")
+
+        assert not any(s.startswith("UPDATE thread") for s in executed)  # thread not clobbered (table is singular)
+        dispatched.assert_not_awaited()  # no dispatch on a non-owned finalize
+
+    @pytest.mark.asyncio
+    async def test_terminal_override_still_excludes_committed_success(self) -> None:
+        # The timeout corrector (allow_terminal_override) may overwrite 'interrupted' but NOT a
+        # committed 'success'/'error': the run UPDATE filter widens, it never drops.
+        captured: list[str] = []
+        session = AsyncMock()
+
+        async def _exec(stmt: object, *a: object, **k: object) -> MagicMock:
+            captured.append(str(stmt.compile(compile_kwargs={"literal_binds": True})))
+            result = MagicMock()
+            result.rowcount = 1
+            return result
+
+        session.execute = _exec
+        session.commit = AsyncMock()
+        with (
+            patch("aegra_api.services.run_status._get_session_maker", return_value=_make_session_maker(session)),
+            patch("aegra_api.services.executor.executor", MagicMock(dispatch_next_for_thread=AsyncMock())),
+        ):
+            await finalize_run("r", "t", status="error", thread_status="error", allow_terminal_override=True)
+
+        run_update = next(s for s in captured if s.startswith("UPDATE runs"))
+        assert "'interrupted'" in run_update  # overrides the cancel handler's interrupted
+        assert "'success'" not in run_update  # but never a committed success
+
+
+def _capturing_session(*, rowcount: int = 1) -> tuple[AsyncMock, list[str]]:
+    """Mock session whose execute() records compiled statements and reports ``rowcount``."""
+    captured: list[str] = []
+    session = AsyncMock()
+
+    async def _exec(stmt: object, *a: object, **k: object) -> MagicMock:
+        captured.append(str(stmt.compile(compile_kwargs={"literal_binds": True})))
+        result = MagicMock()
+        result.rowcount = rowcount
+        return result
+
+    session.execute = _exec
+    session.commit = AsyncMock()
+    return session, captured
+
+
+class TestTryMarkRunRunning:
+    """The pending→running transition is a CAS so a gate-pre-empted run cannot resurrect itself."""
+
+    @pytest.mark.asyncio
+    async def test_returns_true_when_run_still_active(self) -> None:
+        session, captured = _capturing_session(rowcount=1)
+        with patch("aegra_api.services.run_status._get_session_maker", return_value=_make_session_maker(session)):
+            from aegra_api.services.run_status import try_mark_run_running
+
+            assert await try_mark_run_running("run-1") is True
+        # The UPDATE is guarded on the run still being pending/running.
+        assert "'pending'" in captured[0] and "'running'" in captured[0]
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_gate_terminalized_the_run(self) -> None:
+        session, _ = _capturing_session(rowcount=0)
+        with patch("aegra_api.services.run_status._get_session_maker", return_value=_make_session_maker(session)):
+            from aegra_api.services.run_status import try_mark_run_running
+
+            assert await try_mark_run_running("run-1") is False
+
+
+class TestTerminalizeUserCancel:
+    """User-initiated cancels converge: unpark a queued run, else CAS-finalize the active one."""
+
+    @pytest.mark.asyncio
+    async def test_queued_run_is_unparked_without_finalize(self) -> None:
+        session, captured = _capturing_session(rowcount=1)
+        mock_executor = MagicMock(dispatch_next_for_thread=AsyncMock())
+        with (
+            patch("aegra_api.services.run_status._get_session_maker", return_value=_make_session_maker(session)),
+            patch("aegra_api.services.run_status.finalize_run", new_callable=AsyncMock) as mock_finalize,
+            patch("aegra_api.services.executor.executor", mock_executor),
+        ):
+            from aegra_api.services.run_status import terminalize_user_cancel
+
+            await terminalize_user_cancel("run-1", "thread-1")
+
+        assert "'queued'" in captured[0]  # guarded flip, only a still-queued run matches
+        mock_finalize.assert_not_awaited()
+        # If the unparked run headed a stranded queue, the runs behind it must not
+        # wait for the recovery sweep — dispatch follows the unpark (idempotent).
+        mock_executor.dispatch_next_for_thread.assert_awaited_once_with("thread-1")
+
+    @pytest.mark.asyncio
+    async def test_active_run_falls_through_to_finalize_with_lease_clear(self) -> None:
+        session, _ = _capturing_session(rowcount=0)
+        with (
+            patch("aegra_api.services.run_status._get_session_maker", return_value=_make_session_maker(session)),
+            patch("aegra_api.services.run_status.finalize_run", new_callable=AsyncMock) as mock_finalize,
+        ):
+            from aegra_api.services.run_status import terminalize_user_cancel
+
+            await terminalize_user_cancel("run-1", "thread-1")
+
+        mock_finalize.assert_awaited_once()
+        kwargs = mock_finalize.await_args.kwargs
+        assert kwargs["status"] == "interrupted"
+        assert kwargs["thread_status"] == "idle"
+        # Lease cleared so a worker whose pub/sub cancel was lost self-cancels on heartbeat.
+        assert kwargs["clear_lease"] is True
+
+
+class TestFinalizeLeaseHandling:
+    @pytest.mark.asyncio
+    async def test_clear_lease_releases_claim_in_the_terminal_write(self) -> None:
+        session, captured = _capturing_session(rowcount=1)
+        with (
+            patch("aegra_api.services.run_status._get_session_maker", return_value=_make_session_maker(session)),
+            patch("aegra_api.services.executor.executor", MagicMock(dispatch_next_for_thread=AsyncMock())),
+        ):
+            await finalize_run("r", "t", status="interrupted", thread_status="idle", clear_lease=True)
+
+        run_update = next(s for s in captured if s.startswith("UPDATE runs"))
+        assert "claimed_by" in run_update and "lease_expires_at" in run_update
+
+    @pytest.mark.asyncio
+    async def test_claimed_by_narrows_the_override_to_the_callers_lease(self) -> None:
+        # The timeout corrector must not stomp an 'interrupted' the multitask gate wrote:
+        # gate cancels clear the lease, so scoping the WHERE to our claim excludes them.
+        session, captured = _capturing_session(rowcount=0)
+        with (
+            patch("aegra_api.services.run_status._get_session_maker", return_value=_make_session_maker(session)),
+            patch("aegra_api.services.executor.executor", MagicMock(dispatch_next_for_thread=AsyncMock())),
+        ):
+            await finalize_run(
+                "r",
+                "t",
+                status="error",
+                thread_status="error",
+                allow_terminal_override=True,
+                claimed_by="worker-0",
+            )
+
+        run_update = next(s for s in captured if s.startswith("UPDATE runs"))
+        assert "claimed_by = 'worker-0'" in run_update
+
+
+class TestGatePreemptionLeaseClearing:
+    @pytest.mark.asyncio
+    async def test_interrupt_clears_lease_of_preempted_run(self) -> None:
+        active = _fake_run(run_id="run-1", status="running")
+        active.execution_params = {"execution": {"command": None}}
+        session = _session_with_active([active])
+
+        should_run, cancel_ids, _ = await _apply_multitask_strategy(session, "thread-1", "interrupt", _USER)
+
+        assert should_run is True
+        assert cancel_ids == ["run-1"]
+        assert active.status == "interrupted"
+        # Lease released with the pre-emption: a worker whose pub/sub cancel is lost
+        # detects lease loss on its next heartbeat and self-cancels the job.
+        assert active.claimed_by is None
+        assert active.lease_expires_at is None
+
+
+class TestGateResumeInFlightProtection:
+    """interrupt/rollback must not cancel an in-flight resume — the fresh input would
+    land on the pending-interrupt checkpoint and silently consume the HITL pause."""
+
+    @pytest.mark.parametrize("strategy", ["interrupt", "rollback"])
+    @pytest.mark.asyncio
+    async def test_preempting_an_active_resume_is_rejected_409(self, strategy: str) -> None:
+        resume = _fake_run(run_id="resume-1", status="running")
+        resume.execution_params = {"execution": {"command": {"resume": "answer"}}}
+        session = _session_with_active([resume])
+
+        with pytest.raises(HTTPException) as exc:
+            await _apply_multitask_strategy(session, "thread-1", strategy, _USER)
+
+        assert exc.value.status_code == 409
+        assert resume.status == "running"  # untouched
+
+    @pytest.mark.asyncio
+    async def test_enqueue_behind_an_active_resume_still_parks(self) -> None:
+        resume = _fake_run(run_id="resume-1", status="running")
+        resume.execution_params = {"execution": {"command": {"resume": "answer"}}}
+        session = _session_with_active([resume])
+
+        should_run, cancel_ids, _ = await _apply_multitask_strategy(session, "thread-1", "enqueue", _USER)
+
+        assert should_run is False
+        assert cancel_ids == []
+
+    @pytest.mark.asyncio
+    async def test_preempting_a_plain_run_is_still_allowed(self) -> None:
+        plain = _fake_run(run_id="run-1", status="running")
+        plain.execution_params = {"execution": {"command": None}}
+        session = _session_with_active([plain])
+
+        should_run, cancel_ids, _ = await _apply_multitask_strategy(session, "thread-1", "interrupt", _USER)
+
+        assert should_run is True
+        assert cancel_ids == ["run-1"]
+
+
+class TestLockStatementPinning:
+    """Pin the FOR UPDATE serialization and FIFO ordering the docs promise — mocks would
+    otherwise pass green with the locks or the ORDER BY silently removed."""
+
+    @pytest.mark.asyncio
+    async def test_admission_gate_locks_the_thread_row(self) -> None:
+        session = _session_with_active([])
+
+        await _apply_multitask_strategy(session, "thread-1", "enqueue", _USER)
+
+        lock_stmt = str(session.execute.await_args_list[0].args[0])
+        assert "FOR UPDATE" in lock_stmt
+        assert "FROM thread " in lock_stmt  # the thread row lock (table name is singular)
+
+    @pytest.mark.asyncio
+    async def test_finalize_locks_the_thread_row_first(self) -> None:
+        # The comment in finalize_run says its absence deadlocks (40P01) with the gate.
+        session, captured = _capturing_session(rowcount=1)
+        with (
+            patch("aegra_api.services.run_status._get_session_maker", return_value=_make_session_maker(session)),
+            patch("aegra_api.services.executor.executor", MagicMock(dispatch_next_for_thread=AsyncMock())),
+        ):
+            await finalize_run("r", "t", status="success", thread_status="idle")
+
+        assert "FOR UPDATE" in captured[0]
+        assert captured[0].startswith("SELECT thread")  # thread row locked before the run CAS
+
+    @pytest.mark.asyncio
+    async def test_dispatch_locks_thread_and_promotes_fifo(self) -> None:
+        ex = _RecordingExecutor()
+        queued = _fake_run(run_id="queued-1", status="queued")
+        session = AsyncMock()
+        session.execute = AsyncMock()
+        session.commit = AsyncMock()
+        statements: list[str] = []
+
+        async def _scalar(stmt: Any, *a: object, **k: object) -> object:
+            statements.append(str(stmt.compile(dialect=postgresql.dialect())))
+            if len(statements) == 1:
+                return MagicMock(status="busy")  # thread row (locked read)
+            if len(statements) == 2:
+                return None  # no occupying run
+            return queued
+
+        session.scalar = _scalar
+        fake_job = MagicMock()
+        fake_job.identity.run_id = "queued-1"
+        with (
+            patch("aegra_api.services.base_executor._get_session_maker", return_value=_make_session_maker(session)),
+            patch("aegra_api.services.base_executor.RunJob.from_run_orm", return_value=fake_job),
+        ):
+            await ex.dispatch_next_for_thread("thread-1")
+
+        assert "FOR UPDATE" in statements[0]  # thread lock serializes concurrent dispatchers
+        assert "ORDER BY runs.created_at ASC" in statements[2]  # FIFO: oldest queued first
+        assert "FOR UPDATE SKIP LOCKED" in statements[2]

--- a/libs/aegra-api/tests/unit/test_services/test_run_executor.py
+++ b/libs/aegra-api/tests/unit/test_services/test_run_executor.py
@@ -43,7 +43,7 @@ class TestExecuteRunSuccess:
 
         with (
             patch("aegra_api.services.run_executor.get_langgraph_service", return_value=mock_service),
-            patch("aegra_api.services.run_executor.update_run_status", mock_update),
+            patch("aegra_api.services.run_executor.try_mark_run_running", mock_update),
             patch("aegra_api.services.run_executor.finalize_run", mock_finalize),
             patch("aegra_api.services.run_executor.streaming_service") as mock_streaming,
             patch("aegra_api.services.run_executor.stream_graph_events", return_value=_empty_async_gen()),
@@ -61,9 +61,9 @@ class TestExecuteRunSuccess:
 
             await execute_run(_make_job())
 
-        # update_run_status called once for "running"
+        # try_mark_run_running CAS called once
         assert mock_update.await_count == 1
-        assert mock_update.await_args_list[0].args == ("run-1", "running")
+        assert mock_update.await_args_list[0].args == ("run-1",)
 
         # finalize_run called once for success
         mock_finalize.assert_awaited_once()
@@ -79,7 +79,7 @@ class TestExecuteRunCancelledError:
         mock_finalize = AsyncMock()
 
         with (
-            patch("aegra_api.services.run_executor.update_run_status", mock_update),
+            patch("aegra_api.services.run_executor.try_mark_run_running", mock_update),
             patch("aegra_api.services.run_executor.finalize_run", mock_finalize),
             patch("aegra_api.services.run_executor.streaming_service") as mock_streaming,
             patch("aegra_api.services.run_executor._signal_run_done", new_callable=AsyncMock),
@@ -97,9 +97,9 @@ class TestExecuteRunCancelledError:
             with pytest.raises(asyncio.CancelledError):
                 await execute_run(_make_job())
 
-        # update_run_status called once for "running"
+        # try_mark_run_running CAS called once
         assert mock_update.await_count == 1
-        assert mock_update.await_args_list[0].args == ("run-1", "running")
+        assert mock_update.await_args_list[0].args == ("run-1",)
         # finalize_run called for "interrupted"
         mock_finalize.assert_awaited_once()
         assert mock_finalize.await_args.kwargs["status"] == "interrupted"
@@ -113,7 +113,7 @@ class TestExecuteRunException:
         mock_finalize = AsyncMock()
 
         with (
-            patch("aegra_api.services.run_executor.update_run_status", mock_update),
+            patch("aegra_api.services.run_executor.try_mark_run_running", mock_update),
             patch("aegra_api.services.run_executor.finalize_run", mock_finalize),
             patch("aegra_api.services.run_executor.streaming_service") as mock_streaming,
             patch("aegra_api.services.run_executor._signal_run_done", new_callable=AsyncMock),
@@ -130,9 +130,9 @@ class TestExecuteRunException:
 
             await execute_run(_make_job())
 
-        # update_run_status called once for "running"
+        # try_mark_run_running CAS called once
         assert mock_update.await_count == 1
-        assert mock_update.await_args_list[0].args == ("run-1", "running")
+        assert mock_update.await_args_list[0].args == ("run-1",)
         # finalize_run called for "error"
         mock_finalize.assert_awaited_once()
         assert mock_finalize.await_args.kwargs["status"] == "error"
@@ -286,7 +286,7 @@ class TestLeaseLossCancellation:
         mock_signal_done = AsyncMock()
 
         with (
-            patch("aegra_api.services.run_executor.update_run_status", mock_update),
+            patch("aegra_api.services.run_executor.try_mark_run_running", mock_update),
             patch("aegra_api.services.run_executor.finalize_run", mock_finalize),
             patch("aegra_api.services.run_executor.streaming_service") as mock_streaming,
             patch("aegra_api.services.run_executor._signal_run_done", mock_signal_done),
@@ -326,7 +326,7 @@ class TestLeaseLossCancellation:
         mock_signal_done = AsyncMock()
 
         with (
-            patch("aegra_api.services.run_executor.update_run_status", mock_update),
+            patch("aegra_api.services.run_executor.try_mark_run_running", mock_update),
             patch("aegra_api.services.run_executor.finalize_run", mock_finalize),
             patch("aegra_api.services.run_executor.streaming_service") as mock_streaming,
             patch("aegra_api.services.run_executor._signal_run_done", mock_signal_done),
@@ -351,3 +351,30 @@ class TestLeaseLossCancellation:
         # Done-key and cleanup MUST happen on normal cancel
         mock_signal_done.assert_awaited_once_with("run-1")
         mock_streaming.cleanup_run.assert_awaited_once_with("run-1")
+
+
+class TestPreemptedBeforeStart:
+    @pytest.mark.asyncio
+    async def test_gate_preempted_run_skips_execution_and_finalize(self) -> None:
+        """A run whose start CAS fails (multitask gate terminalized it between dispatch
+        and start) must not execute the graph or finalize — the gate owns its status."""
+        mock_finalize = AsyncMock()
+
+        with (
+            patch("aegra_api.services.run_executor.try_mark_run_running", AsyncMock(return_value=False)),
+            patch("aegra_api.services.run_executor._stream_graph", new_callable=AsyncMock) as mock_stream,
+            patch("aegra_api.services.run_executor.finalize_run", mock_finalize),
+            patch("aegra_api.services.run_executor.streaming_service") as mock_streaming,
+            patch("aegra_api.services.run_executor._signal_run_done", new_callable=AsyncMock) as mock_done,
+        ):
+            mock_streaming.cleanup_run = AsyncMock()
+            mock_streaming.signal_run_cancelled = AsyncMock()
+
+            from aegra_api.services.run_executor import execute_run
+
+            await execute_run(_make_job())
+
+        mock_stream.assert_not_awaited()  # graph never runs
+        mock_finalize.assert_not_awaited()  # gate owns the terminal status
+        mock_streaming.signal_run_cancelled.assert_awaited_once()  # SSE clients released
+        mock_done.assert_awaited_once()  # join/wait waiters released

--- a/libs/aegra-api/tests/unit/test_services/test_run_preparation.py
+++ b/libs/aegra-api/tests/unit/test_services/test_run_preparation.py
@@ -6,8 +6,11 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from fastapi import HTTPException
 
+from aegra_api.models.auth import User
 from aegra_api.services import run_preparation as mod
 from aegra_api.services.run_preparation import _validate_resume_command
+
+_USER = User(identity="test-user")
 
 
 @pytest.fixture(autouse=True)
@@ -44,14 +47,15 @@ def _patch_fresh_sessions(monkeypatch: pytest.MonkeyPatch, *threads: object) -> 
 class TestValidateResumeCommand:
     async def test_resume_on_interrupted_thread_passes(self) -> None:
         session = _session_returning(_thread("interrupted"))
-        await _validate_resume_command(session, "t1", {"resume": "yes"})
+        await _validate_resume_command(session, "t1", {"resume": "yes"}, _USER)
 
     async def test_resume_none_on_non_interrupted_thread_is_rejected(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """{"resume": None} must still be guarded — None is a valid resume payload."""
+        """{"resume": None} is resume-shaped and must still be guarded — LangGraph's
+        map_command drops a None resume, so it could never execute safely anyway."""
         _patch_fresh_sessions(monkeypatch, _thread("idle"))
         session = _session_returning(_thread("idle"))
         with pytest.raises(HTTPException) as exc:
-            await _validate_resume_command(session, "t1", {"resume": None})
+            await _validate_resume_command(session, "t1", {"resume": None}, _USER)
         assert exc.value.status_code == 400
 
     async def test_resume_settles_when_status_flips_to_interrupted(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -59,20 +63,21 @@ class TestValidateResumeCommand:
         the guard polls a fresh session and accepts once the status settles."""
         _patch_fresh_sessions(monkeypatch, _thread("busy"), _thread("interrupted"))
         session = _session_returning(_thread("busy"))  # first (request-session) read is stale
-        await _validate_resume_command(session, "t1", {"resume": "yes"})
+        await _validate_resume_command(session, "t1", {"resume": "yes"}, _USER)
 
     async def test_resume_on_missing_thread_is_404(self) -> None:
         session = _session_returning(None)
         with pytest.raises(HTTPException) as exc:
-            await _validate_resume_command(session, "t1", {"resume": None})
+            await _validate_resume_command(session, "t1", {"resume": None}, _USER)
         assert exc.value.status_code == 404
 
     async def test_non_resume_command_skips_check(self) -> None:
         session = _session_returning(_thread("idle"))
-        await _validate_resume_command(session, "t1", {"goto": "node"})
+        await _validate_resume_command(session, "t1", {"goto": "node"}, _USER)
         session.scalar.assert_not_awaited()
 
-    async def test_none_command_skips_check(self) -> None:
+    async def test_none_command_on_idle_thread_passes(self) -> None:
+        # Fresh input now checks the thread's interrupt state (multitask HITL gate),
+        # so the thread IS queried — it just passes on a non-interrupted thread.
         session = _session_returning(_thread("idle"))
-        await _validate_resume_command(session, "t1", None)
-        session.scalar.assert_not_awaited()
+        await _validate_resume_command(session, "t1", None, _USER)

--- a/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
+++ b/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
@@ -623,6 +623,8 @@ class TestExecuteAndRelease:
             status="error",
             thread_status="error",
             error="Job exceeded maximum execution time",
+            allow_terminal_override=True,  # overrides the cancel handler's 'interrupted' finalize
+            claimed_by="worker-0",  # scoped to our lease so gate-owned runs are never stomped
         )
         mock_release.assert_awaited_once_with(run_id, "worker-0")
         # Semaphore released even on timeout

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.9.24"
+version = "0.10.0"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -24,7 +24,7 @@ dependencies = [
     "python-dotenv>=1.2.2",
 
     # Server (always included)
-    "aegra-api~=0.9.0",
+    "aegra-api~=0.10.0",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.9.24"
+version = "0.10.0"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -100,7 +100,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.9.24"
+version = "0.10.0"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
Implements the four double-texting / multitask strategies from #253; the `rollback` strategy also repairs the orphaned-tool-call thread breakage described in #191.

## Problem

`multitask_strategy` is accepted by the API today but never read: a second run created on a thread with an active run silently executes concurrently with it, and both write to the shared LangGraph checkpoint.

## Strategies

| Strategy | Behavior with an active run |
|---|---|
| `enqueue` (default) | Park the new run; dispatch FIFO when the active run finalizes |
| `reject` | `409 Conflict` |
| `interrupt` | Cancel the active run, then run the new one from the interrupted checkpoint |
| `rollback` | Cancel the active run, then **fork** the new run from the checkpoint that *preceded* it — reverting its input and any orphaned tool calls, re-entering via `__start__` so `before_agent` repair middleware fires. On an idle thread it repairs a broken last turn (#191) but never reverts a cleanly completed one |

## Key design decisions

- **Admission gate under `SELECT ... FOR UPDATE`** on the thread row (`run_preparation._apply_multitask_strategy`), matching `finalize_run`'s lock order so concurrent creates serialize without deadlocks. Pre-empted runs are cancelled after commit (lock released) to avoid deadlocking their finalize.
- **Terminal-state writes converge via compare-and-swap** everywhere a cancel can race the run's own finalize: the pending→running transition is a CAS (a gate-pre-empted run cannot resurrect itself), and user cancels (cancel endpoint, PATCH, force-delete, disconnect-cancel) go through a shared `terminalize_user_cancel` helper — whoever wins the CAS resets the thread and promotes the next queued run, so a cancelled head never strands the queue or overwrites an already-committed terminal status.
- **Lost-cancel backstop (worker mode):** gate pre-emptions clear the run's lease, so a worker that missed the pub/sub cancel self-cancels on its next heartbeat instead of racing the new run to completion. The timeout corrector's terminal override is scoped to its own lease so it can never stomp a gate-owned run.
- **Parked runs are internal `queued`, reported as `pending` over the API** — the LangGraph SDK's `RunStatus` vocabulary has no `queued` value and LangGraph Platform reports enqueued double-texts as `pending`, so typed clients (Studio, Agent Chat UI, JS SDK) keep working unchanged.
- **HITL pauses are protected at admission:** fresh input on an interrupted thread is `409` (the guard also holds at queued-run promotion, and `interrupt`/`rollback` refuse to pre-empt an in-flight resume); a null resume is rejected (LangGraph's `map_command` drops it — it would crash the pause to `error`); malformed commands are `422` at admission. A resume jumps ahead of parked runs — it is the only run that can clear the pause.
- **`rollback` deletes nothing.** The installed postgres saver has no safe checkpoint-delete primitive, so the old branch survives as harmless siblings in `/history` while `state` returns the new head. First-run rollback has no earlier checkpoint to fork from and re-enters fresh.
- **New composite index** on `runs (thread_id, status, created_at)` for the admission check and FIFO dispatch, built with the repo's `DROP INDEX CONCURRENTLY IF EXISTS` + `CREATE INDEX CONCURRENTLY` pattern so an interrupted build is resumable.
- **Crash recovery:** queued runs are durable; stranded queues are re-dispatched by the lease reaper (worker mode) and by a startup sweep + periodic sweep in dev mode, which also fails orphaned runs and resets their thread status after a restart.

## Testing

- Unit + integration: ~90 new tests, including compiled-statement pins for the `FOR UPDATE` serialization and the FIFO `ORDER BY` (so removing a lock can't pass silently), CAS/convergence coverage for every cancel path, and HTTP-level validation tests (422/409/400).
- E2E (`tests/e2e/test_runs/test_runs_multitask_e2e.py`, 15 tests, LLM-free via the `stress_test` graph): all four strategies, FIFO promotion order with two queued runs, a truly concurrent `reject` race (`asyncio.gather`, exactly one 409), cancel-converges-thread-and-promotes-queue, HITL-pause protection, rollback repair/no-repair matrix. Verified green in **both** dev (`LocalExecutor`) and prod (Redis workers) modes.
- One behavior fix surfaced by testing: the cancel endpoints used to overwrite an already-committed terminal status (`error`/`success` → `interrupted`) unconditionally; they now converge via CAS and leave committed terminals intact.

## Versioning & docs

- `0.9.x → 0.10.0` (minor): the default handling of concurrent runs changes from "both execute" to `enqueue`.
- New guide `docs/guides/double-texting.mdx`; updates to `human-in-the-loop.mdx` (409 on fresh input to a paused thread), `cron.mdx`, `feature-support.mdx`, OpenAPI spec regenerated.

Closes #253. Closes #191.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added multitask strategies for overlapping runs: `enqueue`, `reject`, `interrupt`, and `rollback`.
  * Queued runs are surfaced as `pending` and promoted in FIFO order.
  * Added rollback execution that preserves existing checkpoints.
  * Improved handling of cancellation, human-in-the-loop pauses, and run resumption.
  * Added recovery for stranded queued runs.

* **Documentation**
  * Added a Double-texting guide and updated cron, feature-support, and human-in-the-loop documentation.
  * Updated API documentation and release version to 0.10.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds multitask handling for overlapping thread runs. The main changes are:

- New `enqueue`, `reject`, `interrupt`, and `rollback` run strategies.
- FIFO queued-run promotion with shared cancel and delete convergence.
- HITL pause protection for fresh input and resume flows.
- Worker and local recovery for stranded queued runs.
- API schema, docs, examples, tests, and version updates.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/services/run_status.py | Adds shared terminalization helpers so cancel paths reset run state and trigger queued-run promotion. |
| libs/aegra-api/src/aegra_api/api/runs.py | Routes cancel, disconnect, update, and force-delete flows through the shared convergence path. |
| libs/aegra-api/src/aegra_api/services/base_executor.py | Adds per-thread queued-run promotion with FIFO ordering, thread locking, and HITL pause protection. |
| libs/aegra-api/src/aegra_api/services/run_preparation.py | Implements the multitask admission gate, queueing behavior, preemption handling, resume protection, and rollback targeting. |
| libs/aegra-api/src/aegra_api/services/lease_reaper.py | Adds worker-mode recovery for queued threads that have no active run. |
| libs/aegra-api/src/aegra_api/services/local_executor.py | Adds local-mode startup and periodic recovery for queued runs after missed dispatch or restart. |

<sub>Reviews (3): Last reviewed commit: ["feat(api): implement multitask\_strategy ..."](https://github.com/aegra/aegra/commit/8073cdb9dc134aa85be8fcb1b247e34d5774c508) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45091952)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/aegra/github/aegra/aegra/-/custom-context?memory=1640ab19-5310-4fc5-aaf6-3760087c66e8))
- Context used - AGENTS.md ([source](https://app.greptile.com/aegra/github/aegra/aegra/-/custom-context?memory=15e5c4fa-b823-4fae-b564-d5a58cb22ed4))

<!-- /greptile_comment -->