### PR TITLE
fix(api): forward context in v2 run.start

### DIFF
--- a/docs/guides/streaming.mdx
+++ b/docs/guides/streaming.mdx
@@ -282,10 +282,16 @@ curl -X POST http://localhost:8000/threads/$THREAD/commands \
   -d '{
         "id": 1,
         "method": "run.start",
-        "params": {"assistant_id": "agent", "input": {"messages": [{"role": "user", "content": "hi"}]}}
+        "params": {
+          "assistant_id": "agent",
+          "input": {"messages": [{"role": "user", "content": "hi"}]},
+          "context": {"tenant_id": "acme"}
+        }
       }'
 # → {"type": "success", "id": 1, "result": {"run_id": "..."}}
 ```
+
+`context` is forwarded to both the graph factory through `ServerRuntime[T]` and graph nodes through `Runtime[T]`.
 
 ### Streaming events
 

--- a/libs/aegra-api/src/aegra_api/services/event_streaming/commands.py
+++ b/libs/aegra-api/src/aegra_api/services/event_streaming/commands.py
@@ -121,6 +121,7 @@ async def _run_start(
         input=input_data,
         command=command,
         config=params.get("config") or {},
+        context=params.get("context") or {},
         metadata=params.get("metadata"),
         interrupt_before=params.get("interrupt_before"),
         interrupt_after=params.get("interrupt_after"),

--- a/libs/aegra-api/src/aegra_api/services/event_streaming/commands.py
+++ b/libs/aegra-api/src/aegra_api/services/event_streaming/commands.py
@@ -103,6 +103,12 @@ async def _run_start(
     if multitask is not None and multitask not in _MULTITASK_STRATEGIES:
         return build_error(command_id, "invalid_argument", f"Unknown multitaskStrategy {multitask!r}."), None
 
+    context = params.get("context")
+    if context is None:
+        context = {}
+    elif not isinstance(context, dict):
+        return build_error(command_id, "invalid_argument", "context must be an object."), None
+
     # run.start with input on an interrupted thread means "answer the pending
     # interrupt" — resume with the input instead of starting a fresh turn that
     # would discard the pending tasks.
@@ -121,7 +127,7 @@ async def _run_start(
         input=input_data,
         command=command,
         config=params.get("config") or {},
-        context=params.get("context") or {},
+        context=context,
         metadata=params.get("metadata"),
         interrupt_before=params.get("interrupt_before"),
         interrupt_after=params.get("interrupt_after"),

--- a/libs/aegra-api/tests/e2e/test_event_streaming/test_sdk_v2_e2e.py
+++ b/libs/aegra-api/tests/e2e/test_event_streaming/test_sdk_v2_e2e.py
@@ -74,6 +74,39 @@ async def test_sdk_thread_stream_run_start_and_events() -> None:
 
 @pytest.mark.e2e
 @pytest.mark.asyncio
+async def test_run_start_persists_request_context() -> None:
+    """The v2 command path preserves context in the run execution request."""
+    if not await _v2_enabled():
+        pytest.skip("FF_V2_EVENT_STREAMING is disabled on the server under test")
+
+    assistant_id = await _ensure_assistant()
+    client = get_client(url=_base_url())
+    thread = await client.threads.create()
+    thread_id = thread["thread_id"]
+
+    async with httpx.AsyncClient(base_url=_base_url(), timeout=10.0) as http:
+        response = await http.post(
+            f"/threads/{thread_id}/commands",
+            json={
+                "id": 1,
+                "method": "run.start",
+                "params": {
+                    "assistant_id": assistant_id,
+                    "input": {"messages": [{"role": "user", "content": json.dumps({"steps": 1})}]},
+                    "context": {"tenant_id": "acme"},
+                },
+            },
+        )
+
+    assert response.status_code == 200
+    run_id = response.json()["result"]["run_id"]
+    run = await client.runs.get(thread_id, run_id)
+    assert run["context"] == {"tenant_id": "acme"}
+    await client.runs.join(thread_id, run_id)
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
 async def test_sdk_receives_values_events() -> None:
     """The SDK receives values-channel events carrying the run's state."""
     if not await _v2_enabled():

--- a/libs/aegra-api/tests/integration/test_api/test_event_streaming.py
+++ b/libs/aegra-api/tests/integration/test_api/test_event_streaming.py
@@ -17,6 +17,7 @@ from aegra_api.api import event_streaming as es_module
 from aegra_api.core.auth_deps import get_current_user, require_auth
 from aegra_api.models.auth import User
 from aegra_api.models.event_streaming import EventStreamRequest
+from aegra_api.models.runs import RunCreate
 from aegra_api.services.broker import broker_manager
 from aegra_api.services.event_streaming import capabilities as caps
 from aegra_api.services.event_streaming import commands as cmd_module
@@ -82,7 +83,10 @@ def _v2_enabled(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
 
 class TestCommandRoute:
     def test_run_start_returns_success_envelope(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured_requests: list[RunCreate] = []
+
         async def fake_prepare(*_args: Any, **_kwargs: Any) -> tuple[str, object, object]:
+            captured_requests.append(_args[2])
             return "run-1", object(), object()
 
         monkeypatch.setattr(cmd_module, "_prepare_run", fake_prepare)
@@ -90,7 +94,15 @@ class TestCommandRoute:
 
         resp = client.post(
             "/threads/t1/commands",
-            json={"id": 1, "method": "run.start", "params": {"assistant_id": "agent", "input": {"messages": []}}},
+            json={
+                "id": 1,
+                "method": "run.start",
+                "params": {
+                    "assistant_id": "agent",
+                    "input": {"messages": []},
+                    "context": {"tenant_id": "acme"},
+                },
+            },
         )
         assert resp.status_code == 200
         assert resp.json() == {
@@ -99,6 +111,7 @@ class TestCommandRoute:
             "result": {"run_id": "run-1"},
             "meta": {"applied_through_seq": 0},
         }
+        assert captured_requests[0].context == {"tenant_id": "acme"}
 
     def test_unknown_command_returns_error_envelope_on_200(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Protocol errors ride HTTP 200 so envelope-parsing clients see the code."""

--- a/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_commands.py
+++ b/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_commands.py
@@ -88,6 +88,17 @@ class TestRunStart:
         assert run_id is None
         prepared_run.assert_not_called()
 
+    @pytest.mark.parametrize("context", [[], False, 0, ""])
+    async def test_run_start_rejects_non_object_context(
+        self, prepared_run: AsyncMock, user: User, context: Any
+    ) -> None:
+        resp, run_id = await _dispatch(
+            {"id": 1, "method": "run.start", "params": {"assistant_id": "agent", "context": context}}, user
+        )
+        assert resp["error"] == "invalid_argument"
+        assert run_id is None
+        prepared_run.assert_not_called()
+
     async def test_run_start_forwards_multitask_strategy(self, prepared_run: AsyncMock, user: User) -> None:
         await _dispatch(
             {

--- a/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_commands.py
+++ b/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_commands.py
@@ -45,7 +45,12 @@ class TestRunStart:
             {
                 "id": 1,
                 "method": "run.start",
-                "params": {"assistant_id": "agent", "input": {"x": 1}, "config": {"c": 2}},
+                "params": {
+                    "assistant_id": "agent",
+                    "input": {"x": 1},
+                    "config": {"c": 2},
+                    "context": {"tenant_id": "acme"},
+                },
             },
             user,
         )
@@ -53,6 +58,7 @@ class TestRunStart:
         assert request.assistant_id == "agent"
         assert request.input == {"x": 1}
         assert request.config == {"c": 2}
+        assert request.context == {"tenant_id": "acme"}
         # v2 runs are flagged for the native v3 stream path.
         assert prepared_run.call_args.kwargs["event_streaming_v2"] is True
 


### PR DESCRIPTION
## Description

Agent Protocol v2 `run.start` commands dropped the request `context` while constructing `RunCreate`. As a result, context never reached run preparation, the execution job, or graph factories using `ServerRuntime[T]`.

This forwards `params.context` through the existing run execution path and documents the supported v2 payload.

## Type of Change

- [x] `fix`: Bug fix
- [x] `docs`: Documentation changes
- [x] `test`: Tests added/updated

## Related Issues

None.

## Changes Made

- Forward v2 `run.start` context into `RunCreate`.
- Add unit, HTTP integration, and real-server E2E regression coverage.
- Document context propagation for v2 streaming commands.

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] E2E tests added/updated
- [x] Manual testing performed

Commands/results:

- `pytest libs/aegra-api/tests/unit libs/aegra-api/tests/integration`: 1801 passed, 1 skipped
- `pytest ...::test_run_start_persists_request_context`: 1 passed against a real server and PostgreSQL
- `ruff format --check .`: passed
- `ruff check .`: passed
- Targeted `ty check` for the modified production module: passed

## Checklist

- [x] Code follows project style (Ruff formatting)
- [x] All linting checks pass (`make lint`)
- [x] Relevant tests pass
- [x] Documentation updated
- [x] Commit messages follow Conventional Commits
- [x] PR title follows Conventional Commits format

## Additional Notes

The repository-wide `ty check` currently reports 56 pre-existing diagnostics in unrelated code. This change introduces no new type diagnostics; the modified production module passes targeted type checking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for passing tenant or request context when starting a run.
  * Context is preserved with the run and forwarded to the graph factory and graph nodes.
  * Invalid non-object context values are rejected with a clear error.
  * Updated the streaming API documentation with a context-enabled example.

* **Tests**
  * Added coverage confirming context is accepted, stored, and propagated successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR fixes Agent Protocol v2 `run.start` so request context is validated and forwarded through `RunCreate`, allowing it to reach persisted runs and graph runtimes.
- Validates that supplied context is an object and defaults omitted context to an empty object.
- Adds unit, HTTP integration, and real-server regression coverage.
- Documents context propagation to graph factories and graph nodes.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/services/event_streaming/commands.py | Validates v2 `run.start` context and forwards it through the existing `RunCreate` execution path without an identified blocking defect. |
| libs/aegra-api/tests/unit/test_services/test_event_streaming/test_commands.py | Adds focused coverage for context forwarding and rejection of non-object values. |
| libs/aegra-api/tests/integration/test_api/test_event_streaming.py | Verifies the HTTP command route passes request context into run preparation. |
| libs/aegra-api/tests/e2e/test_event_streaming/test_sdk_v2_e2e.py | Adds real-server coverage confirming v2 request context is persisted with the run. |
| docs/guides/streaming.mdx | Documents the context-enabled v2 payload and its propagation to graph runtimes. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Commands as v2 run.start
    participant Prep as Run Preparation
    participant DB as Run Persistence
    participant Executor
    participant Graph as Graph Factory / Nodes
    Client->>Commands: params.context
    Commands->>Commands: Validate object
    Commands->>Prep: RunCreate(context)
    Prep->>DB: Persist merged context
    Prep->>Executor: Queue execution context
    Executor->>Graph: ServerRuntime / Runtime context
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(api): validate v2 run context"](https://github.com/aegra/aegra/commit/31f8e1e135f6e8af5700e974fc7e9731d730b3fc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51544123)</sub>

**Context used:**

- Knowledge Base — [Streaming: from LangGraph execution to SSE wire events](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/streaming.md)

<!-- /greptile_comment -->