### PR TITLE
fix(api): make thread creation atomic

### DIFF
--- a/libs/aegra-api/src/aegra_api/api/threads.py
+++ b/libs/aegra-api/src/aegra_api/api/threads.py
@@ -11,6 +11,7 @@ from uuid import uuid4
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from aegra_api.core.active_runs import active_runs
@@ -182,19 +183,6 @@ async def create_thread(
 
     thread_id = request.thread_id or str(uuid4())
 
-    if request.thread_id:
-        existing_stmt = select(ThreadORM).where(
-            ThreadORM.thread_id == thread_id,
-            ThreadORM.user_id == user.identity,
-        )
-        existing = await session.scalar(existing_stmt)
-
-        if existing:
-            if request.if_exists == "do_nothing":
-                return _serialize_thread(existing)
-            else:
-                raise HTTPException(409, f"Thread '{thread_id}' already exists")
-
     metadata = request.metadata or {}
     # Always enforce owner from authenticated user
     metadata["owner"] = user.identity
@@ -203,21 +191,43 @@ async def create_thread(
     metadata.setdefault("graph_id", None)
     metadata.setdefault("thread_name", "")
 
-    thread_orm = ThreadORM(
-        thread_id=thread_id,
-        status="idle",
-        metadata_json=metadata,
-        user_id=user.identity,
+    # Insert first and let the primary key arbitrate. A SELECT-then-INSERT lets
+    # two concurrent requests for the same thread_id both miss the SELECT and
+    # then collide on thread_pkey, and the loser's UniqueViolationError escapes
+    # as a 500 instead of honouring if_exists.
+    insert_stmt = (
+        pg_insert(ThreadORM)
+        .values(
+            thread_id=thread_id,
+            status="idle",
+            metadata_json=metadata,
+            user_id=user.identity,
+        )
+        .on_conflict_do_nothing(index_elements=["thread_id"])
+        .returning(ThreadORM)
     )
-
-    session.add(thread_orm)
+    created = (await session.scalars(insert_stmt)).first()
     await session.commit()
 
-    with contextlib.suppress(Exception):
-        await session.refresh(thread_orm)
+    if created is not None:
+        # Pass metadata explicitly in case the returned row is a partial mock
+        return _serialize_thread(created, default_metadata=metadata)
 
-    # Pass metadata explicitly in case refresh failed (tests/mocks)
-    return _serialize_thread(thread_orm, default_metadata=metadata)
+    # Nothing inserted, so the ID is taken. This read stays scoped to the caller
+    # while thread_pkey is global, so an incumbent owned by someone else is
+    # deliberately not found here and falls through to the conflict below rather
+    # than being adopted.
+    existing = await session.scalar(
+        select(ThreadORM).where(
+            ThreadORM.thread_id == thread_id,
+            ThreadORM.user_id == user.identity,
+        )
+    )
+
+    if existing is not None and request.if_exists == "do_nothing":
+        return _serialize_thread(existing)
+
+    raise HTTPException(409, f"Thread '{thread_id}' already exists")
 
 
 @router.get("/threads", response_model=ThreadList)

--- a/libs/aegra-api/tests/e2e/test_threads/test_concurrent_create.py
+++ b/libs/aegra-api/tests/e2e/test_threads/test_concurrent_create.py
@@ -1,0 +1,89 @@
+"""Concurrent creation must not surface unique violations as 500s.
+
+``if_exists`` used to be implemented as a SELECT followed by an unconditional
+INSERT. Two requests for the same ID both miss the SELECT, both INSERT, and the
+loser's ``UniqueViolationError`` escapes as a 500. These tests drive the real
+server against a real database so the arbitration is exercised where it actually
+happens — in Postgres — rather than against a mocked session.
+"""
+
+import asyncio
+import uuid
+from collections.abc import AsyncIterator
+from typing import Any
+
+import httpx
+import pytest
+
+from aegra_api.settings import settings
+from tests.e2e._utils import elog
+
+# Enough concurrency to interleave several requests inside one another's
+# create window, over enough rounds that a lost race is not merely unlucky.
+CONCURRENCY = 30
+ROUNDS = 6
+
+
+async def _burst(client: httpx.AsyncClient, path: str, payloads: list[dict[str, Any]]) -> list[httpx.Response]:
+    return await asyncio.gather(*(client.post(path, json=p) for p in payloads))
+
+
+@pytest.fixture
+async def warm_client() -> AsyncIterator[httpx.AsyncClient]:
+    """A client whose connections — and the server's DB pool — are already up.
+
+    Without this the burst serialises behind TCP and connection setup and never
+    overlaps server-side, which would let the old racy implementation pass.
+    """
+    async with httpx.AsyncClient(
+        base_url=settings.app.SERVER_URL,
+        timeout=60.0,
+        limits=httpx.Limits(
+            max_connections=CONCURRENCY + 5,
+            max_keepalive_connections=CONCURRENCY + 5,
+        ),
+    ) as client:
+        await asyncio.gather(*(client.get("/threads") for _ in range(CONCURRENCY)))
+        yield client
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_concurrent_thread_create_never_500s(warm_client: httpx.AsyncClient) -> None:
+    """Concurrent do_nothing creates all resolve to one canonical thread."""
+    for round_number in range(ROUNDS):
+        thread_id = f"concurrent-create-{uuid.uuid4()}"
+        payload = {"thread_id": thread_id, "if_exists": "do_nothing"}
+
+        responses = await _burst(warm_client, "/threads", [payload] * CONCURRENCY)
+
+        statuses = sorted({r.status_code for r in responses})
+        failed = [r for r in responses if r.status_code != 200]
+        if failed:
+            elog(
+                "Concurrent create failed",
+                {
+                    "round": round_number + 1,
+                    "thread_id": thread_id,
+                    "statuses": statuses,
+                    "sample_body": failed[0].text[:500],
+                },
+            )
+        assert statuses == [200], f"round {round_number + 1} returned {statuses}"
+        assert {r.json()["thread_id"] for r in responses} == {thread_id}
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_concurrent_thread_create_raise_yields_conflict_not_error(
+    warm_client: httpx.AsyncClient,
+) -> None:
+    """With the default if_exists, losers get 409 — never 500."""
+    thread_id = f"concurrent-conflict-{uuid.uuid4()}"
+
+    responses = await _burst(warm_client, "/threads", [{"thread_id": thread_id}] * CONCURRENCY)
+
+    statuses = [r.status_code for r in responses]
+    elog("Concurrent create with if_exists=raise", {"statuses": sorted(set(statuses))})
+    assert set(statuses) <= {200, 409}, f"unexpected statuses: {sorted(set(statuses))}"
+    assert statuses.count(200) == 1, f"expected exactly one winner, got {statuses.count(200)}"

--- a/libs/aegra-api/tests/e2e/test_threads/test_concurrent_create.py
+++ b/libs/aegra-api/tests/e2e/test_threads/test_concurrent_create.py
@@ -53,9 +53,19 @@ async def test_concurrent_thread_create_never_500s(warm_client: httpx.AsyncClien
     """Concurrent do_nothing creates all resolve to one canonical thread."""
     for round_number in range(ROUNDS):
         thread_id = f"concurrent-create-{uuid.uuid4()}"
-        payload = {"thread_id": thread_id, "if_exists": "do_nothing"}
+        # Distinct markers per request. With identical payloads, a response
+        # assembled from the caller's own input would pass for the stored row.
+        markers = [f"round-{round_number}-request-{i}" for i in range(CONCURRENCY)]
+        payloads = [
+            {
+                "thread_id": thread_id,
+                "if_exists": "do_nothing",
+                "metadata": {"request_marker": marker},
+            }
+            for marker in markers
+        ]
 
-        responses = await _burst(warm_client, "/threads", [payload] * CONCURRENCY)
+        responses = await _burst(warm_client, "/threads", payloads)
 
         statuses = sorted({r.status_code for r in responses})
         failed = [r for r in responses if r.status_code != 200]
@@ -71,6 +81,12 @@ async def test_concurrent_thread_create_never_500s(warm_client: httpx.AsyncClien
             )
         assert statuses == [200], f"round {round_number + 1} returned {statuses}"
         assert {r.json()["thread_id"] for r in responses} == {thread_id}
+
+        # do_nothing owes every caller the one stored thread, so all of them must
+        # carry the winner's marker rather than the one they each submitted.
+        returned = {r.json()["metadata"]["request_marker"] for r in responses}
+        assert len(returned) == 1, f"round {round_number + 1} returned {len(returned)} rows: {returned}"
+        assert returned <= set(markers)
 
 
 @pytest.mark.e2e

--- a/libs/aegra-api/tests/fixtures/database.py
+++ b/libs/aegra-api/tests/fixtures/database.py
@@ -1,13 +1,42 @@
 """Database fixtures for tests"""
 
 from collections.abc import AsyncIterator, Callable
+from types import SimpleNamespace
+from typing import Any
+
+from sqlalchemy import Insert
+from sqlalchemy.dialects import postgresql
+
+
+def echo_inserted_row(stmt: Insert) -> Any:
+    """Rebuild the row an ``INSERT ... RETURNING`` would hand back.
+
+    A handler that creates atomically reads the RETURNING row rather than an
+    object it built itself, so a session mock has to echo the bound values back.
+    """
+    params = stmt.compile(dialect=postgresql.dialect()).params
+    return SimpleNamespace(**params)
+
+
+class DummyScalarResult:
+    """Minimal emulation of SQLAlchemy's ScalarResult"""
+
+    def __init__(self, rows: list[Any] | None = None):
+        self._rows = rows or []
+
+    def all(self) -> list[Any]:
+        return self._rows
+
+    def first(self) -> Any:
+        return self._rows[0] if self._rows else None
 
 
 class DummySessionBase:
     """Minimal emulation of SQLAlchemy AsyncSession for testing
 
     Override scalar/scalars/commit/refresh in subclasses/fixtures to return
-    appropriate rows for a test. By default, returns empty data.
+    appropriate rows for a test. By default, an INSERT is treated as having
+    inserted its row and anything else returns empty data.
     """
 
     async def __aenter__(self):
@@ -29,12 +58,10 @@ class DummySessionBase:
     async def scalar(self, _stmt):
         return None
 
-    async def scalars(self, _stmt):
-        class Result:
-            def all(self_inner):
-                return []
-
-        return Result()
+    async def scalars(self, stmt=None):
+        if isinstance(stmt, Insert):
+            return DummyScalarResult([echo_inserted_row(stmt)])
+        return DummyScalarResult()
 
 
 def override_get_session_dep(

--- a/libs/aegra-api/tests/fixtures/session_fixtures.py
+++ b/libs/aegra-api/tests/fixtures/session_fixtures.py
@@ -2,7 +2,13 @@
 
 from typing import Any
 
-from tests.fixtures.database import DummySessionBase, override_get_session_dep
+from sqlalchemy import Insert
+
+from tests.fixtures.database import (
+    DummyScalarResult,
+    DummySessionBase,
+    override_get_session_dep,
+)
 
 
 class BasicSession(DummySessionBase):
@@ -28,17 +34,11 @@ class ThreadSession(BasicSession):
         super().__init__()
         self.threads = threads or []
 
-    async def scalars(self, stmt: Any) -> Any:
-        """Mock scalars method for thread queries"""
-
-        class Result:
-            def __init__(self, threads_list):
-                self.threads_list = threads_list
-
-            def all(self) -> list[Any]:
-                return self.threads_list
-
-        return Result(self.threads)
+    async def scalars(self, stmt: Any = None) -> Any:
+        # Inserts go to the base, which echoes the RETURNING row create paths read.
+        if isinstance(stmt, Insert):
+            return await super().scalars(stmt)
+        return DummyScalarResult(self.threads)
 
 
 class RunSession(BasicSession):

--- a/libs/aegra-api/tests/integration/test_api/test_threads_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_threads_crud.py
@@ -1,15 +1,22 @@
 """Integration tests for threads CRUD operations"""
 
 from contextlib import asynccontextmanager
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from langgraph.types import StateSnapshot
+from sqlalchemy.dialects import postgresql
 
 from aegra_api.core.orm import get_session as core_get_session
 from tests.fixtures.clients import create_test_app, make_client
-from tests.fixtures.database import DummySessionBase, override_get_session_dep
+from tests.fixtures.database import (
+    DummyScalarResult,
+    DummySessionBase,
+    override_get_session_dep,
+)
 from tests.fixtures.session_fixtures import BasicSession, override_session_dependency
 from tests.fixtures.test_helpers import DummyRun, DummyThread
 
@@ -61,6 +68,25 @@ def _run_row(
 ):
     """Create a mock run ORM object"""
     return DummyRun(run_id, thread_id, status, user_id)
+
+
+def _conflicting_app(app: FastAPI, incumbent: Any) -> FastAPI:
+    """Wire the app to a session whose INSERT conflicts.
+
+    ``incumbent`` is the row the follow-up read finds, or None to model a row
+    that was deleted between the conflict and the read.
+    """
+
+    class Session(DummySessionBase):
+        async def scalars(self, stmt: Any = None) -> DummyScalarResult:
+            # Insert hit a unique constraint, so RETURNING yields nothing.
+            return DummyScalarResult()
+
+        async def scalar(self, _stmt: Any) -> Any:
+            return incumbent
+
+    app.dependency_overrides[core_get_session] = override_get_session_dep(Session)
+    return app
 
 
 class TestCreateThread:
@@ -177,19 +203,7 @@ class TestCreateThread:
         app = create_test_app(include_runs=False, include_threads=True)
 
         existing_thread = _thread_row("existing-thread-id", metadata={"original": True})
-
-        class Session(DummySessionBase):
-            call_count = 0
-
-            async def scalar(self, _stmt):
-                # First call is the existence check
-                Session.call_count += 1
-                if Session.call_count == 1:
-                    return existing_thread
-                return None
-
-        app.dependency_overrides[core_get_session] = override_get_session_dep(Session)
-        client = make_client(app)
+        client = make_client(_conflicting_app(app, existing_thread))
 
         # Try to create with same ID and ifExists='do_nothing'
         resp = client.post(
@@ -207,13 +221,7 @@ class TestCreateThread:
         app = create_test_app(include_runs=False, include_threads=True)
 
         existing_thread = _thread_row("conflict-thread-id")
-
-        class Session(DummySessionBase):
-            async def scalar(self, _stmt):
-                return existing_thread
-
-        app.dependency_overrides[core_get_session] = override_get_session_dep(Session)
-        client = make_client(app)
+        client = make_client(_conflicting_app(app, existing_thread))
 
         # Try to create with same ID (default ifExists='raise')
         resp = client.post("/threads", json={"threadId": "conflict-thread-id"})
@@ -225,18 +233,60 @@ class TestCreateThread:
         app = create_test_app(include_runs=False, include_threads=True)
 
         existing_thread = _thread_row("conflict-thread-id")
-
-        class Session(DummySessionBase):
-            async def scalar(self, _stmt):
-                return existing_thread
-
-        app.dependency_overrides[core_get_session] = override_get_session_dep(Session)
-        client = make_client(app)
+        client = make_client(_conflicting_app(app, existing_thread))
 
         # Explicitly set ifExists='raise'
         resp = client.post(
             "/threads",
             json={"threadId": "conflict-thread-id", "ifExists": "raise"},
+        )
+        assert resp.status_code == 409
+        assert "already exists" in resp.json()["detail"]
+
+    def test_create_thread_insert_is_atomic(self) -> None:
+        """Creation must arbitrate on thread_pkey, not on a preceding SELECT.
+
+        A SELECT-then-INSERT lets two concurrent creates for one thread_id both
+        miss the SELECT and then collide on the primary key, and the loser's
+        UniqueViolationError surfaces as a 500 instead of honouring ifExists.
+        """
+        app = create_test_app(include_runs=False, include_threads=True)
+
+        statements: list[Any] = []
+
+        class Session(DummySessionBase):
+            async def scalars(self, stmt: Any = None) -> DummyScalarResult:
+                statements.append(stmt)
+                return await super().scalars(stmt)
+
+            async def scalar(self, stmt: Any) -> Any:
+                statements.append(stmt)
+                return None
+
+        app.dependency_overrides[core_get_session] = override_get_session_dep(Session)
+        client = make_client(app)
+
+        resp = client.post("/threads", json={"threadId": "atomic-thread-id"})
+        assert resp.status_code == 200
+
+        # The insert is the first statement issued, and it is conflict-tolerant.
+        assert statements, "create_thread issued no statements"
+        sql = str(statements[0].compile(dialect=postgresql.dialect()))
+        assert "INSERT INTO thread" in sql
+        assert "ON CONFLICT (thread_id) DO NOTHING" in sql
+        assert "RETURNING" in sql
+
+    def test_create_thread_conflict_with_other_owner_conflicts(self) -> None:
+        """thread_pkey is global while the read is scoped, so the ID can be taken
+        by another owner. That used to be a permanent 500; it is now a 409, and
+        the other owner's thread is never adopted.
+        """
+        app = create_test_app(include_runs=False, include_threads=True)
+        client = make_client(_conflicting_app(app, None))
+
+        resp = client.post(
+            "/threads",
+            json={"threadId": "foreign-thread-id", "ifExists": "do_nothing"},
         )
         assert resp.status_code == 409
         assert "already exists" in resp.json()["detail"]


### PR DESCRIPTION
## Description

Fixes #487.

`if_exists` on `POST /threads` is a SELECT followed by an unconditional INSERT. Two concurrent creates for the same `thread_id` both miss the SELECT, both INSERT, and the loser's asyncpg `UniqueViolationError` escapes as an unhandled **500** instead of honouring `if_exists`:

```
UniqueViolationError: duplicate key value violates unique constraint "thread_pkey"
```

`if_exists="do_nothing"` is exactly the knob a caller reaches for to make creation replay-safe, so a 500 there defeats its purpose — a client retrying after a lost response can still fail if the retry overlaps the original request's still-open transaction. We hit this in production with two pods dispatching the same webhook in the same second.

## Type of Change

- [x] `fix`: Bug fix

## Related Issues

Fixes #487.

## Changes Made

- Insert first and let the primary key arbitrate: `ON CONFLICT (thread_id) DO NOTHING ... RETURNING`, then read the incumbent and apply `if_exists` to it.
- The incumbent read stays **scoped to the caller**, exactly as before, so an ID held by another owner is still never adopted. That case previously fell through to the INSERT and 500'd permanently (the SELECT is scoped by `user_id`, `thread_pkey` is not); it now answers the 409 this endpoint already documents.
- Patch bump to 0.9.26 in both packages, per the versioning rule in CLAUDE.md.

**No API contract change.** 409 is already a declared response on this endpoint, so the regenerated `docs/openapi.json` differs only in the version string — the endpoint definition is byte-identical. No migration, no new index (`thread_pkey` already exists), and no extra round trip: the old happy path already issued a second statement via `session.refresh()`.

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] E2E tests added/updated
- [x] Manual testing performed

**New `tests/e2e/test_threads/test_concurrent_create.py`** drives the real server against a real database, because the arbitration this fixes happens in Postgres and a mocked session cannot exercise it. The fixture pre-warms client connections and the server's pool first — without that the burst serialises behind connection setup, never overlaps server-side, and the old racy code passes.

A/B on `docker compose -f docker-compose.yml -f docker-compose.dev.yml`, 25–30 concurrent identical creates:

| | old code | this PR |
|---|---|---|
| 5 × 25 requests | 500s in 3 of 5 rounds (4/125) | 0 of 150 |

Exactly one row persisted per round in both cases — this was purely a response-handling failure, never data corruption. `test_concurrent_thread_create_never_500s` fails on the old code and passes on the new.

Integration/unit suites: **1785 passed, 1 skipped**. The skip is `test_assistant_large_config_db.py`, which needs a local Postgres reachable as user `postgres`; it behaves identically on a clean checkout here.

`tests/fixtures/database.py` gained `echo_inserted_row` and `DummyScalarResult.first()` so mocked sessions can model `INSERT ... RETURNING` — the handler now reads the returned row rather than an object it built itself.

## Checklist

- [x] Code follows project style (Ruff formatting)
- [x] All linting checks pass (`make lint`)
- [x] Type checking passes (`make type-check`) — 54 diagnostics before and after, none in the changed file
- [x] All tests pass (`make test`)
- [x] Documentation updated (if needed)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] PR title follows Conventional Commits format

## Note on scope

This PR originally also fixed `create_assistant`, which has the same SELECT-then-INSERT shape against three unique constraints, and introduced a 404 for cross-owner IDs to match the tenancy convention of `get_thread` and `create_run`. That came to +581/−184, which is far outside the normal size for a fix here and bundled an API-semantics question with a straightforward bug.

I've cut it back to threads only, at +237/−61, with no contract change. The assistant fix is verified and ready as a follow-up once this lands (it needs a `metadata` → `metadata_dict` column mapping in the test fixture and rewrites five existing test mocks, so it is genuinely its own change). Happy to open it now if you'd rather review both together.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread creation under concurrent requests, preventing unexpected server errors.
  * Duplicate creation requests now reliably return the existing thread when conflict-tolerant behavior is selected.
  * Conflicts involving another owner are handled correctly with an appropriate conflict response.

* **Release**
  * Updated API and CLI versions to 0.10.1.
  * Updated the published API specification to version 0.10.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes thread creation atomic by using PostgreSQL conflict arbitration and adds coverage for concurrent creation and ownership conflicts.
- Replaces the preflight existence check with `INSERT ... ON CONFLICT DO NOTHING ... RETURNING`.
- Reads the caller-scoped incumbent after a conflict and applies the requested `if_exists` behavior.
- Extends mocked database fixtures and adds integration and end-to-end concurrency tests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with only previously reported repository-convention issues remaining.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/api/threads.py | Reworks thread creation around a conflict-tolerant PostgreSQL insert and an owner-scoped incumbent lookup. |
| libs/aegra-api/tests/e2e/test_threads/test_concurrent_create.py | Adds real-server concurrency tests for replay-safe and conflict-raising creation modes. |
| libs/aegra-api/tests/fixtures/database.py | Extends session mocks to emulate scalar results from `INSERT ... RETURNING`. |
| libs/aegra-api/tests/fixtures/session_fixtures.py | Routes insert statements through the returning-row mock while preserving query fixtures. |
| libs/aegra-api/tests/integration/test_api/test_threads_crud.py | Adds integration coverage for atomic SQL generation and cross-owner conflicts. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant API as Threads API
    participant DB as PostgreSQL
    Client->>API: POST /threads
    API->>DB: INSERT ... ON CONFLICT DO NOTHING RETURNING
    alt Row inserted
        DB-->>API: Created thread
        API-->>Client: 200 thread
    else ID already exists
        DB-->>API: No returned row
        API->>DB: SELECT incumbent scoped to caller
        alt Owned incumbent and do_nothing
            DB-->>API: Existing thread
            API-->>Client: 200 existing thread
        else Conflict
            API-->>Client: 409 already exists
        end
    end
```
</details>

<sub>Reviews (7): Last reviewed commit: ["test: route ThreadSession inserts throug..."](https://github.com/aegra/aegra/commit/13b24d0b638685d621be385064cd536709d42a4c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50214296)</sub>

**Context used:**

- Knowledge Base — [Threads and Runs](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/threads-and-runs.md)

<!-- /greptile_comment -->