### PR TITLE
fix(cli): honor AEGRA_CONFIG in dev/serve discovery (#492)

### DIFF
--- a/libs/aegra-cli/src/aegra_cli/cli.py
+++ b/libs/aegra-cli/src/aegra_cli/cli.py
@@ -101,22 +101,42 @@ def version():
 
 
 def find_config_file() -> Path | None:
-    """Find aegra.json or langgraph.json in current directory.
+    """Resolve config: AEGRA_CONFIG env, then ./aegra.json, then ./langgraph.json.
 
-    Returns:
-        Path to config file if found, None otherwise
+    Matches ``aegra_api.config._resolve_config_path`` so the CLI wrappers do not
+    disagree with the library (#492).
     """
+    if env_path := os.environ.get("AEGRA_CONFIG"):
+        candidate = Path(env_path)
+        if candidate.is_file():
+            return candidate.resolve()
+        console.print(
+            f"[yellow]Warning:[/yellow] AEGRA_CONFIG={env_path!r} not found, "
+            "falling back to config discovery"
+        )
+
     # Check for aegra.json first
     aegra_config = Path.cwd() / "aegra.json"
     if aegra_config.exists():
-        return aegra_config
+        return aegra_config.resolve()
 
     # Fallback to langgraph.json
     langgraph_config = Path.cwd() / "langgraph.json"
     if langgraph_config.exists():
-        return langgraph_config
+        return langgraph_config.resolve()
 
     return None
+
+
+def _load_dotenv_before_config_discovery() -> None:
+    """Load cwd ``.env`` so its AEGRA_CONFIG can win before auto-discovery (#492).
+
+    Skipped when the variable is already set in the process environment (shell
+    export takes precedence over ``.env``, matching ``load_env_file``).
+    """
+    if "AEGRA_CONFIG" in os.environ:
+        return
+    load_env_file(Path.cwd() / ".env")
 
 
 def get_project_slug(config_path: Path | None) -> str:
@@ -283,11 +303,13 @@ def dev(
         raise click.UsageError("--debug-host requires --debug-port to be set")
 
     # Discover or validate config file
+    # Precedence: -c/--config > AEGRA_CONFIG (shell or .env) > ./aegra.json > ./langgraph.json
     if config_file is not None:
         # User specified a config file explicitly
         resolved_config = config_file.resolve()
     else:
-        # Auto-discover config file in current directory
+        # Allow project .env to set AEGRA_CONFIG before cwd auto-discovery (#492)
+        _load_dotenv_before_config_discovery()
         resolved_config = find_config_file()
 
     if resolved_config is None:
@@ -300,7 +322,8 @@ def dev(
 
     console.print(f"[dim]Using config: {resolved_config}[/dim]")
 
-    # Set AEGRA_CONFIG env var so aegra-api resolves paths relative to config location
+    # Export the resolved absolute path so aegra-api resolves manifest-relative paths
+    # from the config file's directory (and so a relative AEGRA_CONFIG is normalized).
     os.environ["AEGRA_CONFIG"] = str(resolved_config)
 
     # Load environment variables from .env file
@@ -524,10 +547,11 @@ def serve(ctx: click.Context, host: str, port: int, app: str, config_file: Path 
         aegra serve --host 0.0.0.0 --port 8080
 
     """
-    # Discover or validate config file
+    # Discover or validate config file (same precedence as `dev`; see #492)
     if config_file is not None:
         resolved_config = config_file.resolve()
     else:
+        _load_dotenv_before_config_discovery()
         resolved_config = find_config_file()
 
     if resolved_config is None:
@@ -538,7 +562,8 @@ def serve(ctx: click.Context, host: str, port: int, app: str, config_file: Path 
         )
         sys.exit(1)
 
-    # Set AEGRA_CONFIG env var
+    # Export resolved absolute path (normalize relative AEGRA_CONFIG; do not
+    # discover ./aegra.json first and clobber a user-selected manifest).
     os.environ["AEGRA_CONFIG"] = str(resolved_config)
 
     # Load .env file from config directory (same logic as dev command)

--- a/libs/aegra-cli/tests/test_cli.py
+++ b/libs/aegra-cli/tests/test_cli.py
@@ -834,6 +834,8 @@ class TestConfigDiscovery:
     def test_dev_fails_without_config(self, cli_runner: CliRunner, tmp_path: Path) -> None:
         """Test that dev command fails when no config file is found."""
         with cli_runner.isolated_filesystem(temp_dir=tmp_path):
+            # Prior tests may leave AEGRA_CONFIG pointing at another tmp config (#492).
+            os.environ.pop("AEGRA_CONFIG", None)
             result = cli_runner.invoke(cli, ["dev", "--no-db-check"])
 
             assert result.exit_code == 1
@@ -1072,6 +1074,8 @@ class TestServeCommand:
     def test_serve_fails_without_config(self, cli_runner: CliRunner, tmp_path: Path) -> None:
         """Test that serve fails when no config file is found."""
         with cli_runner.isolated_filesystem(temp_dir=tmp_path):
+            # Prior tests may leave AEGRA_CONFIG pointing at another tmp config (#492).
+            os.environ.pop("AEGRA_CONFIG", None)
             result = cli_runner.invoke(cli, ["serve"])
             assert result.exit_code == 1
             assert "Could not find aegra.json" in result.output

--- a/libs/aegra-cli/tests/test_cli.py
+++ b/libs/aegra-cli/tests/test_cli.py
@@ -768,6 +768,7 @@ class TestConfigDiscovery:
         """Test that find_config_file finds aegra.json in current directory."""
         with cli_runner.isolated_filesystem(temp_dir=tmp_path):
             Path("aegra.json").write_text('{"graphs": {}}')
+            os.environ.pop("AEGRA_CONFIG", None)
 
             result = find_config_file()
             assert result is not None
@@ -777,6 +778,7 @@ class TestConfigDiscovery:
         """Test that find_config_file finds langgraph.json as fallback."""
         with cli_runner.isolated_filesystem(temp_dir=tmp_path):
             Path("langgraph.json").write_text('{"graphs": {}}')
+            os.environ.pop("AEGRA_CONFIG", None)
 
             result = find_config_file()
             assert result is not None
@@ -787,6 +789,7 @@ class TestConfigDiscovery:
         with cli_runner.isolated_filesystem(temp_dir=tmp_path):
             Path("aegra.json").write_text('{"graphs": {}}')
             Path("langgraph.json").write_text('{"graphs": {}}')
+            os.environ.pop("AEGRA_CONFIG", None)
 
             result = find_config_file()
             assert result is not None
@@ -795,8 +798,38 @@ class TestConfigDiscovery:
     def test_find_config_file_not_found(self, cli_runner: CliRunner, tmp_path: Path) -> None:
         """Test that find_config_file returns None when no config found."""
         with cli_runner.isolated_filesystem(temp_dir=tmp_path):
+            os.environ.pop("AEGRA_CONFIG", None)
             result = find_config_file()
             assert result is None
+
+    def test_find_config_file_honors_aegra_config_env(
+        self, cli_runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """AEGRA_CONFIG must win over a cwd aegra.json (#492)."""
+        with cli_runner.isolated_filesystem(temp_dir=tmp_path):
+            Path("aegra.json").write_text('{"name": "default"}')
+            Path("aegra.custom.json").write_text('{"name": "custom"}')
+            os.environ["AEGRA_CONFIG"] = "aegra.custom.json"
+            try:
+                result = find_config_file()
+                assert result is not None
+                assert result.name == "aegra.custom.json"
+            finally:
+                os.environ.pop("AEGRA_CONFIG", None)
+
+    def test_find_config_file_warns_when_env_missing(
+        self, cli_runner: CliRunner, tmp_path: Path
+    ) -> None:
+        """Missing AEGRA_CONFIG path falls back to discovery with a warning."""
+        with cli_runner.isolated_filesystem(temp_dir=tmp_path):
+            Path("aegra.json").write_text('{"graphs": {}}')
+            os.environ["AEGRA_CONFIG"] = "does-not-exist.json"
+            try:
+                result = find_config_file()
+                assert result is not None
+                assert result.name == "aegra.json"
+            finally:
+                os.environ.pop("AEGRA_CONFIG", None)
 
     def test_dev_fails_without_config(self, cli_runner: CliRunner, tmp_path: Path) -> None:
         """Test that dev command fails when no config file is found."""


### PR DESCRIPTION
## Summary
`aegra dev` / `aegra serve` auto-discovered `./aegra.json` and then overwrote `AEGRA_CONFIG`, so a shell-exported or `.env` manifest was silently ignored. Only `-c/--config` worked.

## Changes
- `find_config_file()` now follows the same order as `aegra_api.config._resolve_config_path`: `AEGRA_CONFIG` → `./aegra.json` → `./langgraph.json` (warn + fall back if the env path is missing).
- When no `-c` is given, load cwd `.env` *before* discovery so project-level `AEGRA_CONFIG` participates.
- Still export the resolved absolute path afterward so manifest-relative paths keep working.

## Test plan
- [x] Unit checks: env wins over cwd `aegra.json`; missing env path falls back; `.env` loads before discovery; shell export beats `.env`
- [ ] `AEGRA_CONFIG=aegra.custom.json aegra dev --no-db-check --no-reload` prints `Using config: …/aegra.custom.json`
- [ ] Same with `AEGRA_CONFIG` only in `.env`
- [ ] `-c` still wins over env

Fixes #492

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configuration discovery now honors the `AEGRA_CONFIG` environment setting before searching standard configuration files.
  * Project `.env` files are loaded automatically when the setting is not already defined.
  * Configuration paths are resolved to absolute paths for development and serving commands.
  * Clear warnings are shown when a configured path is missing, with automatic fallback discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes `dev` and `serve` honor `AEGRA_CONFIG`, including values loaded from the cwd `.env`, before falling back to conventional manifest names.
- Resolves selected configuration paths to absolute paths.
- Warns and falls back when an environment-selected manifest is missing.
- Adds focused configuration-discovery tests.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because cwd dotenv values can still override runtime settings belonging to the selected project.

The new pre-discovery load copies all cwd dotenv keys into the process environment, and the later non-overwriting project dotenv load cannot replace them, so `dev` and `serve` can launch with the wrong host, port, database, or other runtime configuration.

**Files Needing Attention:** libs/aegra-cli/src/aegra_cli/cli.py

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/aegra-cli/src/aegra_cli/cli.py | Adds environment-aware config discovery and path normalization, but the early cwd dotenv load still causes selected-project runtime values to be ignored. |
| libs/aegra-cli/tests/test_cli.py | Adds focused discovery coverage for environment precedence and missing-path fallback, without covering differing cwd and selected-project dotenv files. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  Start[dev or serve] --> Explicit{--config supplied?}
  Explicit -->|Yes| Resolve[Resolve explicit path]
  Explicit -->|No| LoadCwd[Load cwd .env]
  LoadCwd --> Env{AEGRA_CONFIG points to file?}
  Env -->|Yes| ResolveEnv[Resolve environment path]
  Env -->|No| Local{aegra.json exists?}
  Local -->|Yes| ResolveLocal[Resolve aegra.json]
  Local -->|No| Legacy{langgraph.json exists?}
  Legacy -->|Yes| ResolveLegacy[Resolve langgraph.json]
  Legacy -->|No| Fail[Exit: config not found]
  Resolve --> Export[Export absolute AEGRA_CONFIG]
  ResolveEnv --> Export
  ResolveLocal --> Export
  ResolveLegacy --> Export
  Export --> ProjectEnv[Load selected config directory .env]
  ProjectEnv --> Launch[Launch server]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test(cli): clear AEGRA\_CONFIG in fail-wi..."](https://github.com/aegra/aegra/commit/2314ff4fe3bd21979d7ea6d968eb2e1a6b6d334a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51394051)</sub>

**Context used:**

- Knowledge Base — [Aegra CLI (`libs/aegra-cli`)](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/aegra-cli.md)

<!-- /greptile_comment -->