### PR TITLE
fix(api): delete checkpoint data when a thread is deleted

### DIFF
--- a/docs/guides/threads-and-state.mdx
+++ b/docs/guides/threads-and-state.mdx
@@ -146,7 +146,8 @@ for thread in threads:
 
 ## Deleting threads
 
-Deleting a thread cancels any active runs and removes all state:
+Deleting a thread cancels any active runs and removes all state, including
+the checkpoint history stored in the graph backend:
 
 ```python
 await client.threads.delete(thread_id)

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Aegra",
     "description": "Production-ready Agent Protocol server",
-    "version": "0.10.2"
+    "version": "0.10.3"
   },
   "paths": {
     "/info": {
@@ -952,7 +952,7 @@
           "Threads"
         ],
         "summary": "Delete Thread",
-        "description": "Delete a thread by its ID.\n\nPermanently removes the thread and its metadata. Any active runs on the\nthread are automatically cancelled before deletion. Checkpoint history\nstored in the graph backend is not affected.",
+        "description": "Delete a thread by its ID.\n\nPermanently removes the thread, its metadata, and its checkpoint history\nstored in the graph backend. Any active runs on the thread are\nautomatically cancelled before deletion.",
         "operationId": "delete_thread_threads__thread_id__delete",
         "parameters": [
           {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -990,6 +990,16 @@
               }
             }
           },
+          "500": {
+            "description": "Checkpoint cleanup failed; the thread is preserved and the delete can be retried",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentProtocolError"
+                }
+              }
+            }
+          },
           "422": {
             "description": "Validation Error",
             "content": {

--- a/libs/aegra-api/src/aegra_api/api/threads.py
+++ b/libs/aegra-api/src/aegra_api/api/threads.py
@@ -18,6 +18,7 @@ from aegra_api.core.active_runs import active_runs
 from aegra_api.core.auth_deps import auth_dependency, get_current_user
 from aegra_api.core.auth_filters import build_metadata_filter
 from aegra_api.core.auth_handlers import build_auth_context, handle_event
+from aegra_api.core.database import db_manager
 from aegra_api.core.orm import Run as RunORM
 from aegra_api.core.orm import Thread as ThreadORM
 from aegra_api.core.orm import get_session
@@ -829,9 +830,9 @@ async def delete_thread(
 ) -> dict[str, str]:
     """Delete a thread by its ID.
 
-    Permanently removes the thread and its metadata. Any active runs on the
-    thread are automatically cancelled before deletion. Checkpoint history
-    stored in the graph backend is not affected.
+    Permanently removes the thread, its metadata, and its checkpoint history
+    stored in the graph backend. Any active runs on the thread are
+    automatically cancelled before deletion.
     """
     # Authorization check
     ctx = build_auth_context(user, "threads", "delete")
@@ -865,6 +866,10 @@ async def delete_thread(
                 task.cancel()
                 with contextlib.suppress(asyncio.CancelledError, Exception):
                     await task
+
+    # Checkpoints first: if this fails the thread row survives and the client
+    # can retry; the reverse order would orphan LangGraph checkpoint rows.
+    await db_manager.get_checkpointer().adelete_thread(thread_id)
 
     await session.delete(thread)
     await session.commit()

--- a/libs/aegra-api/src/aegra_api/api/threads.py
+++ b/libs/aegra-api/src/aegra_api/api/threads.py
@@ -36,7 +36,7 @@ from aegra_api.models import (
     ThreadUpdate,
     User,
 )
-from aegra_api.models.errors import CONFLICT, NOT_FOUND
+from aegra_api.models.errors import CONFLICT, NOT_FOUND, AgentProtocolError
 from aegra_api.services.streaming_service import streaming_service
 from aegra_api.services.thread_state_service import ThreadStateService
 from aegra_api.utils.run_utils import strip_pinned_config_keys
@@ -822,7 +822,16 @@ async def get_thread_history_get(
     return await get_thread_history_post(thread_id, req, user, session)
 
 
-@router.delete("/threads/{thread_id}", responses={**NOT_FOUND})
+@router.delete(
+    "/threads/{thread_id}",
+    responses={
+        **NOT_FOUND,
+        500: {
+            "model": AgentProtocolError,
+            "description": "Checkpoint cleanup failed; the thread is preserved and the delete can be retried",
+        },
+    },
+)
 async def delete_thread(
     thread_id: str,
     user: User = Depends(get_current_user),

--- a/libs/aegra-api/src/aegra_api/services/run_cleanup.py
+++ b/libs/aegra-api/src/aegra_api/services/run_cleanup.py
@@ -7,11 +7,13 @@ that need cleanup after the underlying run finishes.
 import asyncio
 
 import structlog
+from psycopg import Error as PsycopgError
 from redis import RedisError
 from sqlalchemy import select
 from sqlalchemy.exc import SQLAlchemyError
 
 from aegra_api.core.active_runs import active_runs
+from aegra_api.core.database import db_manager
 from aegra_api.core.orm import Run as RunORM
 from aegra_api.core.orm import Thread as ThreadORM
 from aegra_api.core.orm import _get_session_maker
@@ -25,7 +27,7 @@ _background_cleanup_tasks: set[asyncio.Task[None]] = set()
 
 # Transient infra failures we tolerate during cleanup. Programmer errors
 # (TypeError, AttributeError, ...) propagate.
-_CLEANUP_ERRORS: tuple[type[BaseException], ...] = (RedisError, SQLAlchemyError, OSError)
+_CLEANUP_ERRORS: tuple[type[BaseException], ...] = (RedisError, SQLAlchemyError, OSError, PsycopgError)
 
 
 async def delete_thread_by_id(thread_id: str, user_id: str) -> None:
@@ -64,6 +66,8 @@ async def delete_thread_by_id(thread_id: str, user_id: str) -> None:
             )
         )
         if thread:
+            # Checkpoints first — same ordering rationale as the delete_thread route.
+            await db_manager.get_checkpointer().adelete_thread(thread_id)
             await session.delete(thread)
             await session.commit()
 

--- a/libs/aegra-api/tests/e2e/test_threads/test_thread_deletion.py
+++ b/libs/aegra-api/tests/e2e/test_threads/test_thread_deletion.py
@@ -1,6 +1,31 @@
-import pytest
+import json
 
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from aegra_api.settings import settings
 from tests.e2e._utils import elog, get_e2e_client
+
+_CHECKPOINT_TABLES = ("checkpoints", "checkpoint_blobs", "checkpoint_writes")
+
+
+async def _count_checkpoint_rows(thread_id: str) -> dict[str, int]:
+    """Count LangGraph checkpoint rows for a thread (tables have no ORM models)."""
+    engine = create_async_engine(settings.db.database_url)
+    try:
+        counts: dict[str, int] = {}
+        async with engine.connect() as conn:
+            for table in _CHECKPOINT_TABLES:
+                # Table names come from the fixed tuple above; only the value is user data.
+                result = await conn.execute(
+                    text(f"SELECT count(*) FROM {table} WHERE thread_id = :tid"),  # noqa: S608
+                    {"tid": thread_id},
+                )
+                counts[table] = int(result.scalar_one())
+        return counts
+    finally:
+        await engine.dispose()
 
 
 @pytest.mark.e2e
@@ -191,3 +216,37 @@ async def test_thread_deletion_multiple_runs():
     except Exception:
         # Expected - thread should be gone
         pass
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_thread_deletion_removes_checkpoints() -> None:
+    """DELETE /threads/{id} also removes LangGraph checkpoint rows.
+
+    Regression for the orphaned-checkpoints bug (#288 phase 1): thread
+    deletion used to leave rows in checkpoints/checkpoint_blobs/
+    checkpoint_writes forever.
+    """
+    client = get_e2e_client()
+
+    # stress_test graph: hermetic, no LLM key needed, always writes checkpoints
+    assistant = await client.assistants.create(graph_id="stress_test", if_exists="do_nothing")
+    thread = await client.threads.create()
+    thread_id = thread["thread_id"]
+
+    run = await client.runs.create(
+        thread_id=thread_id,
+        assistant_id=assistant["assistant_id"],
+        input={"messages": [{"role": "user", "content": json.dumps({"delay": 0.1, "steps": 1})}]},
+    )
+    await client.runs.join(thread_id, run["run_id"])
+
+    before = await _count_checkpoint_rows(thread_id)
+    elog("Checkpoint rows before deletion", {"thread_id": thread_id, **before})
+    assert before["checkpoints"] > 0, "completed run should have written checkpoint rows"
+
+    await client.threads.delete(thread_id)
+
+    after = await _count_checkpoint_rows(thread_id)
+    elog("Checkpoint rows after deletion", {"thread_id": thread_id, **after})
+    assert after == dict.fromkeys(_CHECKPOINT_TABLES, 0)

--- a/libs/aegra-api/tests/e2e/test_threads/test_thread_deletion.py
+++ b/libs/aegra-api/tests/e2e/test_threads/test_thread_deletion.py
@@ -7,7 +7,12 @@ from sqlalchemy.ext.asyncio import create_async_engine
 from aegra_api.settings import settings
 from tests.e2e._utils import elog, get_e2e_client
 
-_CHECKPOINT_TABLES = ("checkpoints", "checkpoint_blobs", "checkpoint_writes")
+# One literal query per table: table names can't be bound parameters.
+_CHECKPOINT_COUNT_QUERIES = {
+    "checkpoints": text("SELECT count(*) FROM checkpoints WHERE thread_id = :tid"),
+    "checkpoint_blobs": text("SELECT count(*) FROM checkpoint_blobs WHERE thread_id = :tid"),
+    "checkpoint_writes": text("SELECT count(*) FROM checkpoint_writes WHERE thread_id = :tid"),
+}
 
 
 async def _count_checkpoint_rows(thread_id: str) -> dict[str, int]:
@@ -16,12 +21,8 @@ async def _count_checkpoint_rows(thread_id: str) -> dict[str, int]:
     try:
         counts: dict[str, int] = {}
         async with engine.connect() as conn:
-            for table in _CHECKPOINT_TABLES:
-                # Table names come from the fixed tuple above; only the value is user data.
-                result = await conn.execute(
-                    text(f"SELECT count(*) FROM {table} WHERE thread_id = :tid"),  # noqa: S608
-                    {"tid": thread_id},
-                )
+            for table, query in _CHECKPOINT_COUNT_QUERIES.items():
+                result = await conn.execute(query, {"tid": thread_id})
                 counts[table] = int(result.scalar_one())
         return counts
     finally:
@@ -243,10 +244,12 @@ async def test_thread_deletion_removes_checkpoints() -> None:
 
     before = await _count_checkpoint_rows(thread_id)
     elog("Checkpoint rows before deletion", {"thread_id": thread_id, **before})
-    assert before["checkpoints"] > 0, "completed run should have written checkpoint rows"
+    assert all(count > 0 for count in before.values()), (
+        f"completed run should have written rows in every checkpoint table, got {before}"
+    )
 
     await client.threads.delete(thread_id)
 
     after = await _count_checkpoint_rows(thread_id)
     elog("Checkpoint rows after deletion", {"thread_id": thread_id, **after})
-    assert after == dict.fromkeys(_CHECKPOINT_TABLES, 0)
+    assert after == dict.fromkeys(_CHECKPOINT_COUNT_QUERIES, 0)

--- a/libs/aegra-api/tests/integration/test_api/test_threads_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_threads_crud.py
@@ -11,6 +11,7 @@ from langgraph.types import StateSnapshot
 from psycopg import Error as PsycopgError
 from sqlalchemy.dialects import postgresql
 
+from aegra_api.api import threads as threads_module
 from aegra_api.core.orm import get_session as core_get_session
 from tests.fixtures.clients import create_test_app, make_client
 from tests.fixtures.database import (
@@ -394,7 +395,7 @@ class TestDeleteThread:
         checkpointer = AsyncMock()
         db = MagicMock()
         db.get_checkpointer.return_value = checkpointer
-        monkeypatch.setattr("aegra_api.api.threads.db_manager", db)
+        monkeypatch.setattr(threads_module, "db_manager", db)
         return checkpointer
 
     def test_delete_thread_not_found(self):

--- a/libs/aegra-api/tests/integration/test_api/test_threads_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_threads_crud.py
@@ -8,6 +8,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from langgraph.types import StateSnapshot
+from psycopg import Error as PsycopgError
 from sqlalchemy.dialects import postgresql
 
 from aegra_api.core.orm import get_session as core_get_session
@@ -387,6 +388,15 @@ class TestGetThread:
 class TestDeleteThread:
     """Test DELETE /threads/{thread_id} endpoint"""
 
+    @pytest.fixture
+    def mock_checkpointer(self, monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+        """Stub the checkpointer — db_manager is never initialized in tests."""
+        checkpointer = AsyncMock()
+        db = MagicMock()
+        db.get_checkpointer.return_value = checkpointer
+        monkeypatch.setattr("aegra_api.api.threads.db_manager", db)
+        return checkpointer
+
     def test_delete_thread_not_found(self):
         """Test deleting a non-existent thread"""
         app = create_test_app(include_runs=False, include_threads=True)
@@ -401,7 +411,22 @@ class TestDeleteThread:
         resp = client.delete("/threads/nonexistent")
         assert resp.status_code == 404
 
-    def test_delete_thread_no_active_runs(self):
+    def test_delete_thread_not_found_skips_checkpointer(self, mock_checkpointer: AsyncMock) -> None:
+        """The 404 path never touches the checkpoint backend."""
+        app = create_test_app(include_runs=False, include_threads=True)
+
+        class Session(DummySessionBase):
+            async def scalar(self, _stmt: object) -> None:
+                return None
+
+        app.dependency_overrides[core_get_session] = override_get_session_dep(Session)
+        client = make_client(app)
+
+        resp = client.delete("/threads/nonexistent")
+        assert resp.status_code == 404
+        mock_checkpointer.adelete_thread.assert_not_called()
+
+    def test_delete_thread_no_active_runs(self, mock_checkpointer: AsyncMock) -> None:
         """Test deleting a thread with no active runs"""
         app = create_test_app(include_runs=False, include_threads=True)
 
@@ -430,6 +455,60 @@ class TestDeleteThread:
         resp = client.delete("/threads/test-123")
         assert resp.status_code == 200
         assert resp.json()["status"] == "deleted"
+
+    def test_delete_thread_deletes_backend_checkpoints(self, mock_checkpointer: AsyncMock) -> None:
+        """Deleting a thread also deletes its checkpoint history."""
+        app = create_test_app(include_runs=False, include_threads=True)
+
+        thread = _thread_row("test-123")
+
+        class Session(DummySessionBase):
+            async def scalar(self, _stmt: object) -> object:
+                return thread
+
+            async def delete(self, obj: object) -> None:
+                pass
+
+        app.dependency_overrides[core_get_session] = override_get_session_dep(Session)
+        client = make_client(app)
+
+        resp = client.delete("/threads/test-123")
+        assert resp.status_code == 200
+        mock_checkpointer.adelete_thread.assert_awaited_once_with("test-123")
+
+    def test_delete_thread_returns_500_and_keeps_row_when_checkpoint_delete_fails(
+        self, mock_checkpointer: AsyncMock
+    ) -> None:
+        """Checkpoint-delete failure propagates; the thread row is not committed.
+
+        Deleting the row anyway would orphan the checkpoints — the exact bug
+        this endpoint change fixes. A 500 leaves the delete retryable.
+        """
+        app = create_test_app(include_runs=False, include_threads=True)
+
+        thread = _thread_row("test-123")
+        deleted: list[object] = []
+        committed: list[bool] = []
+
+        class Session(DummySessionBase):
+            async def scalar(self, _stmt: object) -> object:
+                return thread
+
+            async def delete(self, obj: object) -> None:
+                deleted.append(obj)
+
+            async def commit(self) -> None:
+                committed.append(True)
+
+        mock_checkpointer.adelete_thread.side_effect = PsycopgError("checkpoint backend down")
+
+        app.dependency_overrides[core_get_session] = override_get_session_dep(Session)
+        client = TestClient(app, raise_server_exceptions=False)
+
+        resp = client.delete("/threads/test-123")
+        assert resp.status_code == 500
+        assert deleted == []
+        assert committed == []
 
 
 class TestSearchThreads:

--- a/libs/aegra-api/tests/integration/test_api/test_threads_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_threads_crud.py
@@ -508,6 +508,7 @@ class TestDeleteThread:
 
         resp = client.delete("/threads/test-123")
         assert resp.status_code == 500
+        mock_checkpointer.adelete_thread.assert_awaited_once_with("test-123")
         assert deleted == []
         assert committed == []
 

--- a/libs/aegra-api/tests/unit/test_api/test_stateless_runs.py
+++ b/libs/aegra-api/tests/unit/test_api/test_stateless_runs.py
@@ -498,10 +498,12 @@ class TestCleanupAfterBackgroundRun:
                 "aegra_api.services.run_cleanup.delete_thread_by_id",
                 new_callable=AsyncMock,
                 side_effect=PsycopgError("checkpoint backend down"),
-            ),
+            ) as mock_delete,
         ):
             # Should not raise — PsycopgError is in the cleanup tuple
             await _cleanup_after_background_run(run_id, thread_id, user_id)
+
+        mock_delete.assert_awaited_once_with(thread_id, user_id)
 
     @pytest.mark.asyncio
     async def test_deletes_thread_when_wait_times_out(self) -> None:

--- a/libs/aegra-api/tests/unit/test_api/test_stateless_runs.py
+++ b/libs/aegra-api/tests/unit/test_api/test_stateless_runs.py
@@ -9,6 +9,7 @@ from uuid import uuid4
 
 import pytest
 from fastapi.responses import StreamingResponse
+from psycopg import Error as PsycopgError
 from redis import RedisError
 from sse_starlette import EventSourceResponse
 
@@ -78,9 +79,21 @@ class TestDeleteThreadById:
         session.delete = AsyncMock()
         return session
 
+    @pytest.fixture
+    def mock_checkpointer(self) -> AsyncMock:
+        return AsyncMock()
+
+    @pytest.fixture
+    def mock_db_manager(self, mock_checkpointer: AsyncMock) -> MagicMock:
+        db = MagicMock()
+        db.get_checkpointer.return_value = mock_checkpointer
+        return db
+
     @pytest.mark.asyncio
-    async def test_deletes_thread_with_cascade(self, mock_session: AsyncMock) -> None:
-        """Thread and its runs are deleted via cascade."""
+    async def test_deletes_thread_with_cascade(
+        self, mock_session: AsyncMock, mock_db_manager: MagicMock, mock_checkpointer: AsyncMock
+    ) -> None:
+        """Thread, its runs (via cascade), and its checkpoints are deleted."""
         thread_id = str(uuid4())
         user_id = "test-user"
 
@@ -104,11 +117,125 @@ class TestDeleteThreadById:
         mock_maker.return_value.__aenter__ = AsyncMock(return_value=mock_session)
         mock_maker.return_value.__aexit__ = AsyncMock(return_value=False)
 
-        with patch("aegra_api.services.run_cleanup._get_session_maker", return_value=mock_maker):
+        with (
+            patch("aegra_api.services.run_cleanup._get_session_maker", return_value=mock_maker),
+            patch("aegra_api.services.run_cleanup.db_manager", mock_db_manager),
+        ):
             await _delete_thread_by_id(thread_id, user_id)
 
+        mock_checkpointer.adelete_thread.assert_awaited_once_with(thread_id)
         mock_session.delete.assert_called_once_with(thread_orm)
         mock_session.commit.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_deletes_checkpoints_before_thread_commit(
+        self, mock_session: AsyncMock, mock_db_manager: MagicMock, mock_checkpointer: AsyncMock
+    ) -> None:
+        """Checkpoints are deleted before the thread-row commit.
+
+        The reverse order would recreate the orphaned-checkpoints bug: a
+        committed row delete followed by a failed adelete_thread leaves
+        checkpoint rows with no thread handle to retry through.
+        """
+        thread_id = str(uuid4())
+        user_id = "test-user"
+
+        thread_orm = ThreadORM(
+            thread_id=thread_id,
+            user_id=user_id,
+            status="idle",
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = []
+        mock_session.scalars.return_value = mock_scalars
+        mock_session.scalar.return_value = thread_orm
+
+        order: list[str] = []
+        mock_checkpointer.adelete_thread.side_effect = lambda _tid: order.append("checkpoints")
+        mock_session.commit.side_effect = lambda: order.append("commit")
+
+        mock_maker = MagicMock()
+        mock_maker.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_maker.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch("aegra_api.services.run_cleanup._get_session_maker", return_value=mock_maker),
+            patch("aegra_api.services.run_cleanup.db_manager", mock_db_manager),
+        ):
+            await _delete_thread_by_id(thread_id, user_id)
+
+        assert order == ["checkpoints", "commit"]
+
+    @pytest.mark.asyncio
+    async def test_checkpoint_delete_failure_leaves_thread_row(
+        self, mock_session: AsyncMock, mock_db_manager: MagicMock, mock_checkpointer: AsyncMock
+    ) -> None:
+        """A failed checkpoint delete propagates and keeps the thread row.
+
+        The surviving row makes the failure retryable; deleting it anyway
+        would orphan whatever checkpoints the failed call left behind.
+        """
+        thread_id = str(uuid4())
+        user_id = "test-user"
+
+        thread_orm = ThreadORM(
+            thread_id=thread_id,
+            user_id=user_id,
+            status="idle",
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = []
+        mock_session.scalars.return_value = mock_scalars
+        mock_session.scalar.return_value = thread_orm
+
+        mock_checkpointer.adelete_thread.side_effect = PsycopgError("checkpoint backend down")
+
+        mock_maker = MagicMock()
+        mock_maker.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_maker.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        with (  # noqa: SIM117
+            patch("aegra_api.services.run_cleanup._get_session_maker", return_value=mock_maker),
+            patch("aegra_api.services.run_cleanup.db_manager", mock_db_manager),
+        ):
+            with pytest.raises(PsycopgError, match="checkpoint backend down"):
+                await _delete_thread_by_id(thread_id, user_id)
+
+        mock_session.delete.assert_not_called()
+        mock_session.commit.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skips_checkpoint_delete_when_thread_not_owned(
+        self, mock_session: AsyncMock, mock_db_manager: MagicMock, mock_checkpointer: AsyncMock
+    ) -> None:
+        """No checkpoint delete without an ownership-verified thread row.
+
+        adelete_thread takes only a thread_id — calling it when the
+        user-scoped lookup found nothing could wipe another user's data.
+        """
+        mock_scalars = MagicMock()
+        mock_scalars.all.return_value = []
+        mock_session.scalars.return_value = mock_scalars
+        mock_session.scalar.return_value = None
+
+        mock_maker = MagicMock()
+        mock_maker.return_value.__aenter__ = AsyncMock(return_value=mock_session)
+        mock_maker.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch("aegra_api.services.run_cleanup._get_session_maker", return_value=mock_maker),
+            patch("aegra_api.services.run_cleanup.db_manager", mock_db_manager),
+        ):
+            await _delete_thread_by_id("nonexistent", "user")
+
+        mock_checkpointer.adelete_thread.assert_not_called()
+        mock_session.delete.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_cancels_active_runs_before_delete(self, mock_session: AsyncMock) -> None:
@@ -352,6 +479,29 @@ class TestCleanupAfterBackgroundRun:
             await _cleanup_after_background_run(run_id, thread_id, user_id)
 
         mock_delete.assert_called_once_with(thread_id, user_id)
+
+    @pytest.mark.asyncio
+    async def test_swallows_psycopg_error_from_thread_delete(self) -> None:
+        """psycopg failures from cleanup are logged, not propagated.
+
+        Checkpoint deletion runs on the psycopg pool, so PsycopgError must
+        be in _CLEANUP_ERRORS — otherwise a transient backend hiccup would
+        crash the fire-and-forget cleanup task.
+        """
+        run_id = str(uuid4())
+        thread_id = str(uuid4())
+        user_id = "test-user"
+
+        with (
+            patch("aegra_api.services.run_cleanup.active_runs", {}),
+            patch(
+                "aegra_api.services.run_cleanup.delete_thread_by_id",
+                new_callable=AsyncMock,
+                side_effect=PsycopgError("checkpoint backend down"),
+            ),
+        ):
+            # Should not raise — PsycopgError is in the cleanup tuple
+            await _cleanup_after_background_run(run_id, thread_id, user_id)
 
 
 class TestStatelessWaitForRun:

--- a/libs/aegra-api/tests/unit/test_api/test_stateless_runs.py
+++ b/libs/aegra-api/tests/unit/test_api/test_stateless_runs.py
@@ -200,12 +200,12 @@ class TestDeleteThreadById:
         mock_maker.return_value.__aenter__ = AsyncMock(return_value=mock_session)
         mock_maker.return_value.__aexit__ = AsyncMock(return_value=False)
 
-        with (  # noqa: SIM117
+        with (
             patch("aegra_api.services.run_cleanup._get_session_maker", return_value=mock_maker),
             patch("aegra_api.services.run_cleanup.db_manager", mock_db_manager),
+            pytest.raises(PsycopgError, match="checkpoint backend down"),
         ):
-            with pytest.raises(PsycopgError, match="checkpoint backend down"):
-                await _delete_thread_by_id(thread_id, user_id)
+            await _delete_thread_by_id(thread_id, user_id)
 
         mock_session.delete.assert_not_called()
         mock_session.commit.assert_not_called()

--- a/libs/aegra-api/tests/unit/test_api/test_stateless_runs.py
+++ b/libs/aegra-api/tests/unit/test_api/test_stateless_runs.py
@@ -503,6 +503,50 @@ class TestCleanupAfterBackgroundRun:
             # Should not raise — PsycopgError is in the cleanup tuple
             await _cleanup_after_background_run(run_id, thread_id, user_id)
 
+    @pytest.mark.asyncio
+    async def test_deletes_thread_when_wait_times_out(self) -> None:
+        """A run exceeding the wait cap still gets its ephemeral thread deleted."""
+        run_id = str(uuid4())
+        thread_id = str(uuid4())
+        user_id = "test-user"
+
+        with (
+            patch(
+                "aegra_api.services.run_cleanup.executor.wait_for_completion",
+                new_callable=AsyncMock,
+                side_effect=TimeoutError,
+            ),
+            patch(
+                "aegra_api.services.run_cleanup.delete_thread_by_id",
+                new_callable=AsyncMock,
+            ) as mock_delete,
+        ):
+            await _cleanup_after_background_run(run_id, thread_id, user_id)
+
+        mock_delete.assert_awaited_once_with(thread_id, user_id)
+
+    @pytest.mark.asyncio
+    async def test_deletes_thread_when_wait_fails_with_infra_error(self) -> None:
+        """A tolerated infra failure while waiting is logged, not fatal to cleanup."""
+        run_id = str(uuid4())
+        thread_id = str(uuid4())
+        user_id = "test-user"
+
+        with (
+            patch(
+                "aegra_api.services.run_cleanup.executor.wait_for_completion",
+                new_callable=AsyncMock,
+                side_effect=PsycopgError("broker connection lost"),
+            ),
+            patch(
+                "aegra_api.services.run_cleanup.delete_thread_by_id",
+                new_callable=AsyncMock,
+            ) as mock_delete,
+        ):
+            await _cleanup_after_background_run(run_id, thread_id, user_id)
+
+        mock_delete.assert_awaited_once_with(thread_id, user_id)
+
 
 class TestStatelessWaitForRun:
     """Tests for POST /runs/wait."""


### PR DESCRIPTION
## Summary

Phase 1 of #288. Deleting a thread never called the checkpointer's `adelete_thread`, so every deletion left orphaned rows in `checkpoints`, `checkpoint_blobs`, and `checkpoint_writes` forever (these tables have no FK to `thread`, so no DB cascade can clean them). Both deletion paths now clean up checkpoint data:

- `DELETE /threads/{thread_id}` — `api/threads.py::delete_thread`
- `services/run_cleanup.py::delete_thread_by_id` — the helper the issue refers to as `_delete_thread_by_id` in `stateless_runs.py` moved here since, and is shared by stateless runs, crons, and the cron scheduler — so this covers every ephemeral-thread cleanup path (the biggest orphan source, since ephemeral threads leak per run).

## Ordering decision

The checkpointer runs on the psycopg pool (autocommit), a separate transaction from the SQLAlchemy session, so the two deletes can't be atomic — ordering is the only lever. I picked **checkpoints first, thread-row commit second**:

| | `adelete_thread` fails | commit fails after checkpoints deleted |
|---|---|---|
| checkpoints → commit (chosen) | thread row intact, 500 returned, retry works, no orphans | thread survives as a valid empty thread; retrying the delete completes it |
| commit → checkpoints | row gone, checkpoints orphaned forever, retry 404s — reproduces the exact bug | — |

The reverse order has an unrecoverable failure mode; the chosen order's worst case is a benign, retryable partial state.

`adelete_thread` takes only a `thread_id`, so it is called strictly after the user-scoped ownership lookup in both paths — calling it without that check could wipe another user's checkpoints.

## Error handling

- API route: failures propagate → 500, row uncommitted, client retries.
- `run_cleanup`: `psycopg.Error` added to `_CLEANUP_ERRORS` so transient checkpoint-backend failures follow the existing tolerated-infra contract of the cleanup callers. Programmer errors (including `RuntimeError` from an uninitialized `db_manager`) still propagate.

## Tests

- **Unit** (`test_stateless_runs.py`): delete awaited with the right id; ordering regression (checkpoints strictly before commit); failure keeps the thread row; ownership guard skips the call when the row isn't found; widened-tuple swallow test for background cleanup.
- **Integration** (`test_threads_crud.py`): happy path calls `adelete_thread`; checkpoint failure → 500 with no row delete/commit; 404 path never touches the backend.
- **E2E** (`test_thread_deletion_removes_checkpoints`): runs the hermetic `stress_test` graph, asserts checkpoint rows exist, deletes the thread, asserts all three tables are empty for that thread. Verified in both dev (`LocalExecutor`) and prod (Redis workers) modes.

Also verified against a live stack: after exercising both deletion paths, `SELECT count(*) FROM checkpoints c WHERE NOT EXISTS (SELECT 1 FROM thread t WHERE t.thread_id = c.thread_id)` → 0.

## Known limitations

- In prod mode a worker mid-write can persist a checkpoint after `adelete_thread` ran (run cancellation via Redis is asynchronous) → a small bounded orphan. Inherent without cross-store transactions; Phase 2's TTL sweep is the designed backstop.
- A background cleanup task racing shutdown can hit `RuntimeError` from `get_checkpointer()` after `db_manager.close()`. Deliberately not added to the tolerated tuple so lifecycle bugs surface.

## Docs

- `delete_thread` docstring updated (it previously documented that checkpoint history is *not* affected) + `docs/openapi.json` regenerated, `threads-and-state.mdx` updated.

Phase 2 (TTL + background sweep per #288) follows as a separate PR once this lands.

cc @ibbybuilds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deleting a thread now also removes its checkpoint history.
  * Thread records are preserved when checkpoint cleanup fails, allowing deletion to be retried safely.
  * Cleanup failures return an error instead of causing partial deletion.
  * Background cleanup tolerates transient database errors.
  * Active runs continue to be cancelled automatically before thread deletion.
* **Documentation**
  * Updated thread deletion guidance and API documentation to clarify checkpoint removal and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends explicit and ephemeral thread deletion to remove LangGraph checkpoint history before committing the thread-row deletion, preserving retryability when checkpoint cleanup fails.
- Adds checkpoint cleanup to the API and shared run-cleanup paths.
- Documents the revised deletion behavior and API error response.
- Adds unit, integration, and end-to-end regression coverage.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because a transient checkpoint-backend failure permanently abandons the only scheduled cleanup for ephemeral threads.

The background cleanup path catches checkpoint-related database errors, logs them, and completes without retrying or rescheduling; since no orphan-thread sweeper currently exists, the thread and checkpoint rows remain indefinitely.

**Files Needing Attention:** libs/aegra-api/src/aegra_api/services/run_cleanup.py

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/api/threads.py | Adds ownership-gated checkpoint deletion before committing explicit thread deletion. |
| libs/aegra-api/src/aegra_api/services/run_cleanup.py | Adds checkpoint deletion to ephemeral cleanup, but a transient checkpoint error remains terminal because the sole background attempt only logs it. |
| libs/aegra-api/tests/e2e/test_threads/test_thread_deletion.py | Adds end-to-end verification that all three checkpoint tables are cleared using literal parameterized queries. |
| libs/aegra-api/tests/integration/test_api/test_threads_crud.py | Covers successful checkpoint deletion, ownership-safe not-found behavior, and explicit-route failure ordering. |
| libs/aegra-api/tests/unit/test_api/test_stateless_runs.py | Covers ephemeral cleanup ordering and error handling, including the behavior that leaves transient failures without another cleanup attempt. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Caller
    participant Cleanup as Thread cleanup
    participant Checkpointer
    participant DB as Thread database
    Caller->>Cleanup: Delete thread
    Cleanup->>Checkpointer: adelete_thread(thread_id)
    alt Checkpoint deletion succeeds
        Cleanup->>DB: Delete and commit thread row
        Cleanup-->>Caller: Complete
    else Checkpoint deletion raises PsycopgError
        Cleanup-->>Cleanup: Log and return
        Note over Cleanup,DB: Thread row and checkpoint data remain
    end
```
</details>

<sub>Reviews (4): Last reviewed commit: ["test(unit): assert delete was attempted ..."](https://github.com/aegra/aegra/commit/2fa203869ddd5966d6a17ddf1dcaf5c46c6693bf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51609578)</sub>

**Context used:**

- Knowledge Base — [Threads and Runs](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/threads-and-runs.md)
- Knowledge Base — [Execution Engine: Broker, Executors, Leases, and Cleanup](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/execution-engine.md)

<!-- /greptile_comment -->