### PR TITLE
feat(cli): add podman and podman-compose support

### DIFF
--- a/libs/aegra-cli/src/aegra_cli/cli.py
+++ b/libs/aegra-cli/src/aegra_cli/cli.py
@@ -24,7 +24,7 @@ from aegra_cli.templates import (
     get_dockerfile,
     slugify,
 )
-from aegra_cli.utils.docker import ensure_postgres_running
+from aegra_cli.utils.docker import ensure_postgres_running, get_compose_command
 
 console = Console()
 
@@ -642,7 +642,16 @@ def up(compose_file: Path | None, build: bool, services: tuple[str, ...]):
         )
     )
 
-    cmd = ["docker", "compose", "-f", str(compose_file)]
+    try:
+        compose_cmd = get_compose_command()
+    except FileNotFoundError:
+        console.print(
+            "[bold red]Error:[/bold red] No compose tool found.\n"
+            "Install Docker Desktop, podman-compose, or docker-compose."
+        )
+        sys.exit(1)
+
+    cmd = [*compose_cmd, "-f", str(compose_file)]
 
     cmd.append("up")
     cmd.append("-d")
@@ -664,19 +673,18 @@ def up(compose_file: Path | None, build: bool, services: tuple[str, ...]):
         if result.returncode == 0:
             console.print("\n[bold green]Services started successfully![/bold green]")
             console.print()
-            console.print(
-                "[dim]View logs:    docker compose -f " + str(compose_file) + " logs -f[/dim]"
-            )
+            compose_str = " ".join(compose_cmd)
+            console.print(f"[dim]View logs:    {compose_str} -f {compose_file} logs -f[/dim]")
             console.print("[dim]Stop:         aegra down[/dim]")
         else:
             console.print(
-                f"\n[bold red]Error:[/bold red] Docker Compose exited with code {result.returncode}"
+                f"\n[bold red]Error:[/bold red] Compose exited with code {result.returncode}"
             )
         sys.exit(result.returncode)
     except FileNotFoundError:
         console.print(
-            "[bold red]Error:[/bold red] docker is not installed or not in PATH.\n"
-            "Please install Docker Desktop or Docker Engine."
+            "[bold red]Error:[/bold red] Compose tool not found in PATH.\n"
+            "Install Docker Desktop, podman-compose, or docker-compose."
         )
         sys.exit(1)
 
@@ -736,7 +744,16 @@ def down(compose_file: Path | None, volumes: bool):
 
     console.print(f"\n[cyan]Stopping:[/cyan] {target_compose}")
 
-    cmd = ["docker", "compose", "-f", str(target_compose), "down"]
+    try:
+        compose_cmd = get_compose_command()
+    except FileNotFoundError:
+        console.print(
+            "[bold red]Error:[/bold red] No compose tool found.\n"
+            "Install Docker Desktop, podman-compose, or docker-compose."
+        )
+        sys.exit(1)
+
+    cmd = [*compose_cmd, "-f", str(target_compose), "down"]
 
     if volumes:
         cmd.append("-v")
@@ -753,8 +770,8 @@ def down(compose_file: Path | None, volumes: bool):
             sys.exit(1)
     except FileNotFoundError:
         console.print(
-            "[bold red]Error:[/bold red] docker is not installed or not in PATH.\n"
-            "Please install Docker Desktop or Docker Engine."
+            "[bold red]Error:[/bold red] Compose tool not found in PATH.\n"
+            "Install Docker Desktop, podman-compose, or docker-compose."
         )
         sys.exit(1)
 

--- a/libs/aegra-cli/src/aegra_cli/cli.py
+++ b/libs/aegra-cli/src/aegra_cli/cli.py
@@ -28,6 +28,19 @@ from aegra_cli.utils.docker import ensure_postgres_running, get_compose_command
 
 console = Console()
 
+
+def _resolve_compose_command() -> list[str]:
+    """Resolve the compose command or exit with an error."""
+    try:
+        return get_compose_command()
+    except FileNotFoundError:
+        console.print(
+            "[bold red]Error:[/bold red] No compose tool found.\n"
+            "Install Docker Desktop, podman-compose, or docker-compose."
+        )
+        sys.exit(1)
+
+
 # Default values for server options (single source of truth)
 _DEFAULT_DEV_HOST = "127.0.0.1"
 _DEFAULT_SERVE_HOST = "0.0.0.0"  # noqa: S104  # nosec B104 - intentional for Docker
@@ -607,9 +620,8 @@ def serve(ctx: click.Context, host: str, port: int, app: str, config_file: Path 
 )
 @click.argument("services", nargs=-1)
 def up(compose_file: Path | None, build: bool, services: tuple[str, ...]):
-    """Start services with Docker Compose.
+    """Start services with the detected compose tool.
 
-    Uses docker-compose.yml which contains both postgres and the API service.
     Auto-generates Docker files if they don't exist.
 
     Examples:
@@ -642,14 +654,7 @@ def up(compose_file: Path | None, build: bool, services: tuple[str, ...]):
         )
     )
 
-    try:
-        compose_cmd = get_compose_command()
-    except FileNotFoundError:
-        console.print(
-            "[bold red]Error:[/bold red] No compose tool found.\n"
-            "Install Docker Desktop, podman-compose, or docker-compose."
-        )
-        sys.exit(1)
+    compose_cmd = _resolve_compose_command()
 
     cmd = [*compose_cmd, "-f", str(compose_file)]
 
@@ -706,9 +711,7 @@ def up(compose_file: Path | None, build: bool, services: tuple[str, ...]):
     help="Remove named volumes declared in the compose file.",
 )
 def down(compose_file: Path | None, volumes: bool):
-    """Stop services with Docker Compose.
-
-    Runs 'docker compose down' to stop and remove containers.
+    """Stop services with the detected compose tool.
 
     Examples:
 
@@ -744,14 +747,7 @@ def down(compose_file: Path | None, volumes: bool):
 
     console.print(f"\n[cyan]Stopping:[/cyan] {target_compose}")
 
-    try:
-        compose_cmd = get_compose_command()
-    except FileNotFoundError:
-        console.print(
-            "[bold red]Error:[/bold red] No compose tool found.\n"
-            "Install Docker Desktop, podman-compose, or docker-compose."
-        )
-        sys.exit(1)
+    compose_cmd = _resolve_compose_command()
 
     cmd = [*compose_cmd, "-f", str(target_compose), "down"]
 

--- a/libs/aegra-cli/src/aegra_cli/utils/docker.py
+++ b/libs/aegra-cli/src/aegra_cli/utils/docker.py
@@ -283,16 +283,16 @@ def is_postgres_container_running(compose_file: Path | None = None) -> bool:
         except (subprocess.TimeoutExpired, FileNotFoundError):
             pass
     else:
-        try:
-            runtime = get_container_command()
-        except FileNotFoundError:
-            return False
+        runtime = compose_cmd[0].split("-")[0]
+        project = (compose_file.parent.name if compose_file else Path.cwd().name).lower()
         cmd = [
             runtime,
             "ps",
             "-q",
             "--filter",
             "label=com.docker.compose.service=postgres",
+            "--filter",
+            f"label=com.docker.compose.project={project}",
             "--filter",
             "status=running",
         ]

--- a/libs/aegra-cli/src/aegra_cli/utils/docker.py
+++ b/libs/aegra-cli/src/aegra_cli/utils/docker.py
@@ -14,16 +14,72 @@ from rich.console import Console
 console = Console()
 
 
+def get_compose_command() -> list[str]:
+    """Detect the available compose command.
+
+    Checks in order: docker compose (v2 plugin), podman-compose, docker-compose (v1).
+    Returns the command as a list suitable for subprocess calls.
+
+    Raises:
+        FileNotFoundError: If no compose tool is found.
+    """
+    try:
+        result = subprocess.run(
+            ["docker", "compose", "version"],
+            capture_output=True,
+            timeout=10,
+        )
+        if result.returncode == 0:
+            return ["docker", "compose"]
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+
+    if shutil.which("podman-compose"):
+        return ["podman-compose"]
+
+    if shutil.which("docker-compose"):
+        return ["docker-compose"]
+
+    raise FileNotFoundError(
+        "No container compose tool found. Install one of: "
+        "Docker Desktop, podman-compose, or docker-compose."
+    )
+
+
+def get_container_command() -> str:
+    """Detect the available container runtime command.
+
+    Returns 'docker' or 'podman', preferring docker if both are available.
+
+    Raises:
+        FileNotFoundError: If neither docker nor podman is found.
+    """
+    if shutil.which("docker"):
+        return "docker"
+    if shutil.which("podman"):
+        return "podman"
+    raise FileNotFoundError("No container runtime found. Install Docker or Podman.")
+
+
+def is_container_runtime_installed() -> bool:
+    """Check if a container runtime (Docker or Podman) is installed."""
+    return shutil.which("docker") is not None or shutil.which("podman") is not None
+
+
 def is_docker_installed() -> bool:
     """Check if Docker CLI is installed and available in PATH."""
     return shutil.which("docker") is not None
 
 
 def is_docker_running() -> bool:
-    """Check if Docker daemon is running.
+    """Check if a container runtime is available.
 
-    Returns True if we can communicate with Docker daemon.
+    For Docker, checks if the daemon is responding. Podman is daemonless
+    and is always considered running if installed.
     """
+    if shutil.which("podman"):
+        return True
+
     if not is_docker_installed():
         return False
 
@@ -194,7 +250,12 @@ def is_postgres_container_running(compose_file: Path | None = None) -> bool:
     Returns:
         True if postgres service is running.
     """
-    cmd = ["docker", "compose"]
+    try:
+        compose_cmd = get_compose_command()
+    except FileNotFoundError:
+        return False
+
+    cmd = list(compose_cmd)
 
     if compose_file:
         cmd.extend(["-f", str(compose_file)])
@@ -217,8 +278,20 @@ def is_postgres_container_running(compose_file: Path | None = None) -> bool:
     return False
 
 
+def _supports_wait_flag(compose_cmd: list[str]) -> bool:
+    """Check if the compose command supports the --wait flag.
+
+    Docker Compose v2 (plugin) supports --wait. podman-compose and
+    docker-compose v1 do not.
+    """
+    return compose_cmd == ["docker", "compose"]
+
+
 def start_postgres_container(compose_file: Path | None = None) -> bool:
-    """Start the PostgreSQL container using docker compose.
+    """Start the PostgreSQL container using the detected compose tool.
+
+    Uses --wait for Docker Compose v2. For podman-compose and docker-compose v1,
+    starts the container and polls for readiness.
 
     Args:
         compose_file: Optional path to docker-compose.yml file.
@@ -226,30 +299,66 @@ def start_postgres_container(compose_file: Path | None = None) -> bool:
     Returns:
         True if postgres was started successfully.
     """
-    cmd = ["docker", "compose"]
+    try:
+        compose_cmd = get_compose_command()
+    except FileNotFoundError:
+        console.print("[red]No compose tool found[/red]")
+        return False
+
+    cmd = list(compose_cmd)
 
     if compose_file:
         cmd.extend(["-f", str(compose_file)])
 
-    cmd.extend(["up", "-d", "--wait", "postgres"])
+    if _supports_wait_flag(compose_cmd):
+        cmd.extend(["up", "-d", "--wait", "postgres"])
+    else:
+        cmd.extend(["up", "-d", "postgres"])
 
     console.print("[cyan]Starting PostgreSQL container...[/cyan]")
     console.print(f"[dim]Running: {' '.join(cmd)}[/dim]")
 
     try:
         result = subprocess.run(cmd, timeout=120)
-        if result.returncode == 0:
-            console.print("[green]PostgreSQL container started successfully![/green]")
-            return True
-        else:
+        if result.returncode != 0:
             console.print(
                 f"[red]Failed to start PostgreSQL container (exit code {result.returncode})[/red]"
             )
+            return False
     except subprocess.TimeoutExpired:
         console.print("[red]Timeout while starting PostgreSQL container[/red]")
+        return False
     except FileNotFoundError:
-        console.print("[red]Docker command not found[/red]")
+        console.print("[red]Compose command not found[/red]")
+        return False
 
+    if not _supports_wait_flag(compose_cmd):
+        return _wait_for_postgres_ready(compose_file)
+
+    console.print("[green]PostgreSQL container started successfully![/green]")
+    return True
+
+
+def _wait_for_postgres_ready(
+    compose_file: Path | None = None,
+    timeout_seconds: int = 30,
+) -> bool:
+    """Poll PostgreSQL container until it accepts connections.
+
+    Used when the compose tool doesn't support --wait.
+    """
+    import time
+
+    console.print("[dim]Waiting for PostgreSQL to be ready...[/dim]")
+    start_time = time.time()
+
+    while time.time() - start_time < timeout_seconds:
+        if is_postgres_container_running(compose_file):
+            console.print("[green]PostgreSQL container started successfully![/green]")
+            return True
+        time.sleep(1)
+
+    console.print(f"[red]PostgreSQL did not become ready within {timeout_seconds}s[/red]")
     return False
 
 
@@ -291,13 +400,14 @@ def ensure_postgres_running(compose_file: Path | None = None) -> bool:
     Returns:
         True if PostgreSQL is running (either was already running or was started).
     """
-    # Step 1: Check if Docker is installed
-    if not is_docker_installed():
+    # Step 1: Check if a container runtime is installed
+    if not is_container_runtime_installed():
         console.print(
-            "\n[bold red]Docker is not installed![/bold red]\n\n"
-            "Aegra requires Docker to run PostgreSQL for state persistence.\n\n"
+            "\n[bold red]No container runtime found![/bold red]\n\n"
+            "Aegra requires Docker or Podman to run PostgreSQL for state persistence.\n\n"
             "[bold]Installation instructions:[/bold]\n"
-            "  • [cyan]https://docs.docker.com/get-docker/[/cyan]\n"
+            "  • Docker: [cyan]https://docs.docker.com/get-docker/[/cyan]\n"
+            "  • Podman: [cyan]https://podman.io/docs/installation[/cyan]\n"
         )
         return False
 

--- a/libs/aegra-cli/src/aegra_cli/utils/docker.py
+++ b/libs/aegra-cli/src/aegra_cli/utils/docker.py
@@ -442,8 +442,17 @@ def ensure_postgres_running(compose_file: Path | None = None) -> bool:
         )
         return False
 
-    # Step 2: Check if Docker daemon is running
+    # Step 2: Check if container runtime is ready
     if not is_docker_running():
+        if shutil.which("podman") and not shutil.which("docker"):
+            console.print(
+                "\n[bold red]Podman is not ready.[/bold red]\n\n"
+                "Start your Podman machine:\n"
+                "  [cyan]podman machine start[/cyan]\n\n"
+                "[dim]Then run 'aegra dev' again.[/dim]"
+            )
+            return False
+
         console.print("\n[yellow]Docker is not running.[/yellow]")
 
         # Try to start Docker automatically

--- a/libs/aegra-cli/src/aegra_cli/utils/docker.py
+++ b/libs/aegra-cli/src/aegra_cli/utils/docker.py
@@ -4,6 +4,7 @@ This module provides helpers to detect Docker installation, check if Docker is r
 and manage PostgreSQL containers for local development.
 """
 
+import os
 import platform
 import shutil
 import subprocess
@@ -41,7 +42,16 @@ def get_compose_command() -> list[str]:
         pass
 
     if shutil.which("podman-compose"):
-        return ["podman-compose"]
+        try:
+            podman_info = subprocess.run(
+                ["podman", "info"],
+                capture_output=True,
+                timeout=10,
+            )
+            if podman_info.returncode == 0:
+                return ["podman-compose"]
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            pass
 
     if shutil.which("docker-compose"):
         return ["docker-compose"]
@@ -284,7 +294,9 @@ def is_postgres_container_running(compose_file: Path | None = None) -> bool:
             pass
     else:
         runtime = compose_cmd[0].split("-")[0]
-        project = (compose_file.parent.name if compose_file else Path.cwd().name).lower()
+        project = os.environ.get("COMPOSE_PROJECT_NAME") or (
+            compose_file.parent.name if compose_file else Path.cwd().name
+        ).lower()
         cmd = [
             runtime,
             "ps",

--- a/libs/aegra-cli/src/aegra_cli/utils/docker.py
+++ b/libs/aegra-cli/src/aegra_cli/utils/docker.py
@@ -30,7 +30,13 @@ def get_compose_command() -> list[str]:
             timeout=10,
         )
         if result.returncode == 0:
-            return ["docker", "compose"]
+            daemon = subprocess.run(
+                ["docker", "info"],
+                capture_output=True,
+                timeout=10,
+            )
+            if daemon.returncode == 0:
+                return ["docker", "compose"]
     except (subprocess.TimeoutExpired, FileNotFoundError):
         pass
 
@@ -78,7 +84,16 @@ def is_docker_running() -> bool:
     and is always considered running if installed.
     """
     if shutil.which("podman"):
-        return True
+        try:
+            result = subprocess.run(
+                ["podman", "info"],
+                capture_output=True,
+                timeout=10,
+            )
+            if result.returncode == 0:
+                return True
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            pass
 
     if not is_docker_installed():
         return False
@@ -345,17 +360,33 @@ def _wait_for_postgres_ready(
 ) -> bool:
     """Poll PostgreSQL container until it accepts connections.
 
+    Uses pg_isready via compose exec for a true readiness check,
+    rather than just checking container status.
     Used when the compose tool doesn't support --wait.
     """
     import time
+
+    try:
+        compose_cmd = get_compose_command()
+    except FileNotFoundError:
+        return False
+
+    check_cmd = list(compose_cmd)
+    if compose_file:
+        check_cmd.extend(["-f", str(compose_file)])
+    check_cmd.extend(["exec", "-T", "postgres", "pg_isready", "-U", "postgres"])
 
     console.print("[dim]Waiting for PostgreSQL to be ready...[/dim]")
     start_time = time.time()
 
     while time.time() - start_time < timeout_seconds:
-        if is_postgres_container_running(compose_file):
-            console.print("[green]PostgreSQL container started successfully![/green]")
-            return True
+        try:
+            result = subprocess.run(check_cmd, capture_output=True, timeout=10)
+            if result.returncode == 0:
+                console.print("[green]PostgreSQL container started successfully![/green]")
+                return True
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            pass
         time.sleep(1)
 
     console.print(f"[red]PostgreSQL did not become ready within {timeout_seconds}s[/red]")

--- a/libs/aegra-cli/src/aegra_cli/utils/docker.py
+++ b/libs/aegra-cli/src/aegra_cli/utils/docker.py
@@ -80,8 +80,9 @@ def is_docker_installed() -> bool:
 def is_docker_running() -> bool:
     """Check if a container runtime is available.
 
-    For Docker, checks if the daemon is responding. Podman is daemonless
-    and is always considered running if installed.
+    For Docker, checks if the daemon is responding.
+    For Podman, checks if the runtime is ready via ``podman info``
+    (the VM must be running on macOS/Windows).
     """
     if shutil.which("podman"):
         try:
@@ -270,25 +271,37 @@ def is_postgres_container_running(compose_file: Path | None = None) -> bool:
     except FileNotFoundError:
         return False
 
-    cmd = list(compose_cmd)
-
-    if compose_file:
-        cmd.extend(["-f", str(compose_file)])
-
-    cmd.extend(["ps", "--services", "--filter", "status=running"])
-
-    try:
-        result = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-        if result.returncode == 0:
-            running_services = result.stdout.strip().split("\n")
-            return "postgres" in running_services
-    except (subprocess.TimeoutExpired, FileNotFoundError):
-        pass
+    if compose_cmd == ["docker", "compose"]:
+        cmd = list(compose_cmd)
+        if compose_file:
+            cmd.extend(["-f", str(compose_file)])
+        cmd.extend(["ps", "--services", "--filter", "status=running"])
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+            if result.returncode == 0:
+                return "postgres" in result.stdout.strip().split("\n")
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            pass
+    else:
+        try:
+            runtime = get_container_command()
+        except FileNotFoundError:
+            return False
+        cmd = [
+            runtime,
+            "ps",
+            "-q",
+            "--filter",
+            "label=com.docker.compose.service=postgres",
+            "--filter",
+            "status=running",
+        ]
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+            if result.returncode == 0 and result.stdout.strip():
+                return True
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            pass
 
     return False
 
@@ -348,13 +361,14 @@ def start_postgres_container(compose_file: Path | None = None) -> bool:
         return False
 
     if not _supports_wait_flag(compose_cmd):
-        return _wait_for_postgres_ready(compose_file)
+        return _wait_for_postgres_ready(compose_cmd, compose_file)
 
     console.print("[green]PostgreSQL container started successfully![/green]")
     return True
 
 
 def _wait_for_postgres_ready(
+    compose_cmd: list[str],
     compose_file: Path | None = None,
     timeout_seconds: int = 30,
 ) -> bool:
@@ -365,11 +379,6 @@ def _wait_for_postgres_ready(
     Used when the compose tool doesn't support --wait.
     """
     import time
-
-    try:
-        compose_cmd = get_compose_command()
-    except FileNotFoundError:
-        return False
 
     check_cmd = list(compose_cmd)
     if compose_file:
@@ -445,12 +454,20 @@ def ensure_postgres_running(compose_file: Path | None = None) -> bool:
     # Step 2: Check if container runtime is ready
     if not is_docker_running():
         if shutil.which("podman") and not shutil.which("docker"):
-            console.print(
-                "\n[bold red]Podman is not ready.[/bold red]\n\n"
-                "Start your Podman machine:\n"
-                "  [cyan]podman machine start[/cyan]\n\n"
-                "[dim]Then run 'aegra dev' again.[/dim]"
-            )
+            system = platform.system().lower()
+            if system == "linux":
+                console.print(
+                    "\n[bold red]Podman is not working.[/bold red]\n\n"
+                    "Try running [cyan]podman info[/cyan] to diagnose the issue.\n\n"
+                    "[dim]Then run 'aegra dev' again.[/dim]"
+                )
+            else:
+                console.print(
+                    "\n[bold red]Podman is not ready.[/bold red]\n\n"
+                    "Start your Podman machine:\n"
+                    "  [cyan]podman machine start[/cyan]\n\n"
+                    "[dim]Then run 'aegra dev' again.[/dim]"
+                )
             return False
 
         console.print("\n[yellow]Docker is not running.[/yellow]")

--- a/libs/aegra-cli/tests/test_cli.py
+++ b/libs/aegra-cli/tests/test_cli.py
@@ -491,7 +491,11 @@ class TestUpCommand:
     def test_up_builds_correct_command(self, cli_runner: CliRunner, tmp_path: Path) -> None:
         """Test that up command builds the correct docker compose command."""
         with cli_runner.isolated_filesystem(temp_dir=tmp_path):
-            with patch("aegra_cli.cli.subprocess.run") as mock_run:
+            with (
+                patch("aegra_cli.cli.get_compose_command") as mock_compose,
+                patch("aegra_cli.cli.subprocess.run") as mock_run,
+            ):
+                mock_compose.return_value = ["docker", "compose"]
                 mock_run.return_value.returncode = 0
                 result = cli_runner.invoke(cli, ["up"])
 
@@ -506,7 +510,11 @@ class TestUpCommand:
     def test_up_includes_build_by_default(self, cli_runner: CliRunner, tmp_path: Path) -> None:
         """Test that up command includes --build by default."""
         with cli_runner.isolated_filesystem(temp_dir=tmp_path):
-            with patch("aegra_cli.cli.subprocess.run") as mock_run:
+            with (
+                patch("aegra_cli.cli.get_compose_command") as mock_compose,
+                patch("aegra_cli.cli.subprocess.run") as mock_run,
+            ):
+                mock_compose.return_value = ["docker", "compose"]
                 mock_run.return_value.returncode = 0
                 result = cli_runner.invoke(cli, ["up"])
 
@@ -516,7 +524,11 @@ class TestUpCommand:
     def test_up_with_specific_services(self, cli_runner: CliRunner, tmp_path: Path) -> None:
         """Test that up command passes specific services."""
         with cli_runner.isolated_filesystem(temp_dir=tmp_path):
-            with patch("aegra_cli.cli.subprocess.run") as mock_run:
+            with (
+                patch("aegra_cli.cli.get_compose_command") as mock_compose,
+                patch("aegra_cli.cli.subprocess.run") as mock_run,
+            ):
+                mock_compose.return_value = ["docker", "compose"]
                 mock_run.return_value.returncode = 0
                 result = cli_runner.invoke(cli, ["up", "postgres", "redis"])
 
@@ -526,7 +538,11 @@ class TestUpCommand:
 
     def test_up_with_compose_file(self, cli_runner: CliRunner, mock_compose_file: Path) -> None:
         """Test that up command accepts custom compose file."""
-        with patch("aegra_cli.cli.subprocess.run") as mock_run:
+        with (
+            patch("aegra_cli.cli.get_compose_command") as mock_compose,
+            patch("aegra_cli.cli.subprocess.run") as mock_run,
+        ):
+            mock_compose.return_value = ["docker", "compose"]
             mock_run.return_value.returncode = 0
             result = cli_runner.invoke(cli, ["up", "-f", str(mock_compose_file)])
 
@@ -538,7 +554,11 @@ class TestUpCommand:
     def test_up_success_message(self, cli_runner: CliRunner, tmp_path: Path) -> None:
         """Test that up command shows success message."""
         with cli_runner.isolated_filesystem(temp_dir=tmp_path):
-            with patch("aegra_cli.cli.subprocess.run") as mock_run:
+            with (
+                patch("aegra_cli.cli.get_compose_command") as mock_compose,
+                patch("aegra_cli.cli.subprocess.run") as mock_run,
+            ):
+                mock_compose.return_value = ["docker", "compose"]
                 mock_run.return_value.returncode = 0
                 result = cli_runner.invoke(cli, ["up"])
 
@@ -547,27 +567,35 @@ class TestUpCommand:
     def test_up_failure_shows_error(self, cli_runner: CliRunner, tmp_path: Path) -> None:
         """Test that up command shows error on failure."""
         with cli_runner.isolated_filesystem(temp_dir=tmp_path):
-            with patch("aegra_cli.cli.subprocess.run") as mock_run:
+            with (
+                patch("aegra_cli.cli.get_compose_command") as mock_compose,
+                patch("aegra_cli.cli.subprocess.run") as mock_run,
+            ):
+                mock_compose.return_value = ["docker", "compose"]
                 mock_run.return_value.returncode = 1
                 result = cli_runner.invoke(cli, ["up"])
 
                 assert result.exit_code == 1
                 assert "Error" in result.output
 
-    def test_up_docker_not_installed(self, cli_runner: CliRunner, tmp_path: Path) -> None:
-        """Test error handling when docker is not installed."""
+    def test_up_no_compose_tool(self, cli_runner: CliRunner, tmp_path: Path) -> None:
+        """Test error handling when no compose tool is installed."""
         with cli_runner.isolated_filesystem(temp_dir=tmp_path):
-            with patch("aegra_cli.cli.subprocess.run") as mock_run:
-                mock_run.side_effect = FileNotFoundError("docker not found")
+            with patch("aegra_cli.cli.get_compose_command") as mock_compose:
+                mock_compose.side_effect = FileNotFoundError("No container compose tool found")
                 result = cli_runner.invoke(cli, ["up"])
 
                 assert result.exit_code == 1
-                assert "docker is not installed" in result.output
+                assert "no compose tool found" in result.output.lower()
 
     def test_up_shows_running_command(self, cli_runner: CliRunner, tmp_path: Path) -> None:
         """Test that up command shows the command being run."""
         with cli_runner.isolated_filesystem(temp_dir=tmp_path):
-            with patch("aegra_cli.cli.subprocess.run") as mock_run:
+            with (
+                patch("aegra_cli.cli.get_compose_command") as mock_compose,
+                patch("aegra_cli.cli.subprocess.run") as mock_run,
+            ):
+                mock_compose.return_value = ["docker", "compose"]
                 mock_run.return_value.returncode = 0
                 result = cli_runner.invoke(cli, ["up"])
 
@@ -583,7 +611,11 @@ class TestDownCommand:
         with cli_runner.isolated_filesystem(temp_dir=tmp_path):
             Path("docker-compose.yml").write_text("services: {}")
 
-            with patch("aegra_cli.cli.subprocess.run") as mock_run:
+            with (
+                patch("aegra_cli.cli.get_compose_command") as mock_compose,
+                patch("aegra_cli.cli.subprocess.run") as mock_run,
+            ):
+                mock_compose.return_value = ["docker", "compose"]
                 mock_run.return_value.returncode = 0
                 result = cli_runner.invoke(cli, ["down"])
 
@@ -600,7 +632,11 @@ class TestDownCommand:
         with cli_runner.isolated_filesystem(temp_dir=tmp_path):
             Path("docker-compose.yml").write_text("services: {}")
 
-            with patch("aegra_cli.cli.subprocess.run") as mock_run:
+            with (
+                patch("aegra_cli.cli.get_compose_command") as mock_compose,
+                patch("aegra_cli.cli.subprocess.run") as mock_run,
+            ):
+                mock_compose.return_value = ["docker", "compose"]
                 mock_run.return_value.returncode = 0
                 result = cli_runner.invoke(cli, ["down", "--volumes"])
 
@@ -612,7 +648,11 @@ class TestDownCommand:
         with cli_runner.isolated_filesystem(temp_dir=tmp_path):
             Path("docker-compose.yml").write_text("services: {}")
 
-            with patch("aegra_cli.cli.subprocess.run") as mock_run:
+            with (
+                patch("aegra_cli.cli.get_compose_command") as mock_compose,
+                patch("aegra_cli.cli.subprocess.run") as mock_run,
+            ):
+                mock_compose.return_value = ["docker", "compose"]
                 mock_run.return_value.returncode = 0
                 result = cli_runner.invoke(cli, ["down", "-v"])
 
@@ -624,7 +664,11 @@ class TestDownCommand:
         with cli_runner.isolated_filesystem(temp_dir=tmp_path):
             Path("docker-compose.yml").write_text("services: {}")
 
-            with patch("aegra_cli.cli.subprocess.run") as mock_run:
+            with (
+                patch("aegra_cli.cli.get_compose_command") as mock_compose,
+                patch("aegra_cli.cli.subprocess.run") as mock_run,
+            ):
+                mock_compose.return_value = ["docker", "compose"]
                 mock_run.return_value.returncode = 0
                 result = cli_runner.invoke(cli, ["down", "-v"])
 
@@ -635,7 +679,11 @@ class TestDownCommand:
         self, cli_runner: CliRunner, mock_compose_file: Path
     ) -> None:
         """Test that down command accepts custom compose file."""
-        with patch("aegra_cli.cli.subprocess.run") as mock_run:
+        with (
+            patch("aegra_cli.cli.get_compose_command") as mock_compose,
+            patch("aegra_cli.cli.subprocess.run") as mock_run,
+        ):
+            mock_compose.return_value = ["docker", "compose"]
             mock_run.return_value.returncode = 0
             result = cli_runner.invoke(cli, ["down", "-f", str(mock_compose_file)])
 
@@ -649,7 +697,11 @@ class TestDownCommand:
         with cli_runner.isolated_filesystem(temp_dir=tmp_path):
             Path("docker-compose.yml").write_text("services: {}")
 
-            with patch("aegra_cli.cli.subprocess.run") as mock_run:
+            with (
+                patch("aegra_cli.cli.get_compose_command") as mock_compose,
+                patch("aegra_cli.cli.subprocess.run") as mock_run,
+            ):
+                mock_compose.return_value = ["docker", "compose"]
                 mock_run.return_value.returncode = 0
                 result = cli_runner.invoke(cli, ["down"])
 
@@ -660,31 +712,39 @@ class TestDownCommand:
         with cli_runner.isolated_filesystem(temp_dir=tmp_path):
             Path("docker-compose.yml").write_text("services: {}")
 
-            with patch("aegra_cli.cli.subprocess.run") as mock_run:
+            with (
+                patch("aegra_cli.cli.get_compose_command") as mock_compose,
+                patch("aegra_cli.cli.subprocess.run") as mock_run,
+            ):
+                mock_compose.return_value = ["docker", "compose"]
                 mock_run.return_value.returncode = 1
                 result = cli_runner.invoke(cli, ["down"])
 
                 assert result.exit_code == 1
                 assert "failed to stop" in result.output
 
-    def test_down_docker_not_installed(self, cli_runner: CliRunner, tmp_path: Path) -> None:
-        """Test error handling when docker is not installed."""
+    def test_down_no_compose_tool(self, cli_runner: CliRunner, tmp_path: Path) -> None:
+        """Test error handling when no compose tool is installed."""
         with cli_runner.isolated_filesystem(temp_dir=tmp_path):
             Path("docker-compose.yml").write_text("services: {}")
 
-            with patch("aegra_cli.cli.subprocess.run") as mock_run:
-                mock_run.side_effect = FileNotFoundError("docker not found")
+            with patch("aegra_cli.cli.get_compose_command") as mock_compose:
+                mock_compose.side_effect = FileNotFoundError("No container compose tool found")
                 result = cli_runner.invoke(cli, ["down"])
 
                 assert result.exit_code == 1
-                assert "docker is not installed" in result.output
+                assert "no compose tool found" in result.output.lower()
 
     def test_down_shows_running_command(self, cli_runner: CliRunner, tmp_path: Path) -> None:
         """Test that down command shows the command being run."""
         with cli_runner.isolated_filesystem(temp_dir=tmp_path):
             Path("docker-compose.yml").write_text("services: {}")
 
-            with patch("aegra_cli.cli.subprocess.run") as mock_run:
+            with (
+                patch("aegra_cli.cli.get_compose_command") as mock_compose,
+                patch("aegra_cli.cli.subprocess.run") as mock_run,
+            ):
+                mock_compose.return_value = ["docker", "compose"]
                 mock_run.return_value.returncode = 0
                 result = cli_runner.invoke(cli, ["down"])
 
@@ -972,7 +1032,11 @@ class TestUpCommandExtended:
     def test_up_with_no_build_flag(self, cli_runner: CliRunner, tmp_path: Path) -> None:
         """Test that up --no-build skips building."""
         with cli_runner.isolated_filesystem(temp_dir=tmp_path):
-            with patch("aegra_cli.cli.subprocess.run") as mock_run:
+            with (
+                patch("aegra_cli.cli.get_compose_command") as mock_compose,
+                patch("aegra_cli.cli.subprocess.run") as mock_run,
+            ):
+                mock_compose.return_value = ["docker", "compose"]
                 mock_run.return_value.returncode = 0
                 result = cli_runner.invoke(cli, ["up", "--no-build"])
 
@@ -983,12 +1047,15 @@ class TestUpCommandExtended:
     def test_up_auto_generates_docker_files(self, cli_runner: CliRunner, tmp_path: Path) -> None:
         """Test that up auto-generates Docker files."""
         with cli_runner.isolated_filesystem(temp_dir=tmp_path):
-            with patch("aegra_cli.cli.subprocess.run") as mock_run:
+            with (
+                patch("aegra_cli.cli.get_compose_command") as mock_compose,
+                patch("aegra_cli.cli.subprocess.run") as mock_run,
+            ):
+                mock_compose.return_value = ["docker", "compose"]
                 mock_run.return_value.returncode = 0
                 result = cli_runner.invoke(cli, ["up"])
 
                 assert result.exit_code == 0
-                # Files should be created
                 assert Path("docker-compose.yml").exists()
                 assert Path("Dockerfile").exists()
 
@@ -1008,7 +1075,11 @@ class TestDownCommandExtended:
         with cli_runner.isolated_filesystem(temp_dir=tmp_path):
             Path("docker-compose.yml").write_text("services: {}")
 
-            with patch("aegra_cli.cli.subprocess.run") as mock_run:
+            with (
+                patch("aegra_cli.cli.get_compose_command") as mock_compose,
+                patch("aegra_cli.cli.subprocess.run") as mock_run,
+            ):
+                mock_compose.return_value = ["docker", "compose"]
                 mock_run.return_value.returncode = 0
                 result = cli_runner.invoke(cli, ["down"])
 

--- a/libs/aegra-cli/tests/test_docker_utils.py
+++ b/libs/aegra-cli/tests/test_docker_utils.py
@@ -367,6 +367,38 @@ class TestIsPostgresContainerRunning:
             assert "-f" in call_args
             assert str(compose_file) in call_args
 
+    def test_returns_true_with_podman_compose_when_postgres_running(self) -> None:
+        """Test that podman-compose uses container runtime labels instead of --services."""
+        with (
+            patch("aegra_cli.utils.docker.get_compose_command") as mock_compose,
+            patch("aegra_cli.utils.docker.get_container_command") as mock_runtime,
+            patch("aegra_cli.utils.docker.subprocess.run") as mock_run,
+        ):
+            mock_compose.return_value = ["podman-compose"]
+            mock_runtime.return_value = "podman"
+            mock_run.return_value.returncode = 0
+            mock_run.return_value.stdout = "abc123\n"
+
+            assert is_postgres_container_running() is True
+
+            call_args = mock_run.call_args[0][0]
+            assert call_args[0] == "podman"
+            assert "label=com.docker.compose.service=postgres" in " ".join(call_args)
+
+    def test_returns_false_with_podman_compose_when_no_postgres(self) -> None:
+        """Test that podman-compose path returns False when no matching container."""
+        with (
+            patch("aegra_cli.utils.docker.get_compose_command") as mock_compose,
+            patch("aegra_cli.utils.docker.get_container_command") as mock_runtime,
+            patch("aegra_cli.utils.docker.subprocess.run") as mock_run,
+        ):
+            mock_compose.return_value = ["podman-compose"]
+            mock_runtime.return_value = "podman"
+            mock_run.return_value.returncode = 0
+            mock_run.return_value.stdout = ""
+
+            assert is_postgres_container_running() is False
+
 
 class TestFindComposeFile:
     """Tests for find_compose_file function."""
@@ -491,10 +523,8 @@ class TestDevCommandWithDockerCheck:
                 assert result.exit_code == 1
                 assert "Docker is not running" in result.output
 
-    def test_dev_fails_with_podman_guidance_when_podman_not_ready(
-        self, cli_runner, tmp_path
-    ) -> None:
-        """Test that dev shows Podman-specific guidance when only Podman is installed."""
+    def test_dev_fails_with_podman_vm_guidance_on_macos(self, cli_runner, tmp_path) -> None:
+        """Test that dev shows 'podman machine start' on macOS when Podman VM is down."""
         from pathlib import Path
 
         from aegra_cli.cli import cli
@@ -506,16 +536,44 @@ class TestDevCommandWithDockerCheck:
                 patch("aegra_cli.utils.docker.is_container_runtime_installed") as mock_installed,
                 patch("aegra_cli.utils.docker.is_docker_running") as mock_running,
                 patch("aegra_cli.utils.docker.shutil.which") as mock_which,
+                patch("aegra_cli.utils.docker.platform.system") as mock_system,
             ):
                 mock_installed.return_value = True
                 mock_running.return_value = False
                 mock_which.side_effect = lambda cmd: "/usr/bin/podman" if cmd == "podman" else None
+                mock_system.return_value = "Darwin"
 
                 result = cli_runner.invoke(cli, ["dev"])
 
                 assert result.exit_code == 1
                 assert "Podman is not ready" in result.output
                 assert "podman machine start" in result.output
+
+    def test_dev_fails_with_podman_diagnostic_guidance_on_linux(self, cli_runner, tmp_path) -> None:
+        """Test that dev shows diagnostic guidance on Linux when Podman fails."""
+        from pathlib import Path
+
+        from aegra_cli.cli import cli
+
+        with cli_runner.isolated_filesystem(temp_dir=tmp_path):
+            Path("aegra.json").write_text('{"graphs": {}}')
+
+            with (
+                patch("aegra_cli.utils.docker.is_container_runtime_installed") as mock_installed,
+                patch("aegra_cli.utils.docker.is_docker_running") as mock_running,
+                patch("aegra_cli.utils.docker.shutil.which") as mock_which,
+                patch("aegra_cli.utils.docker.platform.system") as mock_system,
+            ):
+                mock_installed.return_value = True
+                mock_running.return_value = False
+                mock_which.side_effect = lambda cmd: "/usr/bin/podman" if cmd == "podman" else None
+                mock_system.return_value = "Linux"
+
+                result = cli_runner.invoke(cli, ["dev"])
+
+                assert result.exit_code == 1
+                assert "Podman is not working" in result.output
+                assert "podman info" in result.output
 
 
 @pytest.fixture

--- a/libs/aegra-cli/tests/test_docker_utils.py
+++ b/libs/aegra-cli/tests/test_docker_utils.py
@@ -9,11 +9,124 @@ import pytest
 
 from aegra_cli.utils.docker import (
     find_compose_file,
+    get_compose_command,
+    get_container_command,
     get_docker_start_instructions,
+    is_container_runtime_installed,
     is_docker_installed,
     is_docker_running,
     is_postgres_container_running,
 )
+
+
+class TestGetComposeCommand:
+    """Tests for get_compose_command function."""
+
+    def test_returns_docker_compose_when_plugin_available(self) -> None:
+        """Test that docker compose v2 plugin is preferred."""
+        with patch("aegra_cli.utils.docker.subprocess.run") as mock_run:
+            mock_run.return_value.returncode = 0
+            result = get_compose_command()
+            assert result == ["docker", "compose"]
+
+    def test_returns_podman_compose_when_docker_plugin_unavailable(self) -> None:
+        """Test fallback to podman-compose when docker compose plugin fails."""
+        with (
+            patch("aegra_cli.utils.docker.subprocess.run") as mock_run,
+            patch("aegra_cli.utils.docker.shutil.which") as mock_which,
+        ):
+            mock_run.return_value.returncode = 1
+            mock_which.side_effect = lambda cmd: (
+                "/usr/bin/podman-compose" if cmd == "podman-compose" else None
+            )
+            result = get_compose_command()
+            assert result == ["podman-compose"]
+
+    def test_returns_docker_compose_v1_as_last_fallback(self) -> None:
+        """Test fallback to standalone docker-compose v1."""
+        with (
+            patch("aegra_cli.utils.docker.subprocess.run") as mock_run,
+            patch("aegra_cli.utils.docker.shutil.which") as mock_which,
+        ):
+            mock_run.return_value.returncode = 1
+            mock_which.side_effect = lambda cmd: (
+                "/usr/bin/docker-compose" if cmd == "docker-compose" else None
+            )
+            result = get_compose_command()
+            assert result == ["docker-compose"]
+
+    def test_raises_when_no_compose_tool_found(self) -> None:
+        """Test that FileNotFoundError is raised when no compose tool exists."""
+        with (
+            patch("aegra_cli.utils.docker.subprocess.run") as mock_run,
+            patch("aegra_cli.utils.docker.shutil.which") as mock_which,
+        ):
+            mock_run.side_effect = FileNotFoundError
+            mock_which.return_value = None
+            with pytest.raises(FileNotFoundError, match="No container compose tool found"):
+                get_compose_command()
+
+    def test_handles_docker_compose_timeout(self) -> None:
+        """Test fallback when docker compose version times out."""
+        import subprocess as sp
+
+        with (
+            patch("aegra_cli.utils.docker.subprocess.run") as mock_run,
+            patch("aegra_cli.utils.docker.shutil.which") as mock_which,
+        ):
+            mock_run.side_effect = sp.TimeoutExpired("docker", 10)
+            mock_which.side_effect = lambda cmd: (
+                "/usr/bin/podman-compose" if cmd == "podman-compose" else None
+            )
+            result = get_compose_command()
+            assert result == ["podman-compose"]
+
+
+class TestGetContainerCommand:
+    """Tests for get_container_command function."""
+
+    def test_returns_docker_when_available(self) -> None:
+        """Test that docker is preferred when both are available."""
+        with patch("aegra_cli.utils.docker.shutil.which") as mock_which:
+            mock_which.side_effect = lambda cmd: (
+                f"/usr/bin/{cmd}" if cmd in ("docker", "podman") else None
+            )
+            assert get_container_command() == "docker"
+
+    def test_returns_podman_when_docker_unavailable(self) -> None:
+        """Test fallback to podman when docker is not installed."""
+        with patch("aegra_cli.utils.docker.shutil.which") as mock_which:
+            mock_which.side_effect = lambda cmd: "/usr/bin/podman" if cmd == "podman" else None
+            assert get_container_command() == "podman"
+
+    def test_raises_when_neither_available(self) -> None:
+        """Test that FileNotFoundError is raised when no runtime exists."""
+        with patch("aegra_cli.utils.docker.shutil.which") as mock_which:
+            mock_which.return_value = None
+            with pytest.raises(FileNotFoundError, match="No container runtime found"):
+                get_container_command()
+
+
+class TestIsContainerRuntimeInstalled:
+    """Tests for is_container_runtime_installed function."""
+
+    def test_returns_true_when_docker_available(self) -> None:
+        """Test returns True when docker is in PATH."""
+        with patch("aegra_cli.utils.docker.shutil.which") as mock_which:
+            mock_which.side_effect = lambda cmd: "/usr/bin/docker" if cmd == "docker" else None
+            assert is_container_runtime_installed() is True
+
+    def test_returns_true_when_podman_available(self) -> None:
+        """Test returns True when only podman is in PATH."""
+        with patch("aegra_cli.utils.docker.shutil.which") as mock_which:
+            mock_which.side_effect = lambda cmd: "/usr/bin/podman" if cmd == "podman" else None
+            assert is_container_runtime_installed() is True
+
+    def test_returns_false_when_neither_available(self) -> None:
+        """Test returns False when no container runtime is installed."""
+        with patch("aegra_cli.utils.docker.shutil.which") as mock_which:
+            mock_which.return_value = None
+            assert is_container_runtime_installed() is False
 
 
 class TestIsDockerInstalled:
@@ -39,9 +152,11 @@ class TestIsDockerRunning:
     def test_returns_true_when_docker_daemon_responds(self) -> None:
         """Test that function returns True when docker info succeeds."""
         with (
+            patch("aegra_cli.utils.docker.shutil.which") as mock_which,
             patch("aegra_cli.utils.docker.is_docker_installed") as mock_installed,
             patch("aegra_cli.utils.docker.subprocess.run") as mock_run,
         ):
+            mock_which.return_value = None  # no podman
             mock_installed.return_value = True
             mock_run.return_value.returncode = 0
 
@@ -52,18 +167,30 @@ class TestIsDockerRunning:
                 timeout=10,
             )
 
+    def test_returns_true_when_podman_available(self) -> None:
+        """Test that function returns True when podman is installed (daemonless)."""
+        with patch("aegra_cli.utils.docker.shutil.which") as mock_which:
+            mock_which.return_value = "/usr/bin/podman"
+            assert is_docker_running() is True
+
     def test_returns_false_when_docker_not_installed(self) -> None:
-        """Test that function returns False when docker is not installed."""
-        with patch("aegra_cli.utils.docker.is_docker_installed") as mock_installed:
+        """Test that function returns False when neither docker nor podman is installed."""
+        with (
+            patch("aegra_cli.utils.docker.shutil.which") as mock_which,
+            patch("aegra_cli.utils.docker.is_docker_installed") as mock_installed,
+        ):
+            mock_which.return_value = None  # no podman
             mock_installed.return_value = False
             assert is_docker_running() is False
 
     def test_returns_false_when_docker_daemon_not_running(self) -> None:
         """Test that function returns False when docker info fails."""
         with (
+            patch("aegra_cli.utils.docker.shutil.which") as mock_which,
             patch("aegra_cli.utils.docker.is_docker_installed") as mock_installed,
             patch("aegra_cli.utils.docker.subprocess.run") as mock_run,
         ):
+            mock_which.return_value = None  # no podman
             mock_installed.return_value = True
             mock_run.return_value.returncode = 1
 
@@ -74,9 +201,11 @@ class TestIsDockerRunning:
         import subprocess
 
         with (
+            patch("aegra_cli.utils.docker.shutil.which") as mock_which,
             patch("aegra_cli.utils.docker.is_docker_installed") as mock_installed,
             patch("aegra_cli.utils.docker.subprocess.run") as mock_run,
         ):
+            mock_which.return_value = None  # no podman
             mock_installed.return_value = True
             mock_run.side_effect = subprocess.TimeoutExpired("docker", 10)
 
@@ -119,7 +248,11 @@ class TestIsPostgresContainerRunning:
 
     def test_returns_true_when_postgres_in_running_services(self) -> None:
         """Test that function returns True when postgres is running."""
-        with patch("aegra_cli.utils.docker.subprocess.run") as mock_run:
+        with (
+            patch("aegra_cli.utils.docker.get_compose_command") as mock_compose,
+            patch("aegra_cli.utils.docker.subprocess.run") as mock_run,
+        ):
+            mock_compose.return_value = ["docker", "compose"]
             mock_run.return_value.returncode = 0
             mock_run.return_value.stdout = "postgres\nredis\n"
 
@@ -127,7 +260,11 @@ class TestIsPostgresContainerRunning:
 
     def test_returns_false_when_postgres_not_running(self) -> None:
         """Test that function returns False when postgres is not in running services."""
-        with patch("aegra_cli.utils.docker.subprocess.run") as mock_run:
+        with (
+            patch("aegra_cli.utils.docker.get_compose_command") as mock_compose,
+            patch("aegra_cli.utils.docker.subprocess.run") as mock_run,
+        ):
+            mock_compose.return_value = ["docker", "compose"]
             mock_run.return_value.returncode = 0
             mock_run.return_value.stdout = "redis\n"
 
@@ -135,22 +272,40 @@ class TestIsPostgresContainerRunning:
 
     def test_returns_false_when_no_services_running(self) -> None:
         """Test that function returns False when no services are running."""
-        with patch("aegra_cli.utils.docker.subprocess.run") as mock_run:
+        with (
+            patch("aegra_cli.utils.docker.get_compose_command") as mock_compose,
+            patch("aegra_cli.utils.docker.subprocess.run") as mock_run,
+        ):
+            mock_compose.return_value = ["docker", "compose"]
             mock_run.return_value.returncode = 0
             mock_run.return_value.stdout = ""
 
             assert is_postgres_container_running() is False
 
-    def test_returns_false_on_docker_compose_failure(self) -> None:
-        """Test that function returns False when docker compose fails."""
-        with patch("aegra_cli.utils.docker.subprocess.run") as mock_run:
+    def test_returns_false_when_no_compose_tool_found(self) -> None:
+        """Test that function returns False when no compose tool is available."""
+        with patch("aegra_cli.utils.docker.get_compose_command") as mock_compose:
+            mock_compose.side_effect = FileNotFoundError
+            assert is_postgres_container_running() is False
+
+    def test_returns_false_on_compose_ps_failure(self) -> None:
+        """Test that function returns False when compose ps command fails."""
+        with (
+            patch("aegra_cli.utils.docker.get_compose_command") as mock_compose,
+            patch("aegra_cli.utils.docker.subprocess.run") as mock_run,
+        ):
+            mock_compose.return_value = ["docker", "compose"]
             mock_run.return_value.returncode = 1
 
             assert is_postgres_container_running() is False
 
     def test_uses_compose_file_when_provided(self) -> None:
         """Test that function uses compose file when provided."""
-        with patch("aegra_cli.utils.docker.subprocess.run") as mock_run:
+        with (
+            patch("aegra_cli.utils.docker.get_compose_command") as mock_compose,
+            patch("aegra_cli.utils.docker.subprocess.run") as mock_run,
+        ):
+            mock_compose.return_value = ["docker", "compose"]
             mock_run.return_value.returncode = 0
             mock_run.return_value.stdout = "postgres\n"
 
@@ -244,8 +399,8 @@ class TestDevCommandWithDockerCheck:
         assert result.exit_code == 0
         assert "--file" in result.output or "-f" in result.output
 
-    def test_dev_fails_when_docker_not_installed(self, cli_runner, tmp_path) -> None:
-        """Test that dev fails gracefully when Docker is not installed."""
+    def test_dev_fails_when_no_runtime_installed(self, cli_runner, tmp_path) -> None:
+        """Test that dev fails gracefully when no container runtime is installed."""
         from pathlib import Path
 
         from aegra_cli.cli import cli
@@ -253,12 +408,12 @@ class TestDevCommandWithDockerCheck:
         with cli_runner.isolated_filesystem(temp_dir=tmp_path):
             Path("aegra.json").write_text('{"graphs": {}}')
 
-            with patch("aegra_cli.utils.docker.is_docker_installed") as mock_installed:
+            with patch("aegra_cli.utils.docker.is_container_runtime_installed") as mock_installed:
                 mock_installed.return_value = False
                 result = cli_runner.invoke(cli, ["dev"])
 
                 assert result.exit_code == 1
-                assert "Docker is not installed" in result.output
+                assert "No container runtime found" in result.output
 
     def test_dev_fails_when_docker_not_running(self, cli_runner, tmp_path) -> None:
         """Test that dev fails gracefully when Docker is not running."""
@@ -270,7 +425,7 @@ class TestDevCommandWithDockerCheck:
             Path("aegra.json").write_text('{"graphs": {}}')
 
             with (
-                patch("aegra_cli.utils.docker.is_docker_installed") as mock_installed,
+                patch("aegra_cli.utils.docker.is_container_runtime_installed") as mock_installed,
                 patch("aegra_cli.utils.docker.is_docker_running") as mock_running,
                 patch("aegra_cli.utils.docker.try_start_docker") as mock_try_start,
             ):

--- a/libs/aegra-cli/tests/test_docker_utils.py
+++ b/libs/aegra-cli/tests/test_docker_utils.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -22,12 +22,42 @@ from aegra_cli.utils.docker import (
 class TestGetComposeCommand:
     """Tests for get_compose_command function."""
 
-    def test_returns_docker_compose_when_plugin_available(self) -> None:
-        """Test that docker compose v2 plugin is preferred."""
+    def test_returns_docker_compose_when_plugin_and_daemon_available(self) -> None:
+        """Test that docker compose v2 plugin is preferred when daemon is running."""
         with patch("aegra_cli.utils.docker.subprocess.run") as mock_run:
             mock_run.return_value.returncode = 0
             result = get_compose_command()
             assert result == ["docker", "compose"]
+            assert mock_run.call_count == 2
+            mock_run.assert_any_call(
+                ["docker", "compose", "version"], capture_output=True, timeout=10
+            )
+            mock_run.assert_any_call(["docker", "info"], capture_output=True, timeout=10)
+
+    def test_falls_back_when_docker_daemon_not_running(self) -> None:
+        """Test fallback to podman-compose when Docker CLI exists but daemon is down."""
+
+        with (
+            patch("aegra_cli.utils.docker.subprocess.run") as mock_run,
+            patch("aegra_cli.utils.docker.shutil.which") as mock_which,
+        ):
+
+            def run_side_effect(cmd, **kwargs):
+                mock_result = MagicMock()
+                if cmd == ["docker", "compose", "version"]:
+                    mock_result.returncode = 0
+                elif cmd == ["docker", "info"]:
+                    mock_result.returncode = 1
+                else:
+                    mock_result.returncode = 1
+                return mock_result
+
+            mock_run.side_effect = run_side_effect
+            mock_which.side_effect = lambda cmd: (
+                "/usr/bin/podman-compose" if cmd == "podman-compose" else None
+            )
+            result = get_compose_command()
+            assert result == ["podman-compose"]
 
     def test_returns_podman_compose_when_docker_plugin_unavailable(self) -> None:
         """Test fallback to podman-compose when docker compose plugin fails."""
@@ -168,10 +198,31 @@ class TestIsDockerRunning:
             )
 
     def test_returns_true_when_podman_available(self) -> None:
-        """Test that function returns True when podman is installed (daemonless)."""
-        with patch("aegra_cli.utils.docker.shutil.which") as mock_which:
+        """Test that function returns True when podman info succeeds."""
+        with (
+            patch("aegra_cli.utils.docker.shutil.which") as mock_which,
+            patch("aegra_cli.utils.docker.subprocess.run") as mock_run,
+        ):
             mock_which.return_value = "/usr/bin/podman"
+            mock_run.return_value.returncode = 0
             assert is_docker_running() is True
+            mock_run.assert_called_once_with(
+                ["podman", "info"],
+                capture_output=True,
+                timeout=10,
+            )
+
+    def test_returns_false_when_podman_not_ready(self) -> None:
+        """Test that function returns False when podman info fails (e.g., VM not running)."""
+        with (
+            patch("aegra_cli.utils.docker.shutil.which") as mock_which,
+            patch("aegra_cli.utils.docker.is_docker_installed") as mock_installed,
+            patch("aegra_cli.utils.docker.subprocess.run") as mock_run,
+        ):
+            mock_which.return_value = "/usr/bin/podman"
+            mock_installed.return_value = False
+            mock_run.return_value.returncode = 1
+            assert is_docker_running() is False
 
     def test_returns_false_when_docker_not_installed(self) -> None:
         """Test that function returns False when neither docker nor podman is installed."""

--- a/libs/aegra-cli/tests/test_docker_utils.py
+++ b/libs/aegra-cli/tests/test_docker_utils.py
@@ -479,15 +479,43 @@ class TestDevCommandWithDockerCheck:
                 patch("aegra_cli.utils.docker.is_container_runtime_installed") as mock_installed,
                 patch("aegra_cli.utils.docker.is_docker_running") as mock_running,
                 patch("aegra_cli.utils.docker.try_start_docker") as mock_try_start,
+                patch("aegra_cli.utils.docker.shutil.which") as mock_which,
             ):
                 mock_installed.return_value = True
                 mock_running.return_value = False
                 mock_try_start.return_value = False
+                mock_which.side_effect = lambda cmd: "/usr/bin/docker" if cmd == "docker" else None
 
                 result = cli_runner.invoke(cli, ["dev"])
 
                 assert result.exit_code == 1
                 assert "Docker is not running" in result.output
+
+    def test_dev_fails_with_podman_guidance_when_podman_not_ready(
+        self, cli_runner, tmp_path
+    ) -> None:
+        """Test that dev shows Podman-specific guidance when only Podman is installed."""
+        from pathlib import Path
+
+        from aegra_cli.cli import cli
+
+        with cli_runner.isolated_filesystem(temp_dir=tmp_path):
+            Path("aegra.json").write_text('{"graphs": {}}')
+
+            with (
+                patch("aegra_cli.utils.docker.is_container_runtime_installed") as mock_installed,
+                patch("aegra_cli.utils.docker.is_docker_running") as mock_running,
+                patch("aegra_cli.utils.docker.shutil.which") as mock_which,
+            ):
+                mock_installed.return_value = True
+                mock_running.return_value = False
+                mock_which.side_effect = lambda cmd: "/usr/bin/podman" if cmd == "podman" else None
+
+                result = cli_runner.invoke(cli, ["dev"])
+
+                assert result.exit_code == 1
+                assert "Podman is not ready" in result.output
+                assert "podman machine start" in result.output
 
 
 @pytest.fixture

--- a/libs/aegra-cli/tests/test_docker_utils.py
+++ b/libs/aegra-cli/tests/test_docker_utils.py
@@ -48,6 +48,8 @@ class TestGetComposeCommand:
                     mock_result.returncode = 0
                 elif cmd == ["docker", "info"]:
                     mock_result.returncode = 1
+                elif cmd == ["podman", "info"]:
+                    mock_result.returncode = 0
                 else:
                     mock_result.returncode = 1
                 return mock_result
@@ -65,12 +67,41 @@ class TestGetComposeCommand:
             patch("aegra_cli.utils.docker.subprocess.run") as mock_run,
             patch("aegra_cli.utils.docker.shutil.which") as mock_which,
         ):
-            mock_run.return_value.returncode = 1
+
+            def run_side_effect(cmd, **kwargs):
+                mock_result = MagicMock()
+                if cmd == ["podman", "info"]:
+                    mock_result.returncode = 0
+                else:
+                    mock_result.returncode = 1
+                return mock_result
+
+            mock_run.side_effect = run_side_effect
             mock_which.side_effect = lambda cmd: (
                 "/usr/bin/podman-compose" if cmd == "podman-compose" else None
             )
             result = get_compose_command()
             assert result == ["podman-compose"]
+
+    def test_skips_podman_compose_when_podman_runtime_unavailable(self) -> None:
+        """Test that podman-compose is skipped when Podman runtime isn't available."""
+        with (
+            patch("aegra_cli.utils.docker.subprocess.run") as mock_run,
+            patch("aegra_cli.utils.docker.shutil.which") as mock_which,
+        ):
+
+            def run_side_effect(cmd, **kwargs):
+                mock_result = MagicMock()
+                mock_result.returncode = 1
+                return mock_result
+
+            mock_run.side_effect = run_side_effect
+            mock_which.side_effect = lambda cmd: {
+                "podman-compose": "/usr/bin/podman-compose",
+                "docker-compose": "/usr/bin/docker-compose",
+            }.get(cmd)
+            result = get_compose_command()
+            assert result == ["docker-compose"]
 
     def test_returns_docker_compose_v1_as_last_fallback(self) -> None:
         """Test fallback to standalone docker-compose v1."""
@@ -104,7 +135,15 @@ class TestGetComposeCommand:
             patch("aegra_cli.utils.docker.subprocess.run") as mock_run,
             patch("aegra_cli.utils.docker.shutil.which") as mock_which,
         ):
-            mock_run.side_effect = sp.TimeoutExpired("docker", 10)
+
+            def run_side_effect(cmd, **kwargs):
+                if cmd == ["podman", "info"]:
+                    mock_result = MagicMock()
+                    mock_result.returncode = 0
+                    return mock_result
+                raise sp.TimeoutExpired("docker", 10)
+
+            mock_run.side_effect = run_side_effect
             mock_which.side_effect = lambda cmd: (
                 "/usr/bin/podman-compose" if cmd == "podman-compose" else None
             )
@@ -451,6 +490,25 @@ class TestIsPostgresContainerRunning:
 
             cmd_str = " ".join(mock_run.call_args[0][0])
             assert "label=com.docker.compose.project=myapp" in cmd_str
+
+    def test_project_from_compose_project_name_env(self) -> None:
+        """Test that COMPOSE_PROJECT_NAME env var takes precedence over directory name."""
+        with (
+            patch("aegra_cli.utils.docker.get_compose_command") as mock_compose,
+            patch("aegra_cli.utils.docker.subprocess.run") as mock_run,
+            patch("aegra_cli.utils.docker.Path.cwd") as mock_cwd,
+            patch.dict("os.environ", {"COMPOSE_PROJECT_NAME": "custom-project"}),
+        ):
+            mock_compose.return_value = ["podman-compose"]
+            mock_run.return_value.returncode = 0
+            mock_run.return_value.stdout = "abc123\n"
+            mock_cwd.return_value = Path("/home/user/myproject")
+
+            assert is_postgres_container_running() is True
+
+            cmd_str = " ".join(mock_run.call_args[0][0])
+            assert "label=com.docker.compose.project=custom-project" in cmd_str
+            assert "myproject" not in cmd_str
 
 
 class TestFindComposeFile:

--- a/libs/aegra-cli/tests/test_docker_utils.py
+++ b/libs/aegra-cli/tests/test_docker_utils.py
@@ -368,36 +368,89 @@ class TestIsPostgresContainerRunning:
             assert str(compose_file) in call_args
 
     def test_returns_true_with_podman_compose_when_postgres_running(self) -> None:
-        """Test that podman-compose uses container runtime labels instead of --services."""
+        """Test that podman-compose derives runtime from compose_cmd and uses labels."""
         with (
             patch("aegra_cli.utils.docker.get_compose_command") as mock_compose,
-            patch("aegra_cli.utils.docker.get_container_command") as mock_runtime,
             patch("aegra_cli.utils.docker.subprocess.run") as mock_run,
+            patch("aegra_cli.utils.docker.Path.cwd") as mock_cwd,
         ):
             mock_compose.return_value = ["podman-compose"]
-            mock_runtime.return_value = "podman"
             mock_run.return_value.returncode = 0
             mock_run.return_value.stdout = "abc123\n"
+            mock_cwd.return_value = Path("/home/user/myproject")
 
             assert is_postgres_container_running() is True
 
             call_args = mock_run.call_args[0][0]
             assert call_args[0] == "podman"
-            assert "label=com.docker.compose.service=postgres" in " ".join(call_args)
+            cmd_str = " ".join(call_args)
+            assert "label=com.docker.compose.service=postgres" in cmd_str
+            assert "label=com.docker.compose.project=myproject" in cmd_str
 
     def test_returns_false_with_podman_compose_when_no_postgres(self) -> None:
         """Test that podman-compose path returns False when no matching container."""
         with (
             patch("aegra_cli.utils.docker.get_compose_command") as mock_compose,
-            patch("aegra_cli.utils.docker.get_container_command") as mock_runtime,
+            patch("aegra_cli.utils.docker.subprocess.run") as mock_run,
+            patch("aegra_cli.utils.docker.Path.cwd") as mock_cwd,
+        ):
+            mock_compose.return_value = ["podman-compose"]
+            mock_run.return_value.returncode = 0
+            mock_run.return_value.stdout = ""
+            mock_cwd.return_value = Path("/home/user/myproject")
+
+            assert is_postgres_container_running() is False
+
+    def test_runtime_derived_from_compose_cmd_not_container_command(self) -> None:
+        """Regression: when both runtimes are installed but Docker daemon is down,
+        runtime must come from compose_cmd, not get_container_command()."""
+        with (
+            patch("aegra_cli.utils.docker.get_compose_command") as mock_compose,
+            patch("aegra_cli.utils.docker.subprocess.run") as mock_run,
+            patch("aegra_cli.utils.docker.Path.cwd") as mock_cwd,
+        ):
+            mock_compose.return_value = ["podman-compose"]
+            mock_run.return_value.returncode = 0
+            mock_run.return_value.stdout = "abc123\n"
+            mock_cwd.return_value = Path("/home/user/aegra")
+
+            assert is_postgres_container_running() is True
+
+            call_args = mock_run.call_args[0][0]
+            assert call_args[0] == "podman"
+
+    def test_docker_compose_v1_derives_docker_runtime(self) -> None:
+        """Test that docker-compose v1 derives 'docker' as the runtime."""
+        with (
+            patch("aegra_cli.utils.docker.get_compose_command") as mock_compose,
+            patch("aegra_cli.utils.docker.subprocess.run") as mock_run,
+            patch("aegra_cli.utils.docker.Path.cwd") as mock_cwd,
+        ):
+            mock_compose.return_value = ["docker-compose"]
+            mock_run.return_value.returncode = 0
+            mock_run.return_value.stdout = "abc123\n"
+            mock_cwd.return_value = Path("/home/user/aegra")
+
+            assert is_postgres_container_running() is True
+
+            call_args = mock_run.call_args[0][0]
+            assert call_args[0] == "docker"
+
+    def test_project_scoped_from_compose_file_parent(self) -> None:
+        """Test that project label uses compose file's parent directory name."""
+        with (
+            patch("aegra_cli.utils.docker.get_compose_command") as mock_compose,
             patch("aegra_cli.utils.docker.subprocess.run") as mock_run,
         ):
             mock_compose.return_value = ["podman-compose"]
-            mock_runtime.return_value = "podman"
             mock_run.return_value.returncode = 0
-            mock_run.return_value.stdout = ""
+            mock_run.return_value.stdout = "abc123\n"
 
-            assert is_postgres_container_running() is False
+            compose_file = Path("/opt/apps/MyApp/docker-compose.yml")
+            assert is_postgres_container_running(compose_file) is True
+
+            cmd_str = " ".join(mock_run.call_args[0][0])
+            assert "label=com.docker.compose.project=myapp" in cmd_str
 
 
 class TestFindComposeFile:


### PR DESCRIPTION
## Summary

Adds runtime detection for container runtimes and compose tools, enabling aegra to work with Podman and podman-compose in addition to Docker.

**Changes:**

- **`docker.py`**: New functions `get_compose_command()`, `get_container_command()`, `is_container_runtime_installed()`. Updated `is_docker_running()` to recognize Podman (daemonless). Updated `start_postgres_container()` to poll for readiness when `--wait` isn't supported (podman-compose, docker-compose v1).
- **`cli.py`**: `up` and `down` commands use `get_compose_command()` instead of hardcoded `["docker", "compose"]`.
- **Tests**: 11 new tests for the detection functions. All existing tests updated with proper mocks for the new compose detection layer.

**Compose tool detection order:**

1. `docker compose` (v2 plugin) - checked via `docker compose version`
2. `podman-compose` - checked via `shutil.which`
3. `docker-compose` (standalone v1) - checked via `shutil.which`

Closes #478

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically detects the available Compose tool for **up** and **down** (using the detected command for execution and output).
  * “View logs” now shows the detected Compose command.
* **Bug Fixes**
  * Improved Podman readiness checks (waits for a successful status response).
  * More reliable PostgreSQL orchestration with Compose-aware service/project scoping and readiness polling.
  * Clearer error messages for missing Compose tools and failed Compose runs, plus platform-specific Podman setup guidance.
* **Tests**
  * Updated and expanded CLI and Docker utility tests to cover Compose/runtime selection and revised error paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds automatic Docker/Podman Compose selection and runtime-aware PostgreSQL lifecycle handling.
- Routes `up` and `down` through the detected compose implementation.
- Validates the Docker daemon and Podman runtime before selecting each respective compose tool.
- Adds fallback PostgreSQL readiness polling for compose implementations without `--wait`.
- Expands CLI and Docker utility tests for runtime selection and command construction.

<h3>Confidence Score: 5/5</h3>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/aegra-cli/src/aegra_cli/cli.py | Replaces hardcoded Docker Compose commands with detected compose commands and updates user-facing output and errors. |
| libs/aegra-cli/src/aegra_cli/utils/docker.py | Adds Docker/Podman selection and PostgreSQL lifecycle handling, but the standalone docker-compose fallback is accepted without validating its Docker daemon. |
| libs/aegra-cli/tests/test_cli.py | Updates CLI tests to mock compose detection and verify revised command and error behavior. |
| libs/aegra-cli/tests/test_docker_utils.py | Expands coverage for compose selection, runtime detection, and runtime-specific container status commands. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Alibs%2Faegra-cli%2Fsrc%2Faegra_cli%2Futils%2Fdocker.py%3A56-57%0A**Standalone%20Compose%20skips%20runtime%20validation**%0A%0AWhen%20%60docker-compose%60%20is%20installed%20but%20its%20Docker%20daemon%20is%20unavailable%2C%20this%20fallback%20returns%20it%20solely%20from%20its%20executable%20presence.%20The%20%60up%60%20and%20%60down%60%20commands%20then%20select%20an%20unusable%20compose%20implementation%20and%20fail%20at%20execution%20instead%20of%20reporting%20that%20no%20operational%20compose%20tool%20is%20available.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=aegra%2Faegra&pr=479&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Alibs%2Faegra-cli%2Fsrc%2Faegra_cli%2Futils%2Fdocker.py%3A56-57%0A**Standalone%20Compose%20skips%20runtime%20validation**%0A%0AWhen%20%60docker-compose%60%20is%20installed%20but%20its%20Docker%20daemon%20is%20unavailable%2C%20this%20fallback%20returns%20it%20solely%20from%20its%20executable%20presence.%20The%20%60up%60%20and%20%60down%60%20commands%20then%20select%20an%20unusable%20compose%20implementation%20and%20fail%20at%20execution%20instead%20of%20reporting%20that%20no%20operational%20compose%20tool%20is%20available.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=479&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22feat%2Fpodman-compose-support%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fpodman-compose-support%22.%0A%0A%23%23%23%20Issue%201%0Alibs%2Faegra-cli%2Fsrc%2Faegra_cli%2Futils%2Fdocker.py%3A56-57%0A**Standalone%20Compose%20skips%20runtime%20validation**%0A%0AWhen%20%60docker-compose%60%20is%20installed%20but%20its%20Docker%20daemon%20is%20unavailable%2C%20this%20fallback%20returns%20it%20solely%20from%20its%20executable%20presence.%20The%20%60up%60%20and%20%60down%60%20commands%20then%20select%20an%20unusable%20compose%20implementation%20and%20fail%20at%20execution%20instead%20of%20reporting%20that%20no%20operational%20compose%20tool%20is%20available.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=aegra%2Faegra&pr=479&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (7): Last reviewed commit: ["chore: trigger re-review"](https://github.com/aegra/aegra/commit/00702cf8860baff632c9fc2b03d4e6d735593834) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48737460)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Aegra CLI (`libs/aegra-cli`)](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/aegra-cli.md)

<!-- /greptile_comment -->