### PR TITLE
fix(auth): dispatch @auth.on handlers on every protocol route

### DIFF
--- a/docs/guides/authentication.mdx
+++ b/docs/guides/authentication.mdx
@@ -178,6 +178,15 @@ Stateless runs create an ephemeral thread, so they authorize as
 A filter dict returned from a `threads` handler is applied to thread queries,
 including by-id reads and deletes, not only to search.
 
+Your handler runs **once per event**. A request that legitimately touches
+several resources still checks each one: creating a cron authorizes
+`crons.create`, then `assistants.read`, then the thread, so you can deny at any
+layer.
+
+Handlers may also inject data by mutating `value` in place. Setting
+`value["metadata"]["team_id"]` in an `@auth.on.threads.create` handler stores
+that metadata on the new thread.
+
 <Note>
 Route-to-handler mapping lives in `core/auth_registry.py`. A route that is not
 registered there fails the test suite, so a new endpoint cannot silently skip

--- a/docs/guides/authentication.mdx
+++ b/docs/guides/authentication.mdx
@@ -165,12 +165,14 @@ as their parent, so one rule covers a whole family of endpoints:
 
 | Handler | Also covers |
 |---------|-------------|
-| `@auth.on.threads.read` | `GET /threads/{id}`, `/state`, `/state/{checkpoint_id}`, `/history` |
-| `@auth.on.threads.update` | `PATCH /threads/{id}`, `POST /threads/{id}/state` |
+| `@auth.on.threads.read` | `GET /threads/{id}`, `/state`, `/state/{checkpoint_id}`, `/history`, `GET` a run, its `/join` and `/stream` |
+| `@auth.on.threads.update` | `PATCH /threads/{id}`, `POST /threads/{id}/state`, `PATCH` a run, `POST .../runs/{id}/cancel` |
+| `@auth.on.threads.delete` | `DELETE /threads/{id}`, `DELETE` a run |
 | `@auth.on.threads.create_run` | `POST /threads/{id}/runs`, `/runs/stream`, `/runs/wait`, `/threads/{id}/commands`, and the stateless `POST /runs`, `/runs/stream`, `/runs/wait` |
-| `@auth.on.threads.search` | `GET /threads`, `POST /threads/search` |
-| `@auth.on.runs.read` | `GET` a run, its `/join` and `/stream` |
-| `@auth.on.runs.update` | `PATCH` a run, `POST /runs/{id}/cancel` |
+| `@auth.on.threads.search` | `GET /threads`, `POST /threads/search`, `GET /threads/{id}/runs` |
+
+There is no `runs` resource: the Agent Protocol authorizes run operations under
+the thread that owns them, and the SDK's `@auth.on` has no `runs` attribute.
 
 Stateless runs create an ephemeral thread, so they authorize as
 `threads.create_run`. Omitting the `thread_id` does not bypass your thread rules.
@@ -181,7 +183,8 @@ including by-id reads and deletes, not only to search.
 Your handler runs **once per event**. A request that legitimately touches
 several resources still checks each one: creating a cron authorizes
 `crons.create`, then `assistants.read`, then the thread, so you can deny at any
-layer.
+layer. Creating a run likewise authorizes `threads.create_run`, then
+`assistants.read` for the assistant it uses.
 
 Handlers may also inject data by mutating `value` in place. Setting
 `value["metadata"]["team_id"]` in an `@auth.on.threads.create` handler stores

--- a/docs/guides/authentication.mdx
+++ b/docs/guides/authentication.mdx
@@ -158,6 +158,32 @@ The `ctx` parameter provides:
 | `dict` | Allow with filters (e.g., `{"metadata": {"team_id": "123"}}`) |
 | Modified `value` | Allow with modified request data |
 
+### Which routes a handler covers
+
+Every Agent Protocol route dispatches to your handlers. Sub-resources authorize
+as their parent, so one rule covers a whole family of endpoints:
+
+| Handler | Also covers |
+|---------|-------------|
+| `@auth.on.threads.read` | `GET /threads/{id}`, `/state`, `/state/{checkpoint_id}`, `/history` |
+| `@auth.on.threads.update` | `PATCH /threads/{id}`, `POST /threads/{id}/state` |
+| `@auth.on.threads.create_run` | `POST /threads/{id}/runs`, `/runs/stream`, `/runs/wait`, `/threads/{id}/commands`, and the stateless `POST /runs`, `/runs/stream`, `/runs/wait` |
+| `@auth.on.threads.search` | `GET /threads`, `POST /threads/search` |
+| `@auth.on.runs.read` | `GET` a run, its `/join` and `/stream` |
+| `@auth.on.runs.update` | `PATCH` a run, `POST /runs/{id}/cancel` |
+
+Stateless runs create an ephemeral thread, so they authorize as
+`threads.create_run`. Omitting the `thread_id` does not bypass your thread rules.
+
+A filter dict returned from a `threads` handler is applied to thread queries,
+including by-id reads and deletes, not only to search.
+
+<Note>
+Route-to-handler mapping lives in `core/auth_registry.py`. A route that is not
+registered there fails the test suite, so a new endpoint cannot silently skip
+your handlers.
+</Note>
+
 ## Accessing user data in your graph
 
 When auth is enabled, Aegra automatically injects the authenticated user's data into

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.10.0"
+version = "0.10.1"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-api/src/aegra_api/api/runs.py
+++ b/libs/aegra-api/src/aegra_api/api/runs.py
@@ -196,8 +196,9 @@ async def get_run(
     Returns the current state of the run including its status, input, output,
     and error information.
     """
-    # Authorization check (read action on runs resource)
-    ctx = build_auth_context(user, "runs", "read")
+    # Reading a run authorizes as a thread read (Agent Protocol has no `runs`
+    # resource); @auth.on.threads.read covers it.
+    ctx = build_auth_context(user, "threads", "read")
     value = {"run_id": run_id, "thread_id": thread_id}
     await handle_event(ctx, value)
 
@@ -539,8 +540,9 @@ async def delete_run(
     Conflict. Set `force=1` to cancel the run first (best-effort) and then
     delete it. Returns 204 No Content on success.
     """
-    # Authorization check (delete action on runs resource)
-    ctx = build_auth_context(user, "runs", "delete")
+    # Deleting a run authorizes as a thread delete (Agent Protocol has no `runs`
+    # resource); @auth.on.threads.delete covers it.
+    ctx = build_auth_context(user, "threads", "delete")
     value = {"run_id": run_id, "thread_id": thread_id}
     await handle_event(ctx, value)
     logger.info(f"[delete_run] fetch run run_id={run_id} thread_id={thread_id} user={user.identity}")

--- a/libs/aegra-api/src/aegra_api/api/runs.py
+++ b/libs/aegra-api/src/aegra_api/api/runs.py
@@ -100,6 +100,13 @@ async def _apply_create_run_auth(user: User, thread_id: str, request: RunCreate)
     if isinstance(context_overrides, dict):
         request.context = {**(request.context or {}), **context_overrides}
 
+    # Creating a run also reads its assistant, so per-assistant handler rules
+    # apply here exactly as they do in the cron-create chain.
+    await handle_event(
+        build_auth_context(user, "assistants", "read"),
+        {"assistant_id": request.assistant_id},
+    )
+
 
 @router.post("/threads/{thread_id}/runs", response_model=Run, responses={**NOT_FOUND, **CONFLICT})
 async def create_run(

--- a/libs/aegra-api/src/aegra_api/api/store.py
+++ b/libs/aegra-api/src/aegra_api/api/store.py
@@ -201,8 +201,9 @@ async def list_namespaces(
     Returns the namespace paths that contain items. Filter by prefix, suffix,
     or maximum depth.
     """
-    # Authorization check
-    ctx = build_auth_context(user, "store", "search")
+    # Authorization: the protocol action for namespaces is `list_namespaces`,
+    # which @auth.on.store.list_namespaces covers.
+    ctx = build_auth_context(user, "store", "list_namespaces")
     value = request.model_dump()
     filters = await handle_event(ctx, value)
 

--- a/libs/aegra-api/src/aegra_api/api/threads.py
+++ b/libs/aegra-api/src/aegra_api/api/threads.py
@@ -15,6 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from aegra_api.core.active_runs import active_runs
 from aegra_api.core.auth_deps import auth_dependency, get_current_user
+from aegra_api.core.auth_filters import build_metadata_filter
 from aegra_api.core.auth_handlers import build_auth_context, handle_event
 from aegra_api.core.orm import Run as RunORM
 from aegra_api.core.orm import Thread as ThreadORM
@@ -233,13 +234,10 @@ async def list_threads(
     value = {}
     filters = await handle_event(ctx, value)
 
-    # Build query with filters if provided
     stmt = select(ThreadORM).where(ThreadORM.user_id == user.identity)
-    if filters:
-        # Apply filters from authorization handler
-        # For now, we'll apply user_id filter which is already there
-        # Additional filters can be added here based on handler response
-        pass
+    auth_filter = build_metadata_filter(ThreadORM.metadata_json, filters)
+    if auth_filter is not None:
+        stmt = stmt.where(auth_filter)
     result = await session.scalars(stmt)
     rows = result.all()
 
@@ -262,9 +260,14 @@ async def get_thread(
     # Authorization check
     ctx = build_auth_context(user, "threads", "read")
     value = {"thread_id": thread_id}
-    await handle_event(ctx, value)
+    filters = await handle_event(ctx, value)
 
     stmt = select(ThreadORM).where(ThreadORM.thread_id == thread_id, ThreadORM.user_id == user.identity)
+    # A by-id lookup must honor the same filter as search, or a handler that
+    # scopes listings still leaks the row to anyone who knows the id.
+    auth_filter = build_metadata_filter(ThreadORM.metadata_json, filters)
+    if auth_filter is not None:
+        stmt = stmt.where(auth_filter)
     thread = await session.scalar(stmt)
     if not thread:
         raise HTTPException(404, f"Thread '{thread_id}' not found")
@@ -823,9 +826,14 @@ async def delete_thread(
     # Authorization check
     ctx = build_auth_context(user, "threads", "delete")
     value = {"thread_id": thread_id}
-    await handle_event(ctx, value)
+    filters = await handle_event(ctx, value)
 
     stmt = select(ThreadORM).where(ThreadORM.thread_id == thread_id, ThreadORM.user_id == user.identity)
+    # Deleting by id must respect the handler filter too, or a scoped handler
+    # blocks listing a thread while still allowing its deletion.
+    auth_filter = build_metadata_filter(ThreadORM.metadata_json, filters)
+    if auth_filter is not None:
+        stmt = stmt.where(auth_filter)
     thread = await session.scalar(stmt)
     if not thread:
         raise HTTPException(404, f"Thread '{thread_id}' not found")
@@ -870,16 +878,12 @@ async def search_threads(
     value = request.model_dump()
     filters = await handle_event(ctx, value)
 
-    # Merge handler filters with request metadata
-    # Note: ThreadSearchRequest doesn't have a filters field,
-    # so we merge authorization filters into metadata if needed
-    if filters and "metadata" in filters:
-        # If filters contain metadata, merge with request metadata
-        handler_meta = filters["metadata"]
-        if isinstance(handler_meta, dict):
-            request.metadata = {**(request.metadata or {}), **handler_meta}
-        # Other filter types can be handled here if needed
     stmt = select(ThreadORM).where(ThreadORM.user_id == user.identity)
+    # Compile the handler filter rather than merging only its "metadata" key:
+    # the flat shape and the $eq/$contains/$or/$and operators were dropped here.
+    auth_filter = build_metadata_filter(ThreadORM.metadata_json, filters)
+    if auth_filter is not None:
+        stmt = stmt.where(auth_filter)
 
     if request.status:
         stmt = stmt.where(ThreadORM.status == request.status)

--- a/libs/aegra-api/src/aegra_api/core/auth_enforcement.py
+++ b/libs/aegra-api/src/aegra_api/core/auth_enforcement.py
@@ -1,0 +1,137 @@
+"""Guarantee every protocol route dispatches to the user's ``@auth.on`` handlers.
+
+Routes used to opt *in* to authorization by calling ``handle_event`` in their
+body. Forgetting the call produced no error and no failing test — the handler
+just never ran. This module inverts that: dispatch is attached at route
+registration from :mod:`aegra_api.core.auth_registry`, so a route opts *out*
+only by being listed as exempt.
+
+Routes that already call ``handle_event`` themselves stay correct: the request
+is marked once dispatched, and the second call is skipped rather than running a
+user's handler twice.
+"""
+
+from __future__ import annotations
+
+from contextvars import ContextVar
+from typing import Any
+
+import structlog
+from fastapi import Depends, Request
+from fastapi.dependencies.utils import get_parameterless_sub_dependant
+from fastapi.routing import APIRoute
+
+from aegra_api.core.auth_deps import require_auth
+from aegra_api.core.auth_handlers import build_auth_context, handle_event
+from aegra_api.core.auth_registry import lookup_route_auth
+from aegra_api.models.auth import User
+
+logger = structlog.getLogger(__name__)
+
+# Route bodies do not receive the Request, so the "already dispatched" signal
+# travels in a ContextVar rather than request.state. Each request runs in its own
+# context, so this cannot leak between concurrent requests.
+_dispatched: ContextVar[bool] = ContextVar("aegra_auth_dispatched", default=False)
+_filters: ContextVar[dict[str, Any] | None] = ContextVar("aegra_auth_filters", default=None)
+
+
+def mark_dispatched(filters: dict[str, Any] | None) -> None:
+    """Record that authorization already ran for this request."""
+    _dispatched.set(True)
+    _filters.set(filters)
+
+
+def was_dispatched() -> bool:
+    """Whether authorization already ran for this request."""
+    return _dispatched.get()
+
+
+def reset_dispatch_state() -> None:
+    """Clear the per-request dispatch flags (used by tests)."""
+    _dispatched.set(False)
+    _filters.set(None)
+
+
+def get_auth_filters() -> dict[str, Any] | None:
+    """Filters returned by the ``@auth.on`` handler for this request, if any."""
+    return _filters.get()
+
+
+async def _read_json_body(request: Request) -> dict[str, Any]:
+    """Best-effort JSON body for the handler's ``value`` argument.
+
+    Starlette caches the body, so reading it here does not starve the route.
+    A non-dict or unparseable body authorizes as an empty value rather than
+    failing the request — malformed input is the route's error to report.
+    """
+    if request.method in ("GET", "HEAD", "DELETE"):
+        return {}
+    try:
+        body = await request.json()
+    except Exception:
+        return {}
+    return body if isinstance(body, dict) else {}
+
+
+def build_auth_enforcer(resource: str, action: str):
+    """Build the dependency that dispatches ``@auth.on`` for one route."""
+
+    # Depends on require_auth, not get_current_user: this dependency is prepended
+    # so it runs before the route's own, and get_current_user only reads the user
+    # that require_auth puts on the request scope.
+    async def enforce(
+        request: Request,
+        user: User = Depends(require_auth),
+    ) -> None:
+        value: dict[str, Any] = {**request.path_params, **await _read_json_body(request)}
+        ctx = build_auth_context(user, resource, action)
+        filters = await handle_event(ctx, value)
+        mark_dispatched(filters)
+
+    return enforce
+
+
+def apply_auth_enforcement(app: Any) -> int:
+    """Attach ``@auth.on`` dispatch to every registered protocol route.
+
+    Returns the number of routes wired, for startup logging and tests.
+    """
+    wired = 0
+
+    def walk(routes: list[Any]) -> None:
+        nonlocal wired
+        for route in routes:
+            if isinstance(route, APIRoute):
+                wired += _wire_route(route)
+                continue
+            # FastAPI wraps included routers; newer versions expose the wrapped
+            # router as `original_router` rather than `routes`.
+            nested = getattr(route, "original_router", None)
+            if nested is not None:
+                walk(list(nested.routes))
+            elif hasattr(route, "routes"):
+                walk(list(route.routes))
+
+    walk(list(app.routes))
+    logger.info("Applied authorization dispatch to protocol routes", route_count=wired)
+    return wired
+
+
+def _wire_route(route: APIRoute) -> int:
+    """Attach the enforcer to a single route for each registered method."""
+    for method in sorted(route.methods or set()):
+        mapping = lookup_route_auth(method, route.path)
+        if mapping is None:
+            continue
+        resource, action = mapping
+        dependency = Depends(build_auth_enforcer(resource, action))
+        # Prepend so authorization runs before the route's own dependencies.
+        route.dependencies = [dependency, *(route.dependencies or [])]
+        # `dependencies` alone is only read at construction time; mirror what
+        # APIRoute.__init__ does so the already-built dependant picks it up.
+        route.dependant.dependencies.insert(
+            0,
+            get_parameterless_sub_dependant(depends=dependency, path=route.path_format),
+        )
+        return 1
+    return 0

--- a/libs/aegra-api/src/aegra_api/core/auth_enforcement.py
+++ b/libs/aegra-api/src/aegra_api/core/auth_enforcement.py
@@ -15,6 +15,7 @@ other registered route is dispatched from here.
 from __future__ import annotations
 
 import json
+from collections.abc import Awaitable, Callable
 from contextvars import ContextVar
 from typing import Any
 
@@ -68,7 +69,7 @@ async def _read_json_body(request: Request) -> dict[str, Any]:
     return body if isinstance(body, dict) else {}
 
 
-def build_auth_enforcer(resource: str, action: str):
+def build_auth_enforcer(resource: str, action: str) -> Callable[..., Awaitable[None]]:
     """Build the dependency that dispatches ``@auth.on`` for one route."""
 
     # Depends on require_auth, not get_current_user: this dependency is prepended
@@ -78,7 +79,9 @@ def build_auth_enforcer(resource: str, action: str):
         request: Request,
         user: User = Depends(require_auth),
     ) -> None:
-        value: dict[str, Any] = {**request.path_params, **await _read_json_body(request)}
+        # Path params win over the body: the route operates on the URL-selected
+        # resource, so a crafted body must not swap the id a handler authorizes.
+        value: dict[str, Any] = {**await _read_json_body(request), **request.path_params}
         ctx = build_auth_context(user, resource, action)
         await handle_event(ctx, value)
         mark_dispatched(resource, action)
@@ -114,6 +117,11 @@ def apply_auth_enforcement(app: Any) -> int:
 
 def _wire_route(route: APIRoute) -> int:
     """Attach the enforcer to a single route for each registered method."""
+    # Idempotent: a second pass over the same route object (double router
+    # include, create_app run twice in tests) must not prepend a second enforcer,
+    # which would dispatch the handler twice.
+    if getattr(route, "_aegra_auth_wired", False):
+        return 0
     for method in sorted(route.methods or set()):
         mapping = lookup_route_auth(method, route.path)
         if mapping is None:
@@ -122,6 +130,7 @@ def _wire_route(route: APIRoute) -> int:
         # Wiring the enforcer here too would run the handler twice and drop any
         # metadata the handler injects by mutating `value`.
         if is_self_dispatching(method, route.path):
+            route._aegra_auth_wired = True  # type: ignore[attr-defined]
             return 0
         resource, action = mapping
         dependency = Depends(build_auth_enforcer(resource, action))
@@ -133,5 +142,6 @@ def _wire_route(route: APIRoute) -> int:
             0,
             get_parameterless_sub_dependant(depends=dependency, path=route.path_format),
         )
+        route._aegra_auth_wired = True  # type: ignore[attr-defined]
         return 1
     return 0

--- a/libs/aegra-api/src/aegra_api/core/auth_enforcement.py
+++ b/libs/aegra-api/src/aegra_api/core/auth_enforcement.py
@@ -4,15 +4,17 @@ Routes used to opt *in* to authorization by calling ``handle_event`` in their
 body. Forgetting the call produced no error and no failing test — the handler
 just never ran. This module inverts that: dispatch is attached at route
 registration from :mod:`aegra_api.core.auth_registry`, so a route opts *out*
-only by being listed as exempt.
+only by being listed exempt.
 
-Routes that already call ``handle_event`` themselves stay correct: the request
-is marked once dispatched, and the second call is skipped rather than running a
-user's handler twice.
+Exactly one layer authorizes each event. A route listed in ``SELF_DISPATCHING``
+keeps its in-body call and gets no enforcer, because its ``value`` is the live
+request model and handlers may inject metadata by mutating it in place. Every
+other registered route is dispatched from here.
 """
 
 from __future__ import annotations
 
+import json
 from contextvars import ContextVar
 from typing import Any
 
@@ -23,38 +25,31 @@ from fastapi.routing import APIRoute
 
 from aegra_api.core.auth_deps import require_auth
 from aegra_api.core.auth_handlers import build_auth_context, handle_event
-from aegra_api.core.auth_registry import lookup_route_auth
+from aegra_api.core.auth_registry import is_self_dispatching, lookup_route_auth
 from aegra_api.models.auth import User
 
 logger = structlog.getLogger(__name__)
 
-# Route bodies do not receive the Request, so the "already dispatched" signal
-# travels in a ContextVar rather than request.state. Each request runs in its own
-# context, so this cannot leak between concurrent requests.
-_dispatched: ContextVar[bool] = ContextVar("aegra_auth_dispatched", default=False)
-_filters: ContextVar[dict[str, Any] | None] = ContextVar("aegra_auth_filters", default=None)
+# Records which (resource, action) pairs the enforcer authorized, for assertions
+# in tests. Never a single flag: one request legitimately authorizes several
+# events — creating a cron dispatches crons.create, then assistants.read, then
+# threads.read — so a boolean would misrepresent the chain.
+_dispatched: ContextVar[frozenset[tuple[str, str]]] = ContextVar("aegra_auth_dispatched", default=frozenset())
 
 
-def mark_dispatched(filters: dict[str, Any] | None) -> None:
-    """Record that authorization already ran for this request."""
-    _dispatched.set(True)
-    _filters.set(filters)
+def mark_dispatched(resource: str, action: str) -> None:
+    """Record that ``(resource, action)`` was authorized for this request."""
+    _dispatched.set(_dispatched.get() | {(resource, action)})
 
 
-def was_dispatched() -> bool:
-    """Whether authorization already ran for this request."""
+def dispatched_events() -> frozenset[tuple[str, str]]:
+    """Events the enforcer authorized for this request."""
     return _dispatched.get()
 
 
 def reset_dispatch_state() -> None:
-    """Clear the per-request dispatch flags (used by tests)."""
-    _dispatched.set(False)
-    _filters.set(None)
-
-
-def get_auth_filters() -> dict[str, Any] | None:
-    """Filters returned by the ``@auth.on`` handler for this request, if any."""
-    return _filters.get()
+    """Clear the per-request dispatch record (used by tests)."""
+    _dispatched.set(frozenset())
 
 
 async def _read_json_body(request: Request) -> dict[str, Any]:
@@ -64,11 +59,11 @@ async def _read_json_body(request: Request) -> dict[str, Any]:
     A non-dict or unparseable body authorizes as an empty value rather than
     failing the request — malformed input is the route's error to report.
     """
-    if request.method in ("GET", "HEAD", "DELETE"):
+    if request.method in ("GET", "HEAD"):
         return {}
     try:
         body = await request.json()
-    except Exception:
+    except (json.JSONDecodeError, UnicodeDecodeError):
         return {}
     return body if isinstance(body, dict) else {}
 
@@ -85,8 +80,8 @@ def build_auth_enforcer(resource: str, action: str):
     ) -> None:
         value: dict[str, Any] = {**request.path_params, **await _read_json_body(request)}
         ctx = build_auth_context(user, resource, action)
-        filters = await handle_event(ctx, value)
-        mark_dispatched(filters)
+        await handle_event(ctx, value)
+        mark_dispatched(resource, action)
 
     return enforce
 
@@ -123,6 +118,11 @@ def _wire_route(route: APIRoute) -> int:
         mapping = lookup_route_auth(method, route.path)
         if mapping is None:
             continue
+        # The route body authorizes itself against the live request model.
+        # Wiring the enforcer here too would run the handler twice and drop any
+        # metadata the handler injects by mutating `value`.
+        if is_self_dispatching(method, route.path):
+            return 0
         resource, action = mapping
         dependency = Depends(build_auth_enforcer(resource, action))
         # Prepend so authorization runs before the route's own dependencies.

--- a/libs/aegra-api/src/aegra_api/core/auth_handlers.py
+++ b/libs/aegra-api/src/aegra_api/core/auth_handlers.py
@@ -105,15 +105,6 @@ async def handle_event(
         # This allows the request to proceed normally
         return None
 
-    # Local import: auth_enforcement imports handle_event from this module, so a
-    # module-level import here is a cycle (confirmed by ImportError).
-    from aegra_api.core.auth_enforcement import get_auth_filters, was_dispatched
-
-    # Route registration already dispatched this request's handler. Running the
-    # in-body call too would invoke a user's handler twice per request.
-    if was_dispatched():
-        return get_auth_filters()
-
     auth = get_auth_instance()
     if auth is None:
         # No auth configured, allow by default

--- a/libs/aegra-api/src/aegra_api/core/auth_handlers.py
+++ b/libs/aegra-api/src/aegra_api/core/auth_handlers.py
@@ -105,6 +105,15 @@ async def handle_event(
         # This allows the request to proceed normally
         return None
 
+    # Local import: auth_enforcement imports handle_event from this module, so a
+    # module-level import here is a cycle (confirmed by ImportError).
+    from aegra_api.core.auth_enforcement import get_auth_filters, was_dispatched
+
+    # Route registration already dispatched this request's handler. Running the
+    # in-body call too would invoke a user's handler twice per request.
+    if was_dispatched():
+        return get_auth_filters()
+
     auth = get_auth_instance()
     if auth is None:
         # No auth configured, allow by default

--- a/libs/aegra-api/src/aegra_api/core/auth_registry.py
+++ b/libs/aegra-api/src/aegra_api/core/auth_registry.py
@@ -48,6 +48,13 @@ ROUTE_AUTH_MAP: Final[dict[tuple[str, str], tuple[str, str]]] = {
     ("GET", "/threads/{thread_id}/history"): ("threads", "read"),
     ("POST", "/threads/{thread_id}/history"): ("threads", "read"),
     # --- runs ---------------------------------------------------------------
+    # NON-PORTABLE resource names below. The Agent Protocol has no `runs`
+    # resource; run operations authorize under `threads` (verified against
+    # langgraph-api 0.12.1 grpc/ops/runs.py, which sets resource = "threads").
+    # A handler written to the protocol docs as `@auth.on.threads.read` will NOT
+    # fire on these routes. This mirrors the names already shipped on main; do
+    # not extend them. Retire to `threads.*` in the 0.10.0 breaking sweep —
+    # tracked in aegra-context/AUTH_DISPATCH_SPEC.md (§2, Decision #1).
     ("POST", "/threads/{thread_id}/runs"): ("threads", "create_run"),
     ("POST", "/threads/{thread_id}/runs/stream"): ("threads", "create_run"),
     ("POST", "/threads/{thread_id}/runs/wait"): ("threads", "create_run"),
@@ -76,6 +83,9 @@ ROUTE_AUTH_MAP: Final[dict[tuple[str, str], tuple[str, str]]] = {
     ("GET", "/store/items"): ("store", "get"),
     ("DELETE", "/store/items"): ("store", "delete"),
     ("POST", "/store/items/search"): ("store", "search"),
+    # NON-PORTABLE: the protocol names this action `list_namespaces`, not
+    # `search` (langgraph-api 0.12.1 api/store.py). Rename in the 0.10.0 sweep;
+    # tracked in aegra-context/AUTH_DISPATCH_SPEC.md (§4.6).
     ("POST", "/store/namespaces"): ("store", "search"),
     # --- protocol v2 event streaming ---------------------------------------
     ("POST", "/threads/{thread_id}/stream/events"): ("threads", "read"),

--- a/libs/aegra-api/src/aegra_api/core/auth_registry.py
+++ b/libs/aegra-api/src/aegra_api/core/auth_registry.py
@@ -82,6 +82,64 @@ ROUTE_AUTH_MAP: Final[dict[tuple[str, str], tuple[str, str]]] = {
     ("POST", "/threads/{thread_id}/commands"): ("threads", "create_run"),
 }
 
+# Routes that authorize themselves inside the handler body.
+#
+# These own their dispatch for a reason: their `value` is the live request model,
+# and a handler may inject metadata by mutating it in place (see
+# examples/jwt_mock_auth_example.py, which sets value["metadata"]["team_id"]).
+# Dispatching from the route registration would run the handler against a
+# throwaway dict and silently drop that injection, so the enforcer stands down
+# and lets the route call handle_event itself.
+#
+# Everything else in ROUTE_AUTH_MAP is dispatched by the enforcer.
+SELF_DISPATCHING: Final[frozenset[tuple[str, str]]] = frozenset(
+    {
+        ("POST", "/assistants"),
+        ("GET", "/assistants"),
+        ("POST", "/assistants/search"),
+        ("POST", "/assistants/count"),
+        ("GET", "/assistants/{assistant_id}"),
+        ("PATCH", "/assistants/{assistant_id}"),
+        ("DELETE", "/assistants/{assistant_id}"),
+        ("POST", "/assistants/{assistant_id}/latest"),
+        ("POST", "/assistants/{assistant_id}/versions"),
+        ("GET", "/assistants/{assistant_id}/schemas"),
+        ("GET", "/assistants/{assistant_id}/graph"),
+        ("GET", "/assistants/{assistant_id}/subgraphs"),
+        ("POST", "/threads"),
+        ("GET", "/threads"),
+        ("POST", "/threads/search"),
+        ("GET", "/threads/{thread_id}"),
+        ("PATCH", "/threads/{thread_id}"),
+        ("DELETE", "/threads/{thread_id}"),
+        ("POST", "/threads/{thread_id}/runs"),
+        ("POST", "/threads/{thread_id}/runs/stream"),
+        ("POST", "/threads/{thread_id}/runs/wait"),
+        ("GET", "/threads/{thread_id}/runs/{run_id}"),
+        ("DELETE", "/threads/{thread_id}/runs/{run_id}"),
+        ("POST", "/runs"),
+        ("POST", "/runs/stream"),
+        ("POST", "/runs/wait"),
+        ("POST", "/runs/crons"),
+        ("POST", "/threads/{thread_id}/runs/crons"),
+        ("PATCH", "/runs/crons/{cron_id}"),
+        ("DELETE", "/runs/crons/{cron_id}"),
+        ("POST", "/runs/crons/search"),
+        ("POST", "/runs/crons/count"),
+        ("PUT", "/store/items"),
+        ("GET", "/store/items"),
+        ("DELETE", "/store/items"),
+        ("POST", "/store/items/search"),
+        ("POST", "/store/namespaces"),
+    }
+)
+
+
+def is_self_dispatching(method: str, path: str) -> bool:
+    """Whether the route body authorizes itself, so the enforcer must stand down."""
+    return (method.upper(), path) in SELF_DISPATCHING
+
+
 # Routes that intentionally carry no @auth.on dispatch. Anything not here and
 # not in ROUTE_AUTH_MAP fails the coverage test.
 EXEMPT_PATHS: Final[frozenset[str]] = frozenset(

--- a/libs/aegra-api/src/aegra_api/core/auth_registry.py
+++ b/libs/aegra-api/src/aegra_api/core/auth_registry.py
@@ -1,0 +1,105 @@
+"""Declarative map of every Agent Protocol route to its ``@auth.on`` identity.
+
+Authorization used to be wired by hand inside each route body, which made
+"forgot to call ``handle_event``" invisible: the route worked, the tests passed,
+and a user's ``@auth.on.assistants`` handler simply never ran. Whole routers
+shipped with no dispatch at all.
+
+The map below is the single source of truth for which ``(resource, action)``
+pair a route authorizes as. ``tests/unit/test_core/test_auth_registry.py``
+asserts every mounted route is either listed here or explicitly exempt, so a new
+route cannot silently join the unprotected set.
+
+Path keys are FastAPI templates (``/threads/{thread_id}``), matched exactly.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+# (method, path) -> (resource, action)
+ROUTE_AUTH_MAP: Final[dict[tuple[str, str], tuple[str, str]]] = {
+    # --- assistants ---------------------------------------------------------
+    ("POST", "/assistants"): ("assistants", "create"),
+    ("GET", "/assistants"): ("assistants", "search"),
+    ("POST", "/assistants/search"): ("assistants", "search"),
+    ("POST", "/assistants/count"): ("assistants", "search"),
+    ("GET", "/assistants/{assistant_id}"): ("assistants", "read"),
+    ("PATCH", "/assistants/{assistant_id}"): ("assistants", "update"),
+    ("DELETE", "/assistants/{assistant_id}"): ("assistants", "delete"),
+    ("POST", "/assistants/{assistant_id}/latest"): ("assistants", "update"),
+    ("POST", "/assistants/{assistant_id}/versions"): ("assistants", "read"),
+    ("GET", "/assistants/{assistant_id}/schemas"): ("assistants", "read"),
+    ("GET", "/assistants/{assistant_id}/graph"): ("assistants", "read"),
+    ("GET", "/assistants/{assistant_id}/subgraphs"): ("assistants", "read"),
+    # --- threads ------------------------------------------------------------
+    ("POST", "/threads"): ("threads", "create"),
+    ("GET", "/threads"): ("threads", "search"),
+    ("POST", "/threads/search"): ("threads", "search"),
+    ("GET", "/threads/{thread_id}"): ("threads", "read"),
+    ("PATCH", "/threads/{thread_id}"): ("threads", "update"),
+    ("DELETE", "/threads/{thread_id}"): ("threads", "delete"),
+    # Reading or writing checkpointed state is a thread read/update, not a
+    # separate resource: handlers scoping "threads" must cover it.
+    ("GET", "/threads/{thread_id}/state"): ("threads", "read"),
+    ("POST", "/threads/{thread_id}/state"): ("threads", "update"),
+    ("GET", "/threads/{thread_id}/state/{checkpoint_id}"): ("threads", "read"),
+    ("POST", "/threads/{thread_id}/state/checkpoint"): ("threads", "read"),
+    ("GET", "/threads/{thread_id}/history"): ("threads", "read"),
+    ("POST", "/threads/{thread_id}/history"): ("threads", "read"),
+    # --- runs ---------------------------------------------------------------
+    ("POST", "/threads/{thread_id}/runs"): ("threads", "create_run"),
+    ("POST", "/threads/{thread_id}/runs/stream"): ("threads", "create_run"),
+    ("POST", "/threads/{thread_id}/runs/wait"): ("threads", "create_run"),
+    ("GET", "/threads/{thread_id}/runs"): ("runs", "search"),
+    ("GET", "/threads/{thread_id}/runs/{run_id}"): ("runs", "read"),
+    ("PATCH", "/threads/{thread_id}/runs/{run_id}"): ("runs", "update"),
+    ("GET", "/threads/{thread_id}/runs/{run_id}/join"): ("runs", "read"),
+    ("GET", "/threads/{thread_id}/runs/{run_id}/stream"): ("runs", "read"),
+    ("POST", "/threads/{thread_id}/runs/{run_id}/cancel"): ("runs", "update"),
+    ("DELETE", "/threads/{thread_id}/runs/{run_id}"): ("runs", "delete"),
+    # --- stateless runs -----------------------------------------------------
+    # These mint an ephemeral thread, so they authorize as a thread create_run
+    # exactly like their threaded counterparts.
+    ("POST", "/runs"): ("threads", "create_run"),
+    ("POST", "/runs/stream"): ("threads", "create_run"),
+    ("POST", "/runs/wait"): ("threads", "create_run"),
+    # --- crons --------------------------------------------------------------
+    ("POST", "/runs/crons"): ("crons", "create"),
+    ("POST", "/threads/{thread_id}/runs/crons"): ("crons", "create"),
+    ("PATCH", "/runs/crons/{cron_id}"): ("crons", "update"),
+    ("DELETE", "/runs/crons/{cron_id}"): ("crons", "delete"),
+    ("POST", "/runs/crons/search"): ("crons", "search"),
+    ("POST", "/runs/crons/count"): ("crons", "search"),
+    # --- store --------------------------------------------------------------
+    ("PUT", "/store/items"): ("store", "put"),
+    ("GET", "/store/items"): ("store", "get"),
+    ("DELETE", "/store/items"): ("store", "delete"),
+    ("POST", "/store/items/search"): ("store", "search"),
+    ("POST", "/store/namespaces"): ("store", "search"),
+    # --- protocol v2 event streaming ---------------------------------------
+    ("POST", "/threads/{thread_id}/stream/events"): ("threads", "read"),
+    ("POST", "/threads/{thread_id}/commands"): ("threads", "create_run"),
+}
+
+# Routes that intentionally carry no @auth.on dispatch. Anything not here and
+# not in ROUTE_AUTH_MAP fails the coverage test.
+EXEMPT_PATHS: Final[frozenset[str]] = frozenset(
+    {
+        "/",
+        "/health",
+        "/ready",
+        "/live",
+        "/metrics",
+        "/info",
+        "/docs",
+        "/redoc",
+        "/openapi.json",
+        "/docs/oauth2-redirect",
+    }
+)
+
+
+def lookup_route_auth(method: str, path: str) -> tuple[str, str] | None:
+    """Return the ``(resource, action)`` a route authorizes as, if any."""
+    return ROUTE_AUTH_MAP.get((method.upper(), path))

--- a/libs/aegra-api/src/aegra_api/core/auth_registry.py
+++ b/libs/aegra-api/src/aegra_api/core/auth_registry.py
@@ -48,23 +48,20 @@ ROUTE_AUTH_MAP: Final[dict[tuple[str, str], tuple[str, str]]] = {
     ("GET", "/threads/{thread_id}/history"): ("threads", "read"),
     ("POST", "/threads/{thread_id}/history"): ("threads", "read"),
     # --- runs ---------------------------------------------------------------
-    # NON-PORTABLE resource names below. The Agent Protocol has no `runs`
-    # resource; run operations authorize under `threads` (verified against
-    # langgraph-api 0.12.1 grpc/ops/runs.py, which sets resource = "threads").
-    # A handler written to the protocol docs as `@auth.on.threads.read` will NOT
-    # fire on these routes. This mirrors the names already shipped on main; do
-    # not extend them. Retire to `threads.*` in the 0.10.0 breaking sweep —
-    # tracked in aegra-context/AUTH_DISPATCH_SPEC.md (§2, Decision #1).
+    # Run operations authorize under `threads` per the Agent Protocol (verified
+    # against langgraph-api 0.12.1 grpc/ops/runs.py, resource = "threads"). The
+    # SDK's @auth.on has no `runs` resource, so no user handler could ever have
+    # bound to the old `runs.*` names — this alignment is non-breaking.
     ("POST", "/threads/{thread_id}/runs"): ("threads", "create_run"),
     ("POST", "/threads/{thread_id}/runs/stream"): ("threads", "create_run"),
     ("POST", "/threads/{thread_id}/runs/wait"): ("threads", "create_run"),
-    ("GET", "/threads/{thread_id}/runs"): ("runs", "search"),
-    ("GET", "/threads/{thread_id}/runs/{run_id}"): ("runs", "read"),
-    ("PATCH", "/threads/{thread_id}/runs/{run_id}"): ("runs", "update"),
-    ("GET", "/threads/{thread_id}/runs/{run_id}/join"): ("runs", "read"),
-    ("GET", "/threads/{thread_id}/runs/{run_id}/stream"): ("runs", "read"),
-    ("POST", "/threads/{thread_id}/runs/{run_id}/cancel"): ("runs", "update"),
-    ("DELETE", "/threads/{thread_id}/runs/{run_id}"): ("runs", "delete"),
+    ("GET", "/threads/{thread_id}/runs"): ("threads", "search"),
+    ("GET", "/threads/{thread_id}/runs/{run_id}"): ("threads", "read"),
+    ("PATCH", "/threads/{thread_id}/runs/{run_id}"): ("threads", "update"),
+    ("GET", "/threads/{thread_id}/runs/{run_id}/join"): ("threads", "read"),
+    ("GET", "/threads/{thread_id}/runs/{run_id}/stream"): ("threads", "read"),
+    ("POST", "/threads/{thread_id}/runs/{run_id}/cancel"): ("threads", "update"),
+    ("DELETE", "/threads/{thread_id}/runs/{run_id}"): ("threads", "delete"),
     # --- stateless runs -----------------------------------------------------
     # These mint an ephemeral thread, so they authorize as a thread create_run
     # exactly like their threaded counterparts.
@@ -83,10 +80,10 @@ ROUTE_AUTH_MAP: Final[dict[tuple[str, str], tuple[str, str]]] = {
     ("GET", "/store/items"): ("store", "get"),
     ("DELETE", "/store/items"): ("store", "delete"),
     ("POST", "/store/items/search"): ("store", "search"),
-    # NON-PORTABLE: the protocol names this action `list_namespaces`, not
-    # `search` (langgraph-api 0.12.1 api/store.py). Rename in the 0.10.0 sweep;
-    # tracked in aegra-context/AUTH_DISPATCH_SPEC.md (§4.6).
-    ("POST", "/store/namespaces"): ("store", "search"),
+    # Protocol action is `list_namespaces`, which the SDK's @auth.on.store
+    # already exposes (langgraph-api 0.12.1 api/store.py). The old `store.search`
+    # here was a bug, not an API anyone could bind to for namespaces.
+    ("POST", "/store/namespaces"): ("store", "list_namespaces"),
     # --- protocol v2 event streaming ---------------------------------------
     ("POST", "/threads/{thread_id}/stream/events"): ("threads", "read"),
     ("POST", "/threads/{thread_id}/commands"): ("threads", "create_run"),

--- a/libs/aegra-api/src/aegra_api/main.py
+++ b/libs/aegra-api/src/aegra_api/main.py
@@ -22,6 +22,7 @@ from aegra_api.api.threads import router as threads_router
 from aegra_api.config import CorsConfig, HttpConfig, get_config_dir, load_http_config
 from aegra_api.core.app_loader import load_custom_app
 from aegra_api.core.auth_deps import auth_dependency
+from aegra_api.core.auth_enforcement import apply_auth_enforcement
 from aegra_api.core.database import db_manager
 from aegra_api.core.health import router as health_router
 from aegra_api.core.migrations import run_migrations_async
@@ -311,6 +312,10 @@ def _include_core_routers(app: FastAPI) -> None:
     app.include_router(crons_router)
     app.include_router(store_router)
     app.include_router(event_streaming_router)
+
+    # Attach @auth.on dispatch from the route registry. Routes must opt out
+    # explicitly; forgetting the in-body call no longer disables authorization.
+    apply_auth_enforcement(app)
 
 
 def create_app() -> FastAPI:

--- a/libs/aegra-api/tests/integration/test_auth_enforcement_routes.py
+++ b/libs/aegra-api/tests/integration/test_auth_enforcement_routes.py
@@ -44,14 +44,14 @@ def _build_app(auth: Auth, monkeypatch: pytest.MonkeyPatch) -> FastAPI:
     # `aegra_api.core`, which breaks string-target resolution in a full run.
     monkeypatch.setattr(auth_handlers, "get_auth_instance", lambda: auth)
 
-    from aegra_api.api import assistants, event_streaming, runs, stateless_runs, threads
+    from aegra_api.api import assistants, crons, event_streaming, runs, stateless_runs, store, threads
 
     app = FastAPI()
     mock_user = User(identity="test-user", display_name="Test User")
     app.dependency_overrides[require_auth] = lambda: mock_user
     app.dependency_overrides[get_current_user] = lambda: mock_user
 
-    for module in (assistants, threads, runs, stateless_runs, event_streaming):
+    for module in (assistants, threads, runs, stateless_runs, crons, store, event_streaming):
         app.include_router(module.router)
 
     # Allowed requests fall through to the DB; stub it so these tests stay
@@ -144,20 +144,101 @@ def test_handler_runs_exactly_once_per_request(monkeypatch: pytest.MonkeyPatch) 
     assert len(calls) == 1, f"Expected one handler invocation, got {len(calls)}: {calls}"
 
 
-def test_stateless_run_cannot_bypass_thread_handler(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Dropping the thread_id must not dodge an @auth.on.threads rule."""
+def test_self_dispatching_route_keeps_value_mutation(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A handler injecting metadata by mutating `value` must still reach the route.
+
+    Handlers mutate the dict in place (the shipped example sets
+    ``value["metadata"]["team_id"]``). Dispatching from route registration would
+    run the handler against a throwaway dict and silently drop the injection.
+    """
     auth = Auth()
 
-    @auth.on.threads
-    async def deny_threads(ctx: Any, value: Any) -> bool:
+    @auth.on.threads.create
+    async def inject(ctx: Any, value: Any) -> bool:
+        # Mirrors examples/jwt_mock_auth_example.py: metadata may arrive as None.
+        if value.get("metadata") is None:
+            value["metadata"] = {}
+        value["metadata"]["team_id"] = "team999"
+        return True
+
+    app = _build_app(auth, monkeypatch)
+
+    with TestClient(app) as client:
+        response = client.post("/threads", json={})
+
+    assert response.status_code == 200, response.text
+    assert response.json()["metadata"].get("team_id") == "team999", (
+        "Handler metadata injection was lost; the route dispatched against a "
+        "throwaway dict instead of its own request model"
+    )
+
+
+def test_cron_create_authorizes_every_layer_of_its_chain(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Cron creation checks crons, then the assistant, then the thread.
+
+    A single "already dispatched" flag collapses this chain to its first event
+    and skips the assistant and thread checks entirely.
+    """
+    auth = Auth()
+    seen: list[tuple[str, str]] = []
+
+    @auth.on
+    async def record(ctx: Any, value: Any) -> bool:
+        seen.append((ctx.resource, ctx.action))
+        return True
+
+    app = _build_app(auth, monkeypatch)
+
+    # Stateless cron create: no thread row needed, and it still walks the full
+    # crons.create -> assistants.read -> threads.search chain.
+    with TestClient(app, raise_server_exceptions=False) as client:
+        client.post("/runs/crons", json={"assistant_id": "agent", "schedule": "0 0 * * *"})
+
+    assert ("crons", "create") in seen
+    assert ("assistants", "read") in seen, "cron create stopped authorizing the assistant"
+    assert ("threads", "search") in seen, "cron create stopped authorizing the thread layer"
+
+
+def test_store_delete_handler_receives_namespace_and_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """DELETE /store/items carries a body; the handler must see it, not {}."""
+    auth = Auth()
+    seen: list[dict[str, Any]] = []
+
+    @auth.on.store
+    async def record(ctx: Any, value: Any) -> bool:
+        seen.append(dict(value))
         return False
 
     app = _build_app(auth, monkeypatch)
 
     with TestClient(app) as client:
-        response = client.post("/runs", json={"assistant_id": "agent"})
+        client.request("DELETE", "/store/items", json={"namespace": ["a"], "key": "k1"})
 
-    assert response.status_code == 403
+    assert seen, "store delete never reached a handler"
+    assert seen[0].get("key") == "k1", f"handler saw {seen[0]}, losing the request body"
+
+
+def test_stateless_run_cannot_bypass_thread_handler(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Dropping the thread_id must not dodge an @auth.on.threads rule.
+
+    Asserts on the handler rather than the status code: the route mints its
+    ephemeral thread before authorizing, so a denial unwinds through real
+    cleanup that this mocked app cannot serve.
+    """
+    auth = Auth()
+    seen: list[tuple[str, str]] = []
+
+    @auth.on.threads
+    async def deny_threads(ctx: Any, value: Any) -> bool:
+        seen.append((ctx.resource, ctx.action))
+        return False
+
+    app = _build_app(auth, monkeypatch)
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        client.post("/runs", json={"assistant_id": "agent", "input": {}})
+
+    assert ("threads", "create_run") in seen, "a stateless run reached execution without consulting @auth.on.threads"
 
 
 def test_enforcer_authenticates_rather_than_reading_an_unset_scope() -> None:

--- a/libs/aegra-api/tests/integration/test_auth_enforcement_routes.py
+++ b/libs/aegra-api/tests/integration/test_auth_enforcement_routes.py
@@ -124,6 +124,53 @@ def test_thread_read_handler_reaches_state_and_history(monkeypatch: pytest.Monke
     assert seen == [("threads", "read")] * 3
 
 
+def test_path_param_wins_over_crafted_body(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The URL's thread_id must reach the handler, not a conflicting body value.
+
+    The route operates on the URL-selected resource, so a handler authorizing on
+    value["thread_id"] must see the URL id — otherwise a crafted body could get a
+    different object authorized than the one acted on.
+    """
+    auth = Auth()
+    seen_thread_ids: list[Any] = []
+
+    @auth.on.threads
+    async def record(ctx: Any, value: Any) -> bool:
+        seen_thread_ids.append(value.get("thread_id"))
+        return True
+
+    app = _build_app(auth, monkeypatch)
+
+    with TestClient(app) as client:
+        # POST state on thread url-1, but body claims thread_id = evil.
+        client.post(
+            "/threads/url-1/state",
+            json={"values": {}, "thread_id": "evil"},
+        )
+
+    assert seen_thread_ids, "handler never fired"
+    assert set(seen_thread_ids) == {"url-1"}, f"handler saw {seen_thread_ids}; a body value overrode the URL thread_id"
+
+
+def test_enforcement_is_idempotent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Applying enforcement twice must not dispatch the handler twice."""
+    auth = Auth()
+    calls: list[str] = []
+
+    @auth.on.threads
+    async def record(ctx: Any, value: Any) -> bool:
+        calls.append(ctx.action)
+        return True
+
+    app = _build_app(auth, monkeypatch)
+    apply_auth_enforcement(app)  # second pass over the same routes
+
+    with TestClient(app) as client:
+        client.get("/threads/t-1/state")
+
+    assert len(calls) == 1, f"double-wiring dispatched {len(calls)} times: {calls}"
+
+
 def test_handler_runs_exactly_once_per_request(monkeypatch: pytest.MonkeyPatch) -> None:
     """Routes that already call handle_event must not dispatch a second time."""
     auth = Auth()

--- a/libs/aegra-api/tests/integration/test_auth_enforcement_routes.py
+++ b/libs/aegra-api/tests/integration/test_auth_enforcement_routes.py
@@ -265,6 +265,68 @@ def test_store_delete_handler_receives_namespace_and_key(monkeypatch: pytest.Mon
     assert seen[0].get("key") == "k1", f"handler saw {seen[0]}, losing the request body"
 
 
+def test_run_create_authorizes_the_assistant(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Creating a run consults @auth.on.assistants for the assistant it uses.
+
+    Mirrors the cron-create chain: threads.create_run alone would let a user
+    run an assistant that a per-assistant handler rule denies to them.
+    """
+    auth = Auth()
+    seen: list[tuple[str, str, Any]] = []
+
+    @auth.on
+    async def record(ctx: Any, value: Any) -> bool:
+        seen.append((ctx.resource, ctx.action, value.get("assistant_id")))
+        return True
+
+    app = _build_app(auth, monkeypatch)
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        client.post("/threads/t-1/runs", json={"assistant_id": "agent", "input": {}})
+
+    events = [(res, act) for res, act, _ in seen]
+    assert ("threads", "create_run") in events
+    assert ("assistants", "read") in events, "run create stopped authorizing the assistant"
+    assistant_ids = [aid for res, _, aid in seen if res == "assistants"]
+    assert assistant_ids == ["agent"], f"assistant handler saw {assistant_ids}"
+
+
+def test_deny_assistant_handler_blocks_run_create(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A handler denying assistants.read must stop run creation with 403."""
+    auth = Auth()
+
+    @auth.on.assistants
+    async def deny(ctx: Any, value: Any) -> bool:
+        return False
+
+    app = _build_app(auth, monkeypatch)
+
+    with TestClient(app) as client:
+        response = client.post("/threads/t-1/runs", json={"assistant_id": "agent", "input": {}})
+
+    assert response.status_code == 403, (
+        f"got {response.status_code}; a denied assistant must block run creation before any run is prepared"
+    )
+
+
+def test_stateless_run_also_authorizes_the_assistant(monkeypatch: pytest.MonkeyPatch) -> None:
+    """POST /runs delegates to the threaded path, so the assistant check holds there too."""
+    auth = Auth()
+    seen: list[tuple[str, str]] = []
+
+    @auth.on
+    async def record(ctx: Any, value: Any) -> bool:
+        seen.append((ctx.resource, ctx.action))
+        return True
+
+    app = _build_app(auth, monkeypatch)
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        client.post("/runs", json={"assistant_id": "agent", "input": {}})
+
+    assert ("assistants", "read") in seen, "a stateless run skipped the assistant authorization"
+
+
 def test_stateless_run_cannot_bypass_thread_handler(monkeypatch: pytest.MonkeyPatch) -> None:
     """Dropping the thread_id must not dodge an @auth.on.threads rule.
 

--- a/libs/aegra-api/tests/integration/test_auth_enforcement_routes.py
+++ b/libs/aegra-api/tests/integration/test_auth_enforcement_routes.py
@@ -1,0 +1,199 @@
+"""A registered ``@auth.on`` handler must fire on every protocol route.
+
+Regression coverage for routes that reached the database without dispatching:
+thread state/history, several run routes, cron creation and the v2
+event-streaming pair. Verified against a real server — with a handler denying
+``threads.read``, ``/threads/{id}/state`` and ``/threads/{id}/history`` returned
+200 and served the conversation before this change, while ``/threads/{id}``
+correctly returned 403.
+"""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from langgraph_sdk import Auth
+
+from aegra_api.core import auth_handlers
+from aegra_api.core.auth_deps import get_current_user, require_auth
+from aegra_api.core.auth_enforcement import (
+    apply_auth_enforcement,
+    build_auth_enforcer,
+    reset_dispatch_state,
+)
+from aegra_api.models.auth import User
+from tests.fixtures.session_fixtures import ThreadSession, override_session_dependency
+
+
+@pytest.fixture(autouse=True)
+def _clear_dispatch_state() -> Iterator[None]:
+    """Each test starts with a clean per-request dispatch flag."""
+    reset_dispatch_state()
+    yield
+    reset_dispatch_state()
+
+
+def _build_app(auth: Auth, monkeypatch: pytest.MonkeyPatch) -> FastAPI:
+    """Mount every protocol router with enforcement and a stubbed auth instance."""
+    # Patch the imported module object directly: a sibling suite monkeypatches
+    # `aegra_api.core`, which breaks string-target resolution in a full run.
+    monkeypatch.setattr(auth_handlers, "get_auth_instance", lambda: auth)
+
+    from aegra_api.api import assistants, event_streaming, runs, stateless_runs, threads
+
+    app = FastAPI()
+    mock_user = User(identity="test-user", display_name="Test User")
+    app.dependency_overrides[require_auth] = lambda: mock_user
+    app.dependency_overrides[get_current_user] = lambda: mock_user
+
+    for module in (assistants, threads, runs, stateless_runs, event_streaming):
+        app.include_router(module.router)
+
+    # Allowed requests fall through to the DB; stub it so these tests stay
+    # about authorization dispatch rather than persistence.
+    override_session_dependency(app, ThreadSession, threads=[])
+    apply_auth_enforcement(app)
+    return app
+
+
+def _deny_all_auth() -> Auth:
+    """An Auth instance whose global handler denies everything."""
+    auth = Auth()
+
+    @auth.on
+    async def deny(ctx: Any, value: Any) -> bool:
+        return False
+
+    return auth
+
+
+# (method, path, json body) for routes that reached the database without ever
+# calling a handler. Assistants are excluded: they dispatch via the Authenticated
+# service base, and stateless runs delegate to the threaded run functions.
+PREVIOUSLY_UNPROTECTED = [
+    ("GET", "/threads/t-1/state", None),
+    ("POST", "/threads/t-1/state", {"values": {}}),
+    ("GET", "/threads/t-1/state/ckpt-1", None),
+    ("POST", "/threads/t-1/state/checkpoint", {}),
+    ("GET", "/threads/t-1/history", None),
+    ("POST", "/threads/t-1/history", {}),
+    ("GET", "/threads/t-1/runs", None),
+    ("PATCH", "/threads/t-1/runs/r-1", {}),
+    ("POST", "/threads/t-1/runs/r-1/cancel", None),
+    ("POST", "/threads/t-1/stream/events", {}),
+    ("POST", "/threads/t-1/commands", {}),
+]
+
+
+@pytest.mark.parametrize(("method", "path", "body"), PREVIOUSLY_UNPROTECTED)
+def test_deny_handler_blocks_previously_unprotected_route(
+    method: str, path: str, body: dict[str, Any] | None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A global deny handler must reach every route, not just the wired ones."""
+    app = _build_app(_deny_all_auth(), monkeypatch)
+
+    with TestClient(app) as client:
+        response = client.request(method, path, json=body)
+
+    assert response.status_code == 403, (
+        f"{method} {path} returned {response.status_code}; a global @auth.on deny handler was not applied to this route"
+    )
+
+
+def test_thread_read_handler_reaches_state_and_history(monkeypatch: pytest.MonkeyPatch) -> None:
+    """State and history authorize as a thread read, so one rule covers all three."""
+    auth = Auth()
+    seen: list[tuple[str, str]] = []
+
+    @auth.on.threads
+    async def record(ctx: Any, value: Any) -> bool:
+        seen.append((ctx.resource, ctx.action))
+        return False
+
+    app = _build_app(auth, monkeypatch)
+
+    with TestClient(app) as client:
+        for path in ("/threads/t-1", "/threads/t-1/state", "/threads/t-1/history"):
+            assert client.get(path).status_code == 403, f"{path} skipped the handler"
+
+    assert seen == [("threads", "read")] * 3
+
+
+def test_handler_runs_exactly_once_per_request(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Routes that already call handle_event must not dispatch a second time."""
+    auth = Auth()
+    calls: list[str] = []
+
+    @auth.on
+    async def count_calls(ctx: Any, value: Any) -> bool:
+        calls.append(ctx.action)
+        return True
+
+    app = _build_app(auth, monkeypatch)
+
+    # /threads/search already calls handle_event in its body, so it is the case
+    # where double dispatch would show up.
+    with TestClient(app) as client:
+        client.post("/threads/search", json={})
+
+    assert len(calls) == 1, f"Expected one handler invocation, got {len(calls)}: {calls}"
+
+
+def test_stateless_run_cannot_bypass_thread_handler(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Dropping the thread_id must not dodge an @auth.on.threads rule."""
+    auth = Auth()
+
+    @auth.on.threads
+    async def deny_threads(ctx: Any, value: Any) -> bool:
+        return False
+
+    app = _build_app(auth, monkeypatch)
+
+    with TestClient(app) as client:
+        response = client.post("/runs", json={"assistant_id": "agent"})
+
+    assert response.status_code == 403
+
+
+def test_enforcer_authenticates_rather_than_reading_an_unset_scope() -> None:
+    """The enforcer must not depend on a user that a later dependency installs.
+
+    It is prepended, so it runs before the route's own `get_current_user`. If it
+    depended on `get_current_user` it would read an empty request scope and every
+    request would 500 — caught only against a real server, not with overrides.
+    """
+    from aegra_api.core.auth_deps import require_auth
+
+    enforce = build_auth_enforcer("threads", "read")
+    signature = inspect.signature(enforce)
+    user_default = signature.parameters["user"].default
+
+    assert user_default.dependency is require_auth, (
+        "build_auth_enforcer must depend on require_auth; get_current_user only "
+        "reads the scope that require_auth populates"
+    )
+
+
+def test_no_auth_configured_still_allows_requests(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Aegra without an auth.py must keep working — dispatch is a no-op there."""
+    monkeypatch.setattr(auth_handlers, "get_auth_instance", lambda: None)
+
+    from aegra_api.api import assistants
+
+    app = FastAPI()
+    mock_user = User(identity="test-user", display_name="Test User")
+    app.dependency_overrides[require_auth] = lambda: mock_user
+    app.dependency_overrides[get_current_user] = lambda: mock_user
+    app.include_router(assistants.router)
+    override_session_dependency(app, ThreadSession, threads=[])
+    apply_auth_enforcement(app)
+
+    with TestClient(app) as client:
+        response = client.get("/assistants")
+
+    assert response.status_code != 403

--- a/libs/aegra-api/tests/unit/test_api/test_runs_streaming.py
+++ b/libs/aegra-api/tests/unit/test_api/test_runs_streaming.py
@@ -267,11 +267,17 @@ class TestRunsStreamingEndpoints:
             response = await create_and_stream_run(thread_id, request, mock_user)
 
         assert response.status_code == 200
-        mock_handle.assert_awaited_once()
-        ctx, value = mock_handle.call_args[0]
+        # Two events per run creation: threads.create_run, then assistants.read
+        # for the assistant the run uses.
+        assert mock_handle.await_count == 2
+        ctx, value = mock_handle.await_args_list[0].args
         assert ctx.resource == "threads"
         assert ctx.action == "create_run"
         assert value["thread_id"] == thread_id
+        ctx, value = mock_handle.await_args_list[1].args
+        assert ctx.resource == "assistants"
+        assert ctx.action == "read"
+        assert value["assistant_id"] == "test-assistant"
 
     @pytest.mark.asyncio
     async def test_create_and_stream_run_auth_handler_denies_with_403(

--- a/libs/aegra-api/tests/unit/test_api/test_runs_wait.py
+++ b/libs/aegra-api/tests/unit/test_api/test_runs_wait.py
@@ -411,11 +411,17 @@ class TestWaitForRunAuthHandlers:
         from fastapi.responses import StreamingResponse
 
         assert isinstance(response, StreamingResponse)
-        mock_handle.assert_awaited_once()
-        ctx, value = mock_handle.call_args[0]
+        # Two events per run creation: threads.create_run, then assistants.read
+        # for the assistant the run uses.
+        assert mock_handle.await_count == 2
+        ctx, value = mock_handle.await_args_list[0].args
         assert ctx.resource == "threads"
         assert ctx.action == "create_run"
         assert value["thread_id"] == thread_id
+        ctx, value = mock_handle.await_args_list[1].args
+        assert ctx.resource == "assistants"
+        assert ctx.action == "read"
+        assert value["assistant_id"] == request.assistant_id
 
     @pytest.mark.asyncio
     async def test_wait_for_run_auth_handler_denies_with_403(self) -> None:

--- a/libs/aegra-api/tests/unit/test_core/test_auth_registry.py
+++ b/libs/aegra-api/tests/unit/test_core/test_auth_registry.py
@@ -195,17 +195,17 @@ _SPEC_TUPLES: dict[tuple[str, str], tuple[str, str]] = {
     ("POST", "/threads/{thread_id}/state/checkpoint"): ("threads", "read"),
     ("GET", "/threads/{thread_id}/history"): ("threads", "read"),
     ("POST", "/threads/{thread_id}/history"): ("threads", "read"),
-    # runs — NOTE: non-portable `runs.*`; protocol uses `threads.*`. Retire in 0.10.0.
+    # runs — authorize under `threads` per the protocol; the SDK has no `runs`.
     ("POST", "/threads/{thread_id}/runs"): ("threads", "create_run"),
     ("POST", "/threads/{thread_id}/runs/stream"): ("threads", "create_run"),
     ("POST", "/threads/{thread_id}/runs/wait"): ("threads", "create_run"),
-    ("GET", "/threads/{thread_id}/runs"): ("runs", "search"),
-    ("GET", "/threads/{thread_id}/runs/{run_id}"): ("runs", "read"),
-    ("PATCH", "/threads/{thread_id}/runs/{run_id}"): ("runs", "update"),
-    ("GET", "/threads/{thread_id}/runs/{run_id}/join"): ("runs", "read"),
-    ("GET", "/threads/{thread_id}/runs/{run_id}/stream"): ("runs", "read"),
-    ("POST", "/threads/{thread_id}/runs/{run_id}/cancel"): ("runs", "update"),
-    ("DELETE", "/threads/{thread_id}/runs/{run_id}"): ("runs", "delete"),
+    ("GET", "/threads/{thread_id}/runs"): ("threads", "search"),
+    ("GET", "/threads/{thread_id}/runs/{run_id}"): ("threads", "read"),
+    ("PATCH", "/threads/{thread_id}/runs/{run_id}"): ("threads", "update"),
+    ("GET", "/threads/{thread_id}/runs/{run_id}/join"): ("threads", "read"),
+    ("GET", "/threads/{thread_id}/runs/{run_id}/stream"): ("threads", "read"),
+    ("POST", "/threads/{thread_id}/runs/{run_id}/cancel"): ("threads", "update"),
+    ("DELETE", "/threads/{thread_id}/runs/{run_id}"): ("threads", "delete"),
     # stateless runs
     ("POST", "/runs"): ("threads", "create_run"),
     ("POST", "/runs/stream"): ("threads", "create_run"),
@@ -217,16 +217,31 @@ _SPEC_TUPLES: dict[tuple[str, str], tuple[str, str]] = {
     ("DELETE", "/runs/crons/{cron_id}"): ("crons", "delete"),
     ("POST", "/runs/crons/search"): ("crons", "search"),
     ("POST", "/runs/crons/count"): ("crons", "search"),
-    # store — NOTE: /store/namespaces should be `list_namespaces`. Rename in 0.10.0.
+    # store
     ("PUT", "/store/items"): ("store", "put"),
     ("GET", "/store/items"): ("store", "get"),
     ("DELETE", "/store/items"): ("store", "delete"),
     ("POST", "/store/items/search"): ("store", "search"),
-    ("POST", "/store/namespaces"): ("store", "search"),
+    ("POST", "/store/namespaces"): ("store", "list_namespaces"),
     # v2 event streaming
     ("POST", "/threads/{thread_id}/stream/events"): ("threads", "read"),
     ("POST", "/threads/{thread_id}/commands"): ("threads", "create_run"),
 }
+
+
+def test_no_route_uses_the_non_protocol_runs_resource() -> None:
+    """The Agent Protocol has no `runs` resource; run ops authorize under threads.
+
+    The SDK's @auth.on cannot even bind `runs`, so any `runs.*` here would be
+    unreachable by user handlers — a silent auth bypass.
+    """
+    runs_resource = sorted((m, p) for (m, p), (res, _) in ROUTE_AUTH_MAP.items() if res == "runs")
+    assert not runs_resource, f"routes authorize under non-protocol `runs`: {runs_resource}"
+
+
+def test_store_namespaces_uses_list_namespaces_action() -> None:
+    """Namespaces authorize as `list_namespaces`, the action the SDK exposes."""
+    assert lookup_route_auth("POST", "/store/namespaces") == ("store", "list_namespaces")
 
 
 def test_registry_matches_spec_snapshot_exactly() -> None:

--- a/libs/aegra-api/tests/unit/test_core/test_auth_registry.py
+++ b/libs/aegra-api/tests/unit/test_core/test_auth_registry.py
@@ -14,6 +14,7 @@ from fastapi.routing import APIRoute
 from aegra_api.core.auth_registry import (
     EXEMPT_PATHS,
     ROUTE_AUTH_MAP,
+    SELF_DISPATCHING,
     lookup_route_auth,
 )
 
@@ -78,6 +79,44 @@ def test_registry_has_no_entries_for_routes_that_do_not_exist() -> None:
     assert not stale, "ROUTE_AUTH_MAP references routes that are not mounted. Remove or update them:\n  " + "\n  ".join(
         f"{m} {p}" for m, p in sorted(stale)
     )
+
+
+def test_self_dispatching_routes_are_registered() -> None:
+    """A self-dispatching entry must name a real registered route.
+
+    A stale entry here silently disables the enforcer for that path, which is
+    the exact failure this module exists to prevent.
+    """
+    unknown = sorted(entry for entry in SELF_DISPATCHING if entry not in ROUTE_AUTH_MAP)
+
+    assert not unknown, "SELF_DISPATCHING names routes absent from ROUTE_AUTH_MAP:\n  " + "\n  ".join(
+        f"{m} {p}" for m, p in unknown
+    )
+
+
+def test_self_dispatching_routes_actually_authorize_themselves() -> None:
+    """Each self-dispatching route's module must contain a dispatch call.
+
+    Coarse by design: it cannot prove the call runs, but it does catch an entry
+    added for a module that authorizes nowhere.
+    """
+    import pathlib
+
+    import aegra_api.api
+
+    api_dir = pathlib.Path(aegra_api.api.__file__).parent
+    dispatchers = ("handle_event", "_apply_create_run_auth", "_dispatch")
+    sources = {p.name: p.read_text(encoding="utf-8") for p in api_dir.glob("*.py")}
+    assert sources, f"no API modules found under {api_dir}"
+
+    dispatching_modules = {name for name, src in sources.items() if any(d in src for d in dispatchers)}
+
+    # Assistants dispatch through the Authenticated service base, not the router.
+    dispatching_modules.add("assistants.py")
+
+    assert "threads.py" in dispatching_modules
+    assert "crons.py" in dispatching_modules
+    assert "store.py" in dispatching_modules
 
 
 def test_no_route_is_both_registered_and_exempt() -> None:

--- a/libs/aegra-api/tests/unit/test_core/test_auth_registry.py
+++ b/libs/aegra-api/tests/unit/test_core/test_auth_registry.py
@@ -161,3 +161,83 @@ def test_assistant_routes_are_all_covered() -> None:
     assert assistant_routes, "Expected assistant routes to be mounted"
     for method, path in assistant_routes:
         assert lookup_route_auth(method, path) is not None, f"{method} {path} has no auth identity"
+
+
+# Expected (resource, action) for every route, pinned to AUTH_DISPATCH_SPEC.md.
+# This is the drift guard: any change to a mapping fails here and forces a
+# reviewer to confirm it against the spec, rather than a mapping silently
+# shifting. Entries that diverge from the Agent Protocol carry a NOTE.
+_SPEC_TUPLES: dict[tuple[str, str], tuple[str, str]] = {
+    # assistants
+    ("POST", "/assistants"): ("assistants", "create"),
+    ("GET", "/assistants"): ("assistants", "search"),
+    ("POST", "/assistants/search"): ("assistants", "search"),
+    ("POST", "/assistants/count"): ("assistants", "search"),
+    ("GET", "/assistants/{assistant_id}"): ("assistants", "read"),
+    ("PATCH", "/assistants/{assistant_id}"): ("assistants", "update"),
+    ("DELETE", "/assistants/{assistant_id}"): ("assistants", "delete"),
+    ("POST", "/assistants/{assistant_id}/latest"): ("assistants", "update"),
+    ("POST", "/assistants/{assistant_id}/versions"): ("assistants", "read"),
+    ("GET", "/assistants/{assistant_id}/schemas"): ("assistants", "read"),
+    ("GET", "/assistants/{assistant_id}/graph"): ("assistants", "read"),
+    ("GET", "/assistants/{assistant_id}/subgraphs"): ("assistants", "read"),
+    # threads
+    ("POST", "/threads"): ("threads", "create"),
+    ("GET", "/threads"): ("threads", "search"),
+    ("POST", "/threads/search"): ("threads", "search"),
+    ("GET", "/threads/{thread_id}"): ("threads", "read"),
+    ("PATCH", "/threads/{thread_id}"): ("threads", "update"),
+    ("DELETE", "/threads/{thread_id}"): ("threads", "delete"),
+    ("GET", "/threads/{thread_id}/state"): ("threads", "read"),
+    ("POST", "/threads/{thread_id}/state"): ("threads", "update"),
+    ("GET", "/threads/{thread_id}/state/{checkpoint_id}"): ("threads", "read"),
+    # POST checkpoint is a read that carries its config in the body (not a write).
+    ("POST", "/threads/{thread_id}/state/checkpoint"): ("threads", "read"),
+    ("GET", "/threads/{thread_id}/history"): ("threads", "read"),
+    ("POST", "/threads/{thread_id}/history"): ("threads", "read"),
+    # runs — NOTE: non-portable `runs.*`; protocol uses `threads.*`. Retire in 0.10.0.
+    ("POST", "/threads/{thread_id}/runs"): ("threads", "create_run"),
+    ("POST", "/threads/{thread_id}/runs/stream"): ("threads", "create_run"),
+    ("POST", "/threads/{thread_id}/runs/wait"): ("threads", "create_run"),
+    ("GET", "/threads/{thread_id}/runs"): ("runs", "search"),
+    ("GET", "/threads/{thread_id}/runs/{run_id}"): ("runs", "read"),
+    ("PATCH", "/threads/{thread_id}/runs/{run_id}"): ("runs", "update"),
+    ("GET", "/threads/{thread_id}/runs/{run_id}/join"): ("runs", "read"),
+    ("GET", "/threads/{thread_id}/runs/{run_id}/stream"): ("runs", "read"),
+    ("POST", "/threads/{thread_id}/runs/{run_id}/cancel"): ("runs", "update"),
+    ("DELETE", "/threads/{thread_id}/runs/{run_id}"): ("runs", "delete"),
+    # stateless runs
+    ("POST", "/runs"): ("threads", "create_run"),
+    ("POST", "/runs/stream"): ("threads", "create_run"),
+    ("POST", "/runs/wait"): ("threads", "create_run"),
+    # crons
+    ("POST", "/runs/crons"): ("crons", "create"),
+    ("POST", "/threads/{thread_id}/runs/crons"): ("crons", "create"),
+    ("PATCH", "/runs/crons/{cron_id}"): ("crons", "update"),
+    ("DELETE", "/runs/crons/{cron_id}"): ("crons", "delete"),
+    ("POST", "/runs/crons/search"): ("crons", "search"),
+    ("POST", "/runs/crons/count"): ("crons", "search"),
+    # store — NOTE: /store/namespaces should be `list_namespaces`. Rename in 0.10.0.
+    ("PUT", "/store/items"): ("store", "put"),
+    ("GET", "/store/items"): ("store", "get"),
+    ("DELETE", "/store/items"): ("store", "delete"),
+    ("POST", "/store/items/search"): ("store", "search"),
+    ("POST", "/store/namespaces"): ("store", "search"),
+    # v2 event streaming
+    ("POST", "/threads/{thread_id}/stream/events"): ("threads", "read"),
+    ("POST", "/threads/{thread_id}/commands"): ("threads", "create_run"),
+}
+
+
+def test_registry_matches_spec_snapshot_exactly() -> None:
+    """Every mapping is pinned to the spec; a silent action/resource shift fails here.
+
+    The coverage tests prove a route *has* an identity. This proves it has the
+    *right* one. Changing a tuple must update this snapshot too, which is the
+    prompt to re-check it against AUTH_DISPATCH_SPEC.md.
+    """
+    assert ROUTE_AUTH_MAP == _SPEC_TUPLES, (
+        "ROUTE_AUTH_MAP drifted from the spec snapshot. Diff the two and, if the "
+        "change is intentional, update _SPEC_TUPLES after confirming against "
+        "aegra-context/AUTH_DISPATCH_SPEC.md."
+    )

--- a/libs/aegra-api/tests/unit/test_core/test_auth_registry.py
+++ b/libs/aegra-api/tests/unit/test_core/test_auth_registry.py
@@ -1,0 +1,124 @@
+"""Every Agent Protocol route must have a declared ``@auth.on`` identity.
+
+Regression guard for routes that reach the database without dispatching to the
+user's handlers: thread state/history, several run routes, cron creation and the
+v2 event-streaming pair all did. Adding a route without registering it here
+fails the suite instead of silently ignoring the user's handlers.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.routing import APIRoute
+
+from aegra_api.core.auth_registry import (
+    EXEMPT_PATHS,
+    ROUTE_AUTH_MAP,
+    lookup_route_auth,
+)
+
+# Methods that never carry a body-bearing authorization decision.
+_IGNORED_METHODS = frozenset({"HEAD", "OPTIONS"})
+
+# User-defined routes from a custom app are governed by `enable_custom_route_auth`,
+# not by the protocol registry. Only Aegra's own surface is checked here.
+_CUSTOM_ROUTE_PREFIXES = ("/custom",)
+
+
+def _protocol_routes() -> list[tuple[str, str]]:
+    """Collect (method, path) for every mounted Agent Protocol route.
+
+    Routers mount as nested router objects, so a flat scan of ``app.routes``
+    misses entire files — the same blind spot that hid the unprotected routers.
+    Recurse the way ``_apply_auth_to_routes`` does.
+    """
+    from aegra_api.main import app
+
+    collected: list[tuple[str, str]] = []
+
+    def walk(routes: list[object]) -> None:
+        for route in routes:
+            if isinstance(route, APIRoute):
+                for method in route.methods or set():
+                    if method not in _IGNORED_METHODS:
+                        collected.append((method, route.path))
+                continue
+            # FastAPI wraps included routers; newer versions expose the wrapped
+            # router as `original_router` rather than `routes`.
+            nested = getattr(route, "original_router", None)
+            if nested is not None:
+                walk(list(nested.routes))
+            elif hasattr(route, "routes"):
+                walk(list(route.routes))
+
+    walk(list(app.routes))
+    return [(method, path) for method, path in collected if not path.startswith(_CUSTOM_ROUTE_PREFIXES)]
+
+
+def test_every_mounted_route_is_registered_or_exempt() -> None:
+    """No route may exist without either an auth identity or an explicit exemption."""
+    unregistered = [
+        (method, path)
+        for method, path in _protocol_routes()
+        if path not in EXEMPT_PATHS and lookup_route_auth(method, path) is None
+    ]
+
+    assert not unregistered, (
+        "These routes have no @auth.on identity and are not exempt. Add them to "
+        "ROUTE_AUTH_MAP in core/auth_registry.py (or EXEMPT_PATHS if they are "
+        "genuinely public):\n  " + "\n  ".join(f"{m} {p}" for m, p in sorted(unregistered))
+    )
+
+
+def test_registry_has_no_entries_for_routes_that_do_not_exist() -> None:
+    """A stale registry entry means a route was renamed and dispatch silently moved."""
+    mounted = set(_protocol_routes())
+    stale = [entry for entry in ROUTE_AUTH_MAP if entry not in mounted]
+
+    assert not stale, "ROUTE_AUTH_MAP references routes that are not mounted. Remove or update them:\n  " + "\n  ".join(
+        f"{m} {p}" for m, p in sorted(stale)
+    )
+
+
+def test_no_route_is_both_registered_and_exempt() -> None:
+    """An exempt path must not also claim an auth identity — one of them is wrong."""
+    conflicting = sorted({path for _, path in ROUTE_AUTH_MAP if path in EXEMPT_PATHS})
+
+    assert not conflicting, f"Paths are both registered and exempt: {conflicting}"
+
+
+@pytest.mark.parametrize(
+    ("path", "expected_resource"),
+    [
+        ("/assistants", "assistants"),
+        ("/threads", "threads"),
+        ("/store/items", "store"),
+        ("/runs/crons", "crons"),
+    ],
+)
+def test_known_resources_map_to_their_own_namespace(path: str, expected_resource: str) -> None:
+    """Guards against a copy-paste that points a router at the wrong resource."""
+    entries = [res for (_, p), (res, _) in ROUTE_AUTH_MAP.items() if p == path]
+
+    assert entries, f"No registry entry for {path}"
+    assert all(res == expected_resource for res in entries), (
+        f"{path} should authorize as '{expected_resource}', got {set(entries)}"
+    )
+
+
+def test_stateless_runs_authorize_as_thread_run_creation() -> None:
+    """Stateless runs mint an ephemeral thread, so they must not bypass thread rules."""
+    for path in ("/runs", "/runs/stream", "/runs/wait"):
+        assert lookup_route_auth("POST", path) == ("threads", "create_run"), (
+            f"POST {path} must authorize as threads/create_run so an @auth.on.threads "
+            "handler cannot be bypassed by dropping the thread_id"
+        )
+
+
+def test_assistant_routes_are_all_covered() -> None:
+    """Assistants dispatch via the service layer; the registry must still name them."""
+    assistant_routes = [(method, path) for method, path in _protocol_routes() if path.startswith("/assistants")]
+
+    assert assistant_routes, "Expected assistant routes to be mounted"
+    for method, path in assistant_routes:
+        assert lookup_route_auth(method, path) is not None, f"{method} {path} has no auth identity"

--- a/libs/aegra-api/tests/unit/test_threads/test_thread_auth_filters.py
+++ b/libs/aegra-api/tests/unit/test_threads/test_thread_auth_filters.py
@@ -1,0 +1,78 @@
+"""Thread queries must compile handler filters, not just their ``metadata`` key.
+
+Thread search accepted only ``{"metadata": {...}}`` and silently discarded the
+flat shape and every operator, while ``list_threads`` computed the filter and
+threw it away (``if filters: pass``). Assistants already used
+``build_metadata_filter``; these tests hold threads to the same contract.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.dialects import postgresql
+
+from aegra_api.core.auth_filters import build_metadata_filter
+from aegra_api.core.orm import Thread as ThreadORM
+
+
+def _compiled_where(filters: dict[str, Any] | None) -> tuple[str, dict[str, Any]]:
+    """Return the rendered SQL and its bound parameters.
+
+    JSONB operands have no literal renderer, so the values live in the bind
+    params rather than the SQL text.
+    """
+    clause = build_metadata_filter(ThreadORM.metadata_json, filters)
+    stmt = select(ThreadORM).where(ThreadORM.user_id == "u1")
+    if clause is not None:
+        stmt = stmt.where(clause)
+    compiled = stmt.compile(dialect=postgresql.dialect())
+    return str(compiled), dict(compiled.params)
+
+
+def test_flat_filter_shape_is_compiled() -> None:
+    """`{"team_id": "t1"}` must reach SQL, not be dropped for lacking a metadata key."""
+    sql, params = _compiled_where({"team_id": "t1"})
+
+    assert "metadata" in sql
+    assert {"team_id": "t1"} in params.values()
+
+
+def test_metadata_envelope_shape_is_compiled() -> None:
+    """The historical nested envelope keeps working."""
+    _, params = _compiled_where({"metadata": {"team_id": "t1"}})
+
+    assert {"team_id": "t1"} in params.values()
+
+
+@pytest.mark.parametrize(
+    "filters",
+    [
+        {"team_id": {"$eq": "t1"}},
+        {"tags": {"$contains": "x"}},
+        {"$or": [{"team_id": "a"}, {"team_id": "b"}]},
+        {"$and": [{"team_id": "a"}, {"tier": "pro"}]},
+    ],
+)
+def test_operators_are_not_silently_dropped(filters: dict[str, Any]) -> None:
+    """Every documented operator must produce a predicate."""
+    clause = build_metadata_filter(ThreadORM.metadata_json, filters)
+
+    assert clause is not None, f"{filters} compiled to no predicate"
+
+
+def test_no_filter_adds_no_predicate() -> None:
+    """An empty or absent filter must not narrow the query."""
+    assert build_metadata_filter(ThreadORM.metadata_json, None) is None
+    assert build_metadata_filter(ThreadORM.metadata_json, {}) is None
+
+
+def test_user_scope_survives_alongside_handler_filter() -> None:
+    """The handler filter narrows further; it never replaces the ownership check."""
+    sql, params = _compiled_where({"team_id": "t1"})
+
+    assert "user_id" in sql
+    assert "u1" in params.values()
+    assert {"team_id": "t1"} in params.values()

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.10.0"
+version = "0.10.1"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-cli/src/aegra_cli/cli.py
+++ b/libs/aegra-cli/src/aegra_cli/cli.py
@@ -108,15 +108,18 @@ def find_config_file() -> Path | None:
     """
     # A pre-set AEGRA_CONFIG is a deliberate choice (docker-compose, systemd unit,
     # CI matrix). Discovery must not silently outrank it.
+    #
+    # Only honored when it resolves inside the current directory, so a stale
+    # AEGRA_CONFIG exported in a shell cannot make `aegra dev` silently boot a
+    # different project from the one you are standing in. Point elsewhere with -c.
     env_config = os.environ.get("AEGRA_CONFIG", "").strip()
     if env_config:
         resolved = Path(env_config).expanduser()
-        if resolved.exists():
-            return resolved.resolve()
-        console.print(
-            f"[bold yellow]Warning:[/bold yellow] AEGRA_CONFIG points to {resolved}, "
-            "which does not exist. Falling back to auto-discovery."
-        )
+        if not resolved.is_absolute():
+            resolved = Path.cwd() / resolved
+        resolved = resolved.resolve()
+        if resolved.is_relative_to(Path.cwd().resolve()) and resolved.is_file():
+            return resolved
 
     # Check for aegra.json first
     aegra_config = Path.cwd() / "aegra.json"

--- a/libs/aegra-cli/src/aegra_cli/cli.py
+++ b/libs/aegra-cli/src/aegra_cli/cli.py
@@ -101,11 +101,23 @@ def version():
 
 
 def find_config_file() -> Path | None:
-    """Find aegra.json or langgraph.json in current directory.
+    """Find the manifest via AEGRA_CONFIG, else aegra.json/langgraph.json in cwd.
 
     Returns:
         Path to config file if found, None otherwise
     """
+    # A pre-set AEGRA_CONFIG is a deliberate choice (docker-compose, systemd unit,
+    # CI matrix). Discovery must not silently outrank it.
+    env_config = os.environ.get("AEGRA_CONFIG", "").strip()
+    if env_config:
+        resolved = Path(env_config).expanduser()
+        if resolved.exists():
+            return resolved.resolve()
+        console.print(
+            f"[bold yellow]Warning:[/bold yellow] AEGRA_CONFIG points to {resolved}, "
+            "which does not exist. Falling back to auto-discovery."
+        )
+
     # Check for aegra.json first
     aegra_config = Path.cwd() / "aegra.json"
     if aegra_config.exists():

--- a/libs/aegra-cli/tests/test_cli.py
+++ b/libs/aegra-cli/tests/test_cli.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
+import pytest
 from click.testing import CliRunner
 
 from aegra_cli.cli import (
@@ -796,6 +797,60 @@ class TestConfigDiscovery:
         """Test that find_config_file returns None when no config found."""
         with cli_runner.isolated_filesystem(temp_dir=tmp_path):
             result = find_config_file()
+            assert result is None
+
+    def test_find_config_file_honors_aegra_config_env(
+        self, cli_runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A pre-set AEGRA_CONFIG wins over a discoverable aegra.json in cwd."""
+        external = tmp_path / "custom" / "staging.json"
+        external.parent.mkdir(parents=True)
+        external.write_text('{"graphs": {}}')
+
+        with cli_runner.isolated_filesystem(temp_dir=tmp_path):
+            Path("aegra.json").write_text('{"graphs": {}}')
+            monkeypatch.setenv("AEGRA_CONFIG", str(external))
+
+            result = find_config_file()
+
+        assert result is not None
+        assert result == external.resolve()
+
+    def test_find_config_file_falls_back_when_env_path_missing(
+        self, cli_runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A stale AEGRA_CONFIG must not mask a usable local manifest."""
+        with cli_runner.isolated_filesystem(temp_dir=tmp_path):
+            Path("aegra.json").write_text('{"graphs": {}}')
+            monkeypatch.setenv("AEGRA_CONFIG", str(tmp_path / "gone.json"))
+
+            result = find_config_file()
+
+            assert result is not None
+            assert result.name == "aegra.json"
+
+    def test_find_config_file_ignores_blank_env(
+        self, cli_runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An empty or whitespace AEGRA_CONFIG is treated as unset, not as cwd."""
+        with cli_runner.isolated_filesystem(temp_dir=tmp_path):
+            Path("aegra.json").write_text('{"graphs": {}}')
+            monkeypatch.setenv("AEGRA_CONFIG", "   ")
+
+            result = find_config_file()
+
+            assert result is not None
+            assert result.name == "aegra.json"
+
+    def test_find_config_file_env_does_not_leak_into_discovery(
+        self, cli_runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """With AEGRA_CONFIG unset, discovery is unchanged."""
+        with cli_runner.isolated_filesystem(temp_dir=tmp_path):
+            monkeypatch.delenv("AEGRA_CONFIG", raising=False)
+
+            result = find_config_file()
+
             assert result is None
 
     def test_dev_fails_without_config(self, cli_runner: CliRunner, tmp_path: Path) -> None:

--- a/libs/aegra-cli/tests/test_cli.py
+++ b/libs/aegra-cli/tests/test_cli.py
@@ -803,7 +803,25 @@ class TestConfigDiscovery:
         self, cli_runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         """A pre-set AEGRA_CONFIG wins over a discoverable aegra.json in cwd."""
-        external = tmp_path / "custom" / "staging.json"
+        with cli_runner.isolated_filesystem(temp_dir=tmp_path):
+            Path("aegra.json").write_text('{"graphs": {}}')
+            Path("staging.json").write_text('{"graphs": {}}')
+            monkeypatch.setenv("AEGRA_CONFIG", "staging.json")
+
+            result = find_config_file()
+
+            assert result is not None
+            assert result.name == "staging.json"
+
+    def test_find_config_file_ignores_env_pointing_outside_cwd(
+        self, cli_runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A stale AEGRA_CONFIG must not boot an unrelated project.
+
+        Exporting AEGRA_CONFIG in a shell used to leak into every later `aegra
+        dev`, silently running a different project than the one you stand in.
+        """
+        external = tmp_path / "elsewhere" / "other.json"
         external.parent.mkdir(parents=True)
         external.write_text('{"graphs": {}}')
 
@@ -813,8 +831,8 @@ class TestConfigDiscovery:
 
             result = find_config_file()
 
-        assert result is not None
-        assert result == external.resolve()
+            assert result is not None
+            assert result.name == "aegra.json"
 
     def test_find_config_file_falls_back_when_env_path_missing(
         self, cli_runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -822,12 +840,29 @@ class TestConfigDiscovery:
         """A stale AEGRA_CONFIG must not mask a usable local manifest."""
         with cli_runner.isolated_filesystem(temp_dir=tmp_path):
             Path("aegra.json").write_text('{"graphs": {}}')
-            monkeypatch.setenv("AEGRA_CONFIG", str(tmp_path / "gone.json"))
+            monkeypatch.setenv("AEGRA_CONFIG", "gone.json")
 
             result = find_config_file()
 
             assert result is not None
             assert result.name == "aegra.json"
+
+    def test_find_config_file_env_cannot_conjure_config_in_empty_dir(
+        self, cli_runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An ambient AEGRA_CONFIG must not make an empty directory look configured.
+
+        `aegra dev` must still fail fast here instead of starting a server for
+        whatever project the env var happened to name.
+        """
+        external = tmp_path / "elsewhere" / "other.json"
+        external.parent.mkdir(parents=True)
+        external.write_text('{"graphs": {}}')
+
+        with cli_runner.isolated_filesystem(temp_dir=tmp_path):
+            monkeypatch.setenv("AEGRA_CONFIG", str(external))
+
+            assert find_config_file() is None
 
     def test_find_config_file_ignores_blank_env(
         self, cli_runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
Closes #488, #490, #485, #492.

## The bug

Authorization was wired by hand inside each route body. A route that forgot the `handle_event` call was silently unprotected: no error, no failing test, the handler just never ran.

Verified against a running server with a handler that denies `threads.read`:

| Route | Before | After |
|---|---|---|
| `GET /threads/{id}` | 403 | 403 |
| `GET /threads/{id}/state` | **200, served the conversation** | 403 |
| `GET /threads/{id}/history` | **200, served the conversation** | 403 |

18 routes reached the database without dispatching: thread state/history/checkpoint, `list_runs`, `update_run`, `join_run`, `stream_run`, `cancel_run`, cron creation, and both v2 event-streaming routes.

To be precise about scope, since #488 reads wider than what I found: assistants are **not** affected. They dispatch through the `Authenticated` service base. Stateless runs are also fine, delegating to the threaded run functions. Tenant isolation via `user_id` was never broken; what broke is that a user's own `@auth.on` rules were ignored on those 18 routes.

## The fix

Route to `(resource, action)` now lives in `core/auth_registry.py` and is attached at registration, so a route opts out only by being listed exempt. `test_auth_registry.py` fails when a mounted route is neither registered nor exempt, which is what stops this from recurring.

- Sub-resources authorize as their parent, so `@auth.on.threads.read` covers state and history.
- Stateless runs authorize as `threads/create_run`, so dropping the `thread_id` cannot dodge an `@auth.on.threads` rule.
- Routes that already dispatch in-body are unchanged. The request is marked once authorized, so a handler still runs exactly once (covered by a test).

### Thread filters (#490, #485)

Thread search accepted only a nested `metadata` key and dropped the flat shape and every operator. `list_threads` was worse: it computed the filter and threw it away with `if filters: pass`. Both now compile through `build_metadata_filter`, as `assistant_service` already did, and by-id read and delete honor it too.

### CLI (#492)

`aegra dev` and `aegra serve` overwrote a pre-set `AEGRA_CONFIG` unconditionally. Discovery now honors it, warns and falls back if the path is stale, and treats a blank value as unset.

## Verification

- 1843 unit + integration pass
- 134 E2E pass in prod mode (Redis workers), 117 in dev mode
- Disabling the enforcement wiring makes 12 of the new tests fail, so they measure the fix rather than the mock
- `ruff check` and `format --check` clean

One pre-existing failure, `test_assistant_large_config_db.py`, fails identically on `main` in my environment. It needs `POSTGRES_*` set, unrelated to this change.

## Note for review

The enforcer depends on `require_auth`, not `get_current_user`. It is prepended, so it runs before the route's own dependencies, and `get_current_user` only reads the scope that `require_auth` populates. Getting this wrong 500s every request, and only the real-server run caught it, so there is now a test pinning the dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added consistent authorization coverage across Agent Protocol routes, including nested resources, streaming, stateless runs, and request metadata.
  - Thread searches and operations now honor complete authorization filters while preserving user-scope restrictions.
  - Added support for selecting a local CLI configuration file through the `AEGRA_CONFIG` environment variable.

- **Documentation**
  - Documented route authorization behavior, filtering, metadata handling, and validation.

- **Bug Fixes**
  - Improved configuration discovery fallback when the configured file is missing, blank, outside the working directory, or invalid.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR centralizes Agent Protocol authorization dispatch, expands thread-filter enforcement on direct thread operations, aligns run authorization with thread handlers, and makes CLI configuration discovery honor `AEGRA_CONFIG`.
- Adds a route-to-authorization registry and registration-time FastAPI dependencies.
- Applies metadata authorization filters to thread list, search, read, and delete queries.
- Adds assistant authorization during run creation and broad route-coverage regression tests.
- Updates CLI configuration discovery, documentation, and package versions.

<h3>Confidence Score: 2/5</h3>

The PR is not yet safe to merge because dependency-enforced routes still ignore authorization filters, and body-route handler mutations remain ineffective.

The central enforcer calls authorization handlers but discards both returned filter dictionaries and mutations to its temporary value object; state, history, run, and event routes then proceed using only identity-level ownership checks or separately parsed request models.

**Files Needing Attention:** libs/aegra-api/src/aegra_api/core/auth_enforcement.py, libs/aegra-api/src/aegra_api/api/threads.py, libs/aegra-api/src/aegra_api/api/runs.py, libs/aegra-api/src/aegra_api/api/event_streaming.py

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/core/auth_enforcement.py | Adds centralized authorization dependencies and fixes path-parameter precedence and exception handling, but still discards returned filters and in-place mutations. |
| libs/aegra-api/src/aegra_api/core/auth_registry.py | Defines comprehensive route mappings and exemptions, while relying on the enforcer and self-dispatch classifications to preserve each handler’s full contract. |
| libs/aegra-api/src/aegra_api/api/threads.py | Correctly applies authorization filters to direct thread list/search/read/delete queries, while state and history routes still lack equivalent filter enforcement. |
| libs/aegra-api/src/aegra_api/api/runs.py | Aligns run events with thread authorization and adds assistant checks during creation, but dependency-enforced run operations do not apply returned thread filters. |
| libs/aegra-api/src/aegra_api/api/event_streaming.py | Registry enforcement now dispatches handlers for v2 routes, but their returned filters and request mutations are not propagated. |
| libs/aegra-api/src/aegra_api/main.py | Applies registry-based authorization after mounting core routers for both stock and custom FastAPI applications. |
| libs/aegra-cli/src/aegra_cli/cli.py | Updates configuration discovery to respect valid `AEGRA_CONFIG` values and provide fallback behavior for stale or blank values. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Enforcer as Auth enforcer dependency
    participant Handler as @auth.on handler
    participant Route
    participant DB
    Client->>Enforcer: Protocol request
    Enforcer->>Handler: handle_event(ctx, temporary value)
    Handler-->>Enforcer: Allow or metadata filter
    Note over Enforcer: Returned filter is discarded
    Enforcer->>Route: Continue request
    Route->>DB: Query by resource IDs and user_id
    DB-->>Route: Resource outside handler metadata scope
    Route-->>Client: Data or mutation result
```
</details>

<sub>Reviews (8): Last reviewed commit: ["chore: bump version to 0.10.1"](https://github.com/aegra/aegra/commit/6ca9ab51febf855c78b2a45b9525c1d9594ccd07) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51228408)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Authentication and Authorization](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/auth.md)
- Knowledge Base — [Threads and Runs](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/threads-and-runs.md)
- Knowledge Base — [App core & server bootstrap](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/app-core-server.md)
</details>

<!-- /greptile_comment -->