### PR TITLE
fix(api): make threaded run admission retry-safe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,21 @@ jobs:
       contents: read
       pull-requests: write
 
+    services:
+      postgres:
+        image: postgres:18.0-bookworm
+        env:
+          POSTGRES_USER: user
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: aegra
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U user -d aegra"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
     steps:
       - uses: actions/checkout@v4
         with:
@@ -55,6 +70,12 @@ jobs:
       - name: Install workspace dependencies
         run: uv sync --all-packages
 
+      - name: Run database migrations
+        working-directory: libs/aegra-api
+        env:
+          DATABASE_URL: "postgresql://user:password@localhost:5432/aegra"
+        run: uv run alembic upgrade head
+
       - name: Type check with ty
         run: uv run ty check libs/aegra-api/src/ libs/aegra-cli/src/
         continue-on-error: true
@@ -66,11 +87,7 @@ jobs:
       - name: Run tests with pytest
         env:
           AEGRA_CONFIG: ""
-          POSTGRES_USER: "user"
-          POSTGRES_PASSWORD: "password"
-          POSTGRES_HOST: "localhost"
-          POSTGRES_PORT: "5432"
-          POSTGRES_DB: "aegra"
+          DATABASE_URL: "postgresql://user:password@localhost:5432/aegra"
         run: uv run --package aegra-api pytest libs/aegra-api/tests/unit libs/aegra-api/tests/integration --cov=libs/aegra-api/src --cov-report=xml --cov-report=term
 
       - name: Upload coverage to Codecov

--- a/docs/guides/worker-architecture.mdx
+++ b/docs/guides/worker-architecture.mdx
@@ -52,6 +52,14 @@ The happy path of a single run, step by step:
 
 Behind the scenes, the **Lease Reaper** scans PostgreSQL every 15 seconds for runs with expired leases (crashed workers) and re-enqueues them. Workers also send **OpenTelemetry traces** to Langfuse, Phoenix, or any OTLP collector.
 
+## Retry-safe background admission
+
+`POST /threads/{thread_id}/runs` accepts an optional `Idempotency-Key` header for callers that may retry an ambiguous HTTP response. The key is scoped to the authenticated user and thread. Repeating the same key and request returns the original run without submitting it twice; reusing the key with a different request returns `409 Conflict`. This contract applies only to threaded background creation, not stream, wait, or stateless creation transports.
+
+Set `multitask_strategy` to `"interrupt"` when a new run must replace an active run on the same thread. Aegra terminalizes a pending predecessor or waits for a running predecessor to acknowledge interruption before it admits the successor. If quiescence cannot be proved within the bounded wait, creation fails with `409 Conflict` and no successor is persisted. Other strategy names retain their existing compatibility behavior and do not gain admission semantics here.
+
+For strongest checkpoint recovery, set `durability` to `"sync"`. Aegra persists the setting with the queued job and forwards it through both legacy and Agent Protocol v2 execution paths. Omitting the field preserves LangGraph's existing default.
+
 ## Horizontal scaling
 
 Every instance is stateless — add more instances behind a load balancer to increase capacity. All instances share the same Redis and PostgreSQL backends.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Aegra",
     "description": "Production-ready Agent Protocol server",
-    "version": "0.10.0"
+    "version": "0.10.1"
   },
   "paths": {
     "/info": {
@@ -1589,6 +1589,27 @@
               "type": "string",
               "title": "Thread Id"
             }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 255,
+                  "pattern": "^[\\x21-\\x7E]+$"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Stable visible-ASCII key for safely replaying a threaded run creation request.",
+              "title": "Idempotency-Key"
+            },
+            "description": "Stable visible-ASCII key for safely replaying a threaded run creation request."
           }
         ],
         "requestBody": {
@@ -4744,6 +4765,19 @@
             ],
             "title": "Multitask Strategy",
             "description": "Strategy for handling concurrent runs on same thread: 'reject', 'interrupt', 'rollback', or 'enqueue'."
+          },
+          "durability": {
+            "anyOf": [
+              {
+                "type": "string",
+                "const": "sync"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Durability",
+            "description": "Checkpoint durability mode"
           },
           "command": {
             "anyOf": [

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.10.0"
+version = "0.10.1"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-api/src/aegra_api/api/runs.py
+++ b/libs/aegra-api/src/aegra_api/api/runs.py
@@ -3,7 +3,7 @@
 import asyncio
 import contextlib
 from collections.abc import AsyncGenerator, MutableMapping
-from typing import Any
+from typing import Annotated, Any
 
 import structlog
 from fastapi import APIRouter, Depends, Header, HTTPException, Query
@@ -107,6 +107,16 @@ async def create_run(
     request: RunCreate,
     user: User = Depends(get_current_user),
     session: AsyncSession = Depends(get_session),
+    idempotency_key: Annotated[
+        str | None,
+        Header(
+            alias="Idempotency-Key",
+            min_length=1,
+            max_length=255,
+            pattern=r"^[\x21-\x7E]+$",
+            description="Stable visible-ASCII key for safely replaying a threaded run creation request.",
+        ),
+    ] = None,
 ) -> Run:
     """Create and execute a new run.
 
@@ -121,7 +131,14 @@ async def create_run(
 
     await _apply_create_run_auth(user, thread_id, request)
 
-    _run_id, run, _job = await _prepare_run(session, thread_id, request, user, initial_status="pending")
+    _run_id, run, _job = await _prepare_run(
+        session,
+        thread_id,
+        request,
+        user,
+        initial_status="pending",
+        idempotency_key=idempotency_key,
+    )
 
     return run
 

--- a/libs/aegra-api/src/aegra_api/api/runs.py
+++ b/libs/aegra-api/src/aegra_api/api/runs.py
@@ -138,6 +138,7 @@ async def create_run(
         user,
         initial_status="pending",
         idempotency_key=idempotency_key,
+        openswe_background_admission=True,
     )
 
     return run

--- a/libs/aegra-api/src/aegra_api/models/run_job.py
+++ b/libs/aegra-api/src/aegra_api/models/run_job.py
@@ -10,7 +10,7 @@ frozen=True for immutability. Serialization uses model_dump/model_validate
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -43,6 +43,7 @@ class RunExecution(BaseModel):
     command: dict[str, Any] | None = None
     # When true, stream via the native v3 protocol producer for Agent Protocol v2.
     event_streaming_v2: bool = False
+    durability: Literal["sync"] | None = None
 
 
 class RunBehavior(BaseModel):

--- a/libs/aegra-api/src/aegra_api/models/runs.py
+++ b/libs/aegra-api/src/aegra_api/models/runs.py
@@ -56,6 +56,7 @@ class RunCreate(BaseModel):
         None,
         description="Strategy for handling concurrent runs on same thread: 'reject', 'interrupt', 'rollback', or 'enqueue'.",
     )
+    durability: Literal["sync"] | None = Field(None, description="Checkpoint durability mode")
 
     # Human-in-the-loop fields (core HITL functionality)
     command: dict[str, Any] | None = Field(

--- a/libs/aegra-api/src/aegra_api/services/event_streaming/native_stream.py
+++ b/libs/aegra-api/src/aegra_api/services/event_streaming/native_stream.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator
 from functools import lru_cache
-from typing import Any
+from typing import Any, Literal
 
 
 @lru_cache(maxsize=1)
@@ -62,6 +62,7 @@ async def stream_native_v3_events(
     input_data: Any,
     config: dict[str, Any],
     context: dict[str, Any] | None = None,
+    durability: Literal["sync"] | None = None,
 ) -> AsyncIterator[tuple[str, dict[str, Any]]]:
     """Yield ``(method, protocol_event)`` pairs from a native v3 run.
 
@@ -70,7 +71,12 @@ async def stream_native_v3_events(
     event we can't reconstruct is dropped rather than forwarded malformed.
     """
     run_stream = await graph.astream_events(
-        input_data, config, version="v3", context=context, transformers=_extra_transformers()
+        input_data,
+        config,
+        version="v3",
+        context=context,
+        transformers=_extra_transformers(),
+        **({"durability": durability} if durability is not None else {}),
     )
     async with run_stream as stream:
         async for event in stream:

--- a/libs/aegra-api/src/aegra_api/services/graph_streaming.py
+++ b/libs/aegra-api/src/aegra_api/services/graph_streaming.py
@@ -7,7 +7,7 @@ handling message accumulation, event processing, and multiple stream modes.
 import uuid
 from collections.abc import AsyncIterator, Callable
 from contextlib import aclosing
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 import structlog
 from langchain_core.messages import (
@@ -124,6 +124,7 @@ async def stream_graph_events(
     output_keys: list[str] | None = None,
     on_checkpoint: Callable[[CheckpointPayload | None], None] = lambda _: None,
     on_task_result: Callable[[TaskResultPayload], None] = lambda _: None,
+    durability: Literal["sync"] | None = None,
 ) -> AnyStream:
     """Stream events from a graph execution.
 
@@ -205,6 +206,7 @@ async def stream_graph_events(
                 stream_mode=list(stream_modes_set),
                 subgraphs=subgraphs,
                 **interrupt_kwargs,
+                **({"durability": durability} if durability is not None else {}),
             )
         ) as stream:
             async for event in stream:
@@ -292,6 +294,7 @@ async def stream_graph_events(
                 output_keys=output_keys,
                 subgraphs=subgraphs,
                 **interrupt_kwargs,
+                **({"durability": durability} if durability is not None else {}),
             )
         ) as stream:
             async for event in stream:

--- a/libs/aegra-api/src/aegra_api/services/run_executor.py
+++ b/libs/aegra-api/src/aegra_api/services/run_executor.py
@@ -207,6 +207,7 @@ async def _stream_legacy(
         subgraphs=job.behavior.subgraphs,
         on_checkpoint=lambda _: None,
         on_task_result=lambda _: None,
+        durability=job.execution.durability,
     ):
         event_id = await broker_manager.allocate_event_id(run_id)
         await streaming_service.put_to_broker(run_id, event_id, (event_type, event_data))
@@ -236,6 +237,7 @@ async def _stream_native_v2(
         input_data=execution_input,
         config=run_config,
         context=job.execution.context,
+        durability=job.execution.durability,
     ):
         event_id = await broker_manager.allocate_event_id(run_id)
         await streaming_service.put_to_broker(run_id, event_id, (method, event))

--- a/libs/aegra-api/src/aegra_api/services/run_preparation.py
+++ b/libs/aegra-api/src/aegra_api/services/run_preparation.py
@@ -5,14 +5,17 @@ resume-command validation, and config/context merging logic.
 """
 
 import asyncio
+import hashlib
+import json
 from datetime import UTC, datetime
 from typing import Any
-from uuid import uuid4
+from uuid import NAMESPACE_URL, uuid4, uuid5
 
 import structlog
 from asgi_correlation_id import correlation_id
 from fastapi import HTTPException
-from sqlalchemy import or_, select, update
+from sqlalchemy import or_, select, text, update
+from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from aegra_api.core.orm import Assistant as AssistantORM
@@ -37,6 +40,15 @@ logger = structlog.getLogger(__name__)
 # rejecting — otherwise a valid resume races to a spurious 400.
 _RESUME_SETTLE_ATTEMPTS = 10
 _RESUME_SETTLE_INTERVAL_SECONDS = 0.1
+
+
+def _idempotent_run_id(user_id: str, thread_id: str, key: str) -> str:
+    return str(uuid5(NAMESPACE_URL, json.dumps([user_id, thread_id, key], separators=(",", ":"))))
+
+
+def _request_fingerprint(request: RunCreate) -> str:
+    payload = json.dumps(request.model_dump(mode="json"), sort_keys=True, separators=(",", ":"), ensure_ascii=False)
+    return hashlib.sha256(payload.encode()).hexdigest()
 
 
 async def _validate_resume_command(session: AsyncSession, thread_id: str, command: dict[str, Any] | None) -> None:
@@ -194,6 +206,7 @@ async def _prepare_run(
     *,
     initial_status: str,
     event_streaming_v2: bool = False,
+    idempotency_key: str | None = None,
 ) -> tuple[str, Run, RunJob]:
     """Shared run-creation logic used by create, stream, and wait endpoints.
 
@@ -201,9 +214,28 @@ async def _prepare_run(
     builds a RunJob, submits it to the executor, and returns the triple
     ``(run_id, run_model, job)``.
     """
-    await _validate_resume_command(session, thread_id, request.command)
+    request_fingerprint = _request_fingerprint(request) if idempotency_key is not None else None
+    run_id = (
+        _idempotent_run_id(user.identity, thread_id, idempotency_key) if idempotency_key is not None else str(uuid4())
+    )
+    if idempotency_key is not None:
+        await session.execute(
+            text("SELECT pg_advisory_xact_lock(hashtextextended(:scope, 0))"),
+            {"scope": f"{len(user.identity)}:{user.identity}{thread_id}"},
+        )
+        existing = await session.scalar(
+            select(RunORM).where(
+                RunORM.run_id == run_id,
+                RunORM.thread_id == thread_id,
+                RunORM.user_id == user.identity,
+            )
+        )
+        if existing is not None:
+            if (existing.execution_params or {}).get("idempotency_fingerprint") != request_fingerprint:
+                raise HTTPException(409, "Idempotency-Key was already used with a different request")
+            return run_id, Run.model_validate(existing), RunJob.from_run_orm(existing)
 
-    run_id = str(uuid4())
+    await _validate_resume_command(session, thread_id, request.command)
     langgraph_service = get_langgraph_service()
     logger.info(
         "Scheduling run",
@@ -282,6 +314,8 @@ async def _prepare_run(
         "thread_id": thread_id,
         "graph_id": assistant.graph_id,
     }
+    if request_fingerprint is not None:
+        exec_params["idempotency_fingerprint"] = request_fingerprint
 
     now = datetime.now(UTC)
     run_orm = RunORM(
@@ -299,8 +333,45 @@ async def _prepare_run(
         error_message=None,
         execution_params=exec_params,
     )
-    session.add(run_orm)
-    await session.commit()
+    if request_fingerprint is None:
+        session.add(run_orm)
+        await session.commit()
+    else:
+        inserted = await session.scalar(
+            insert(RunORM)
+            .values(
+                run_id=run_id,
+                thread_id=thread_id,
+                assistant_id=resolved_assistant_id,
+                status=initial_status,
+                input=request.input,
+                config=config,
+                context=context,
+                user_id=user.identity,
+                created_at=now,
+                updated_at=now,
+                output=None,
+                error_message=None,
+                execution_params=exec_params,
+            )
+            .on_conflict_do_nothing(index_elements=[RunORM.run_id])
+            .returning(RunORM.run_id)
+        )
+        if inserted is None:
+            await session.rollback()
+            existing = await session.scalar(
+                select(RunORM).where(
+                    RunORM.run_id == run_id,
+                    RunORM.thread_id == thread_id,
+                    RunORM.user_id == user.identity,
+                )
+            )
+            if existing is None:
+                raise RuntimeError("idempotent run disappeared after insertion conflict")
+            if (existing.execution_params or {}).get("idempotency_fingerprint") != request_fingerprint:
+                raise HTTPException(409, "Idempotency-Key was already used with a different request")
+            return run_id, Run.model_validate(existing), RunJob.from_run_orm(existing)
+        await session.commit()
 
     run = Run.model_validate(run_orm)
 

--- a/libs/aegra-api/src/aegra_api/services/run_preparation.py
+++ b/libs/aegra-api/src/aegra_api/services/run_preparation.py
@@ -27,6 +27,7 @@ from aegra_api.models.run_job import RunBehavior, RunExecution, RunIdentity, Run
 from aegra_api.services.executor import executor
 from aegra_api.services.langgraph_service import get_langgraph_service
 from aegra_api.services.run_status import set_thread_status
+from aegra_api.services.streaming_service import streaming_service
 from aegra_api.utils.assistants import resolve_assistant_id
 from aegra_api.utils.run_utils import _merge_jsonb
 
@@ -40,6 +41,9 @@ logger = structlog.getLogger(__name__)
 # rejecting — otherwise a valid resume races to a spurious 400.
 _RESUME_SETTLE_ATTEMPTS = 10
 _RESUME_SETTLE_INTERVAL_SECONDS = 0.1
+_INTERRUPT_SETTLE_ATTEMPTS = 100
+_INTERRUPT_SETTLE_INTERVAL_SECONDS = 0.1
+_TERMINAL_RUN_STATUSES = frozenset({"success", "error", "timeout", "interrupted"})
 
 
 def _idempotent_run_id(user_id: str, thread_id: str, key: str) -> str:
@@ -207,6 +211,7 @@ async def _prepare_run(
     initial_status: str,
     event_streaming_v2: bool = False,
     idempotency_key: str | None = None,
+    openswe_background_admission: bool = False,
 ) -> tuple[str, Run, RunJob]:
     """Shared run-creation logic used by create, stream, and wait endpoints.
 
@@ -218,11 +223,12 @@ async def _prepare_run(
     run_id = (
         _idempotent_run_id(user.identity, thread_id, idempotency_key) if idempotency_key is not None else str(uuid4())
     )
-    if idempotency_key is not None:
+    if openswe_background_admission and (idempotency_key is not None or request.multitask_strategy == "interrupt"):
         await session.execute(
             text("SELECT pg_advisory_xact_lock(hashtextextended(:scope, 0))"),
             {"scope": f"{len(user.identity)}:{user.identity}{thread_id}"},
         )
+    if request_fingerprint is not None:
         existing = await session.scalar(
             select(RunORM).where(
                 RunORM.run_id == run_id,
@@ -275,6 +281,69 @@ async def _prepare_run(
     available_graphs = langgraph_service.list_graphs()
     if assistant.graph_id not in available_graphs:
         raise HTTPException(404, f"Graph '{assistant.graph_id}' not found for assistant")
+
+    if openswe_background_admission and request.multitask_strategy == "interrupt":
+        predecessors = (
+            await session.scalars(
+                select(RunORM).where(
+                    RunORM.thread_id == thread_id,
+                    RunORM.user_id == user.identity,
+                    RunORM.status.in_(("pending", "running")),
+                )
+            )
+        ).all()
+        running_ids: list[str] = []
+        for predecessor in predecessors:
+            status = predecessor.status
+            if status == "pending":
+                claimed = await session.scalar(
+                    update(RunORM)
+                    .where(
+                        RunORM.run_id == predecessor.run_id,
+                        RunORM.thread_id == thread_id,
+                        RunORM.user_id == user.identity,
+                        RunORM.status == "pending",
+                    )
+                    .values(status="interrupted", updated_at=datetime.now(UTC))
+                    .returning(RunORM.run_id)
+                )
+                if claimed is not None:
+                    continue
+                status = await session.scalar(
+                    select(RunORM.status).where(
+                        RunORM.run_id == predecessor.run_id,
+                        RunORM.thread_id == thread_id,
+                        RunORM.user_id == user.identity,
+                    )
+                )
+                if status not in ("running", "interrupted"):
+                    raise HTTPException(409, f"Active run '{predecessor.run_id}' completed without interruption")
+            if status == "running":
+                if not await streaming_service.interrupt_run(predecessor.run_id):
+                    raise HTTPException(409, f"Could not interrupt active run '{predecessor.run_id}'")
+                running_ids.append(predecessor.run_id)
+            elif status not in _TERMINAL_RUN_STATUSES:
+                raise HTTPException(409, f"Active run '{predecessor.run_id}' changed unexpectedly")
+        for _ in range(_INTERRUPT_SETTLE_ATTEMPTS):
+            if not running_ids:
+                break
+            states: dict[str, str] = {}
+            rows = await session.execute(
+                select(RunORM.run_id, RunORM.status).where(
+                    RunORM.run_id.in_(running_ids),
+                    RunORM.thread_id == thread_id,
+                    RunORM.user_id == user.identity,
+                )
+            )
+            for active_run_id, active_status in rows.all():
+                states[active_run_id] = active_status
+            if all(states.get(run_id) in _TERMINAL_RUN_STATUSES for run_id in running_ids):
+                if any(states.get(run_id) != "interrupted" for run_id in running_ids):
+                    raise HTTPException(409, "Active run completed without acknowledging interruption")
+                break
+            await asyncio.sleep(_INTERRUPT_SETTLE_INTERVAL_SECONDS)
+        else:
+            raise HTTPException(409, "Timed out waiting for active runs to acknowledge interruption")
 
     # Mark thread as busy and update metadata
     await update_thread_metadata(

--- a/libs/aegra-api/src/aegra_api/services/run_preparation.py
+++ b/libs/aegra-api/src/aegra_api/services/run_preparation.py
@@ -363,6 +363,7 @@ async def _prepare_run(
             checkpoint=request.checkpoint,
             command=request.command,
             event_streaming_v2=event_streaming_v2,
+            durability=request.durability,
         ),
         behavior=RunBehavior(
             interrupt_before=request.interrupt_before,

--- a/libs/aegra-api/src/aegra_api/services/worker_executor.py
+++ b/libs/aegra-api/src/aegra_api/services/worker_executor.py
@@ -20,7 +20,7 @@ import structlog
 from asgi_correlation_id import correlation_id
 from redis import RedisError
 from redis import TimeoutError as RedisTimeoutError
-from sqlalchemy import select, update
+from sqlalchemy import func, select, update
 
 from aegra_api.core.active_runs import active_runs, explicit_run_cancellations
 from aegra_api.core.orm import Run as RunORM
@@ -298,12 +298,12 @@ class WorkerExecutor(BaseExecutor):
             client = redis_manager.get_client()
             result = await client.blpop(settings.worker.WORKER_QUEUE_KEY, timeout=5)  # type: ignore[arg-type]
             if result is None:
-                return None
+                return await self._poll_postgres(idempotent_only=True)
             return result[1]
         except RedisTimeoutError:
             # Idle expiry: a blocking BLPOP hit the socket timeout with no jobs.
-            # Normal when the queue is empty, not a connectivity failure — re-loop.
-            return None
+            # Recover only retry-keyed runs that may have missed Redis enqueue.
+            return await self._poll_postgres(idempotent_only=True)
         except RedisError as exc:
             logger.warning("Redis BLPOP failed, falling back to Postgres poll", error=str(exc))
             await asyncio.sleep(settings.worker.POSTGRES_POLL_INTERVAL_SECONDS)
@@ -359,16 +359,19 @@ class WorkerExecutor(BaseExecutor):
             )
 
     @staticmethod
-    async def _poll_postgres() -> str | None:
+    async def _poll_postgres(*, idempotent_only: bool = False) -> str | None:
         """Pick the oldest pending, unclaimed run from Postgres."""
         maker = _get_session_maker()
         async with maker() as session:
-            run_id = await session.scalar(
+            statement = (
                 select(RunORM.run_id)
                 .where(RunORM.status == "pending", RunORM.claimed_by.is_(None))
                 .order_by(RunORM.created_at.asc())
                 .limit(1)
             )
+            if idempotent_only:
+                statement = statement.where(func.jsonb_exists(RunORM.execution_params, "idempotency_fingerprint"))
+            run_id = await session.scalar(statement)
             return run_id
 
 

--- a/libs/aegra-api/tests/integration/test_api/test_runs_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_runs_crud.py
@@ -130,6 +130,20 @@ class TestCreateRun:
         # Should get validation error (422) for missing input/command
         assert resp.status_code == 422
 
+    def test_rejects_invalid_idempotency_key_headers(self) -> None:
+        """The retry key is bounded visible ASCII before handler execution."""
+        app = create_test_app(include_runs=True, include_threads=False)
+        override_session_dependency(app, BasicSession)
+        client = make_client(app)
+
+        for key in ("", "contains space", "x" * 256):
+            response = client.post(
+                "/threads/test-thread-123/runs",
+                headers={"Idempotency-Key": key},
+                json={"assistant_id": "asst-123", "input": {}},
+            )
+            assert response.status_code == 422
+
 
 class TestGetRun:
     """Test GET /threads/{thread_id}/runs/{run_id}"""

--- a/libs/aegra-api/tests/integration/test_openswe_idempotency.py
+++ b/libs/aegra-api/tests/integration/test_openswe_idempotency.py
@@ -15,6 +15,7 @@ from aegra_api.models import Run as RunModel
 from aegra_api.models import RunCreate, User
 from aegra_api.models.run_job import RunJob
 from aegra_api.services.run_preparation import _idempotent_run_id, _prepare_run
+from aegra_api.services.run_status import finalize_run
 from aegra_api.services.worker_executor import WorkerExecutor
 from aegra_api.settings import settings
 
@@ -29,6 +30,7 @@ async def test_concurrent_same_key_submits_once_and_mismatch_conflicts() -> None
     user = User(identity="openswe-idempotency", scopes=[])
     thread_id, assistant_id = "openswe-idempotency-thread", "openswe-idempotency-assistant"
     run_id = _idempotent_run_id(user.identity, thread_id, "delivery-1")
+    foreign_run_id = "openswe-idempotency-foreign-run"
     try:
         async with engine.begin() as connection:
             await connection.execute(select(1))
@@ -50,11 +52,28 @@ async def test_concurrent_same_key_submits_once_and_mismatch_conflicts() -> None
                 )
             )
             session.add(Thread(thread_id=thread_id, user_id=user.identity, status="idle", metadata_json={}))
+            await session.flush()
+            session.add(
+                Run(
+                    run_id=foreign_run_id,
+                    thread_id=thread_id,
+                    assistant_id=assistant_id,
+                    status="running",
+                    input={},
+                    config={},
+                    context={},
+                    output=None,
+                    error_message=None,
+                    user_id="openswe-idempotency-other-tenant",
+                    execution_params={},
+                )
+            )
             await session.commit()
 
         async def create(
             payload: str | None,
             key: str | None = "delivery-1",
+            strategy: str | None = None,
             command: dict | None = None,
         ) -> tuple[str, RunModel, RunJob]:
             async with maker() as session:
@@ -65,18 +84,32 @@ async def test_concurrent_same_key_submits_once_and_mismatch_conflicts() -> None
                         assistant_id=assistant_id,
                         input={"message": payload} if command is None else None,
                         command=command,
+                        multitask_strategy=strategy,
                     ),
                     user,
                     initial_status="pending",
                     idempotency_key=key,
+                    openswe_background_admission=True,
                 )
 
-        submit = AsyncMock()
+        events: list[tuple[str, str]] = []
+        submit = AsyncMock(side_effect=lambda job: events.append(("submit", job.identity.run_id)))
+
+        async def acknowledge_interrupt(old: str) -> bool:
+            events.append(("interrupt", old))
+            async with maker() as ack_session:
+                await ack_session.execute(update(Run).where(Run.run_id == old).values(status="interrupted"))
+                await ack_session.commit()
+            events.append(("ack", old))
+            return True
+
+        interrupt = AsyncMock(side_effect=acknowledge_interrupt)
         graph_service = MagicMock()
         graph_service.list_graphs.return_value = ["contract-graph"]
         with (
             patch("aegra_api.services.run_preparation.get_langgraph_service", return_value=graph_service),
             patch("aegra_api.services.run_preparation.executor.submit", submit),
+            patch("aegra_api.services.run_preparation.streaming_service.interrupt_run", interrupt),
         ):
             first, second = await asyncio.gather(create("same"), create("same"))
             assert first[0] == second[0] == run_id
@@ -100,7 +133,6 @@ async def test_concurrent_same_key_submits_once_and_mismatch_conflicts() -> None
                 assert thread is not None
                 assert thread.status == "idle"
                 assert thread.metadata_json == {"sentinel": "unchanged"}
-
             lost_insert = await create("lost-insert", "delivery-lost-insert")
             async with maker() as session:
                 await session.execute(update(Run).where(Run.run_id == lost_insert[0]).values(status="success"))
@@ -130,6 +162,7 @@ async def test_concurrent_same_key_submits_once_and_mismatch_conflicts() -> None
                         user,
                         initial_status="pending",
                         idempotency_key="delivery-lost-insert",
+                        openswe_background_admission=True,
                     )
             assert lost_insert_replay[0] == lost_insert[0]
             assert submit.await_count == submitted_after_lost_insert
@@ -138,6 +171,91 @@ async def test_concurrent_same_key_submits_once_and_mismatch_conflicts() -> None
                 assert thread is not None
                 assert thread.status == "idle"
                 assert thread.metadata_json == {"sentinel": "lost-insert"}
+                await session.execute(update(Run).where(Run.run_id == run_id).values(status="running"))
+                await session.commit()
+
+            replacement_keys = ("delivery-2a", "delivery-2b")
+            replacements = await asyncio.gather(*(create("replacement", key, "interrupt") for key in replacement_keys))
+            assert interrupt.await_count == 1
+            async with maker() as session:
+                states = [await session.scalar(select(Run.status).where(Run.run_id == run[0])) for run in replacements]
+            assert sorted(states) == ["interrupted", "pending"]
+            async with maker() as session:
+                foreign_status = await session.scalar(select(Run.status).where(Run.run_id == foreign_run_id))
+            assert foreign_status == "running"
+            pending_index = states.index("pending")
+            replacement = replacements[pending_index]
+            submitted_after_replacements = submit.await_count
+            await create("replacement", replacement_keys[pending_index], "interrupt")
+            assert interrupt.await_count == 1
+            assert submit.await_count == submitted_after_replacements
+
+            async with maker() as session:
+                await session.execute(update(Run).where(Run.run_id == replacement[0]).values(status="running"))
+                await session.commit()
+            with (
+                patch(
+                    "aegra_api.services.run_preparation.streaming_service.interrupt_run", AsyncMock(return_value=True)
+                ),
+                patch("aegra_api.services.run_preparation._INTERRUPT_SETTLE_ATTEMPTS", 1),
+                patch("aegra_api.services.run_preparation._INTERRUPT_SETTLE_INTERVAL_SECONDS", 0),
+                pytest.raises(HTTPException, match="acknowledge") as timeout,
+            ):
+                await create("blocked", "delivery-3", "interrupt")
+            assert timeout.value.status_code == 409
+            assert submit.await_count == submitted_after_replacements
+
+            race_id = _idempotent_run_id(user.identity, thread_id, "terminal-race")
+            async with maker() as session:
+                await session.execute(update(Run).where(Run.run_id == replacement[0]).values(status="pending"))
+                await session.commit()
+                original_scalar = session.scalar
+                complete_before_claim = True
+
+                async def complete_pending_run(statement: Any, *args: Any, **kwargs: Any) -> Any:
+                    nonlocal complete_before_claim
+                    if complete_before_claim and getattr(statement, "is_update", False):
+                        complete_before_claim = False
+                        async with maker() as competing_session:
+                            await competing_session.execute(
+                                update(Run).where(Run.run_id == replacement[0]).values(status="success")
+                            )
+                            await competing_session.commit()
+                    return await original_scalar(statement, *args, **kwargs)
+
+                with (
+                    patch.object(session, "scalar", AsyncMock(side_effect=complete_pending_run)),
+                    pytest.raises(HTTPException) as terminal_race,
+                ):
+                    await _prepare_run(
+                        session,
+                        thread_id,
+                        RunCreate(
+                            assistant_id=assistant_id,
+                            input={"message": "terminal-race"},
+                            multitask_strategy="interrupt",
+                        ),
+                        user,
+                        initial_status="pending",
+                        idempotency_key="terminal-race",
+                        openswe_background_admission=True,
+                    )
+                assert terminal_race.value.status_code == 409
+                assert not complete_before_claim
+                assert await session.scalar(select(Run.run_id).where(Run.run_id == race_id)) is None
+                await session.execute(update(Run).where(Run.run_id == replacement[0]).values(status="running"))
+                await session.commit()
+            assert submit.await_count == submitted_after_replacements
+
+            with patch("aegra_api.services.run_status._get_session_maker", return_value=maker):
+                await finalize_run(
+                    replacement[0], thread_id, user_id=user.identity, status="success", thread_status="idle"
+                )
+                await finalize_run(run_id, thread_id, user_id=user.identity, status="error", thread_status="error")
+            async with maker() as session:
+                assert await session.scalar(select(Run.status).where(Run.run_id == run_id)) == "interrupted"
+                assert await session.scalar(select(Run.status).where(Run.run_id == replacement[0])) == "success"
+                assert await session.scalar(select(Thread.status).where(Thread.thread_id == thread_id)) == "idle"
 
             failed_id = _idempotent_run_id(user.identity, thread_id, "delivery-4")
             with (

--- a/libs/aegra-api/tests/integration/test_openswe_idempotency.py
+++ b/libs/aegra-api/tests/integration/test_openswe_idempotency.py
@@ -1,0 +1,178 @@
+"""OpenSWE's exact threaded-background idempotency contract."""
+
+import asyncio
+import os
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import delete, func, select, update
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from aegra_api.core.orm import Assistant, Run, Thread
+from aegra_api.models import Run as RunModel
+from aegra_api.models import RunCreate, User
+from aegra_api.models.run_job import RunJob
+from aegra_api.services.run_preparation import _idempotent_run_id, _prepare_run
+from aegra_api.services.worker_executor import WorkerExecutor
+from aegra_api.settings import settings
+
+
+@pytest.mark.asyncio
+async def test_concurrent_same_key_submits_once_and_mismatch_conflicts() -> None:
+    if not os.environ.get("DATABASE_URL"):
+        pytest.skip("DATABASE_URL is required for the OpenSWE PostgreSQL integration test")
+
+    engine = create_async_engine(settings.db.database_url)
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    user = User(identity="openswe-idempotency", scopes=[])
+    thread_id, assistant_id = "openswe-idempotency-thread", "openswe-idempotency-assistant"
+    run_id = _idempotent_run_id(user.identity, thread_id, "delivery-1")
+    try:
+        async with engine.begin() as connection:
+            await connection.execute(select(1))
+        async with maker() as session:
+            await session.execute(delete(Run).where(Run.thread_id == thread_id))
+            await session.execute(delete(Thread).where(Thread.thread_id == thread_id))
+            await session.execute(delete(Assistant).where(Assistant.assistant_id == assistant_id))
+            session.add(
+                Assistant(
+                    assistant_id=assistant_id,
+                    graph_id="contract-graph",
+                    config={},
+                    context={},
+                    user_id=user.identity,
+                    name="contract",
+                    description="contract",
+                    metadata_dict={},
+                    version=1,
+                )
+            )
+            session.add(Thread(thread_id=thread_id, user_id=user.identity, status="idle", metadata_json={}))
+            await session.commit()
+
+        async def create(
+            payload: str | None,
+            key: str | None = "delivery-1",
+            command: dict | None = None,
+        ) -> tuple[str, RunModel, RunJob]:
+            async with maker() as session:
+                return await _prepare_run(
+                    session,
+                    thread_id,
+                    RunCreate(
+                        assistant_id=assistant_id,
+                        input={"message": payload} if command is None else None,
+                        command=command,
+                    ),
+                    user,
+                    initial_status="pending",
+                    idempotency_key=key,
+                )
+
+        submit = AsyncMock()
+        graph_service = MagicMock()
+        graph_service.list_graphs.return_value = ["contract-graph"]
+        with (
+            patch("aegra_api.services.run_preparation.get_langgraph_service", return_value=graph_service),
+            patch("aegra_api.services.run_preparation.executor.submit", submit),
+        ):
+            first, second = await asyncio.gather(create("same"), create("same"))
+            assert first[0] == second[0] == run_id
+            assert submit.await_count == 1
+            async with maker() as session:
+                count = await session.scalar(select(func.count()).select_from(Run).where(Run.run_id == run_id))
+                assert count == 1
+                await session.execute(update(Run).where(Run.run_id == run_id).values(status="success"))
+                await session.execute(
+                    update(Thread)
+                    .where(Thread.thread_id == thread_id)
+                    .values(status="idle", metadata_json={"sentinel": "unchanged"})
+                )
+                await session.commit()
+            with pytest.raises(HTTPException) as conflict:
+                await create("different")
+            assert conflict.value.status_code == 409
+            assert submit.await_count == 1
+            async with maker() as session:
+                thread = await session.scalar(select(Thread).where(Thread.thread_id == thread_id))
+                assert thread is not None
+                assert thread.status == "idle"
+                assert thread.metadata_json == {"sentinel": "unchanged"}
+
+            lost_insert = await create("lost-insert", "delivery-lost-insert")
+            async with maker() as session:
+                await session.execute(update(Run).where(Run.run_id == lost_insert[0]).values(status="success"))
+                await session.execute(
+                    update(Thread)
+                    .where(Thread.thread_id == thread_id)
+                    .values(status="idle", metadata_json={"sentinel": "lost-insert"})
+                )
+                await session.commit()
+            submitted_after_lost_insert = submit.await_count
+            async with maker() as session:
+                original_scalar = session.scalar
+                hide_existing_once = True
+
+                async def hide_existing_run(statement: Any, *args: Any, **kwargs: Any) -> Any:
+                    nonlocal hide_existing_once
+                    if hide_existing_once:
+                        hide_existing_once = False
+                        return None
+                    return await original_scalar(statement, *args, **kwargs)
+
+                with patch.object(session, "scalar", AsyncMock(side_effect=hide_existing_run)):
+                    lost_insert_replay = await _prepare_run(
+                        session,
+                        thread_id,
+                        RunCreate(assistant_id=assistant_id, input={"message": "lost-insert"}),
+                        user,
+                        initial_status="pending",
+                        idempotency_key="delivery-lost-insert",
+                    )
+            assert lost_insert_replay[0] == lost_insert[0]
+            assert submit.await_count == submitted_after_lost_insert
+            async with maker() as session:
+                thread = await session.scalar(select(Thread).where(Thread.thread_id == thread_id))
+                assert thread is not None
+                assert thread.status == "idle"
+                assert thread.metadata_json == {"sentinel": "lost-insert"}
+
+            failed_id = _idempotent_run_id(user.identity, thread_id, "delivery-4")
+            with (
+                patch(
+                    "aegra_api.services.run_preparation.executor.submit", AsyncMock(side_effect=RuntimeError("crash"))
+                ),
+                pytest.raises(RuntimeError, match="crash"),
+            ):
+                await create("recover", "delivery-4")
+            with patch("aegra_api.services.worker_executor._get_session_maker", return_value=maker):
+                executor = WorkerExecutor()
+                assert await executor._poll_postgres(idempotent_only=True) == failed_id
+                ordinary_id = (await create("ordinary", None))[0]
+                async with maker() as session:
+                    await session.execute(update(Run).where(Run.run_id == failed_id).values(status="error"))
+                    await session.commit()
+                assert await executor._poll_postgres(idempotent_only=True) is None
+                assert await executor._poll_postgres() == ordinary_id
+
+            submitted_before_resume = submit.await_count
+            async with maker() as session:
+                await session.execute(update(Thread).where(Thread.thread_id == thread_id).values(status="interrupted"))
+                await session.commit()
+            resumed = await create(None, "delivery-resume", command={"resume": "continue"})
+            async with maker() as session:
+                await session.execute(update(Run).where(Run.run_id == resumed[0]).values(status="success"))
+                await session.execute(update(Thread).where(Thread.thread_id == thread_id).values(status="idle"))
+                await session.commit()
+            replayed = await create(None, "delivery-resume", command={"resume": "continue"})
+            assert replayed[0] == resumed[0]
+            assert submit.await_count == submitted_before_resume + 1
+    finally:
+        async with maker() as session:
+            await session.execute(delete(Run).where(Run.thread_id == thread_id))
+            await session.execute(delete(Thread).where(Thread.thread_id == thread_id))
+            await session.execute(delete(Assistant).where(Assistant.assistant_id == assistant_id))
+            await session.commit()
+        await engine.dispose()

--- a/libs/aegra-api/tests/unit/test_api/test_crons.py
+++ b/libs/aegra-api/tests/unit/test_api/test_crons.py
@@ -73,6 +73,7 @@ class TestTriggerFirstRun:
         assert result is mock_run
         mock_prepare.assert_awaited_once()
         assert mock_prepare.await_args.args[1] == "eph-thread-1"
+        assert "openswe_background_admission" not in mock_prepare.await_args.kwargs
         mock_schedule.assert_called_once_with("run-001", "eph-thread-1", mock_user.identity)
 
     @pytest.mark.asyncio

--- a/libs/aegra-api/tests/unit/test_api/test_runs_streaming.py
+++ b/libs/aegra-api/tests/unit/test_api/test_runs_streaming.py
@@ -67,6 +67,7 @@ class TestRunsStreamingEndpoints:
             assistant_id="test-assistant",
             input={"message": "stream me"},
             stream_mode=["events"],
+            multitask_strategy="interrupt",
         )
 
         with (
@@ -83,6 +84,10 @@ class TestRunsStreamingEndpoints:
                 "aegra_api.services.run_preparation.executor.submit",
                 new_callable=AsyncMock,
             ) as mock_submit,
+            patch(
+                "aegra_api.services.run_preparation.streaming_service.interrupt_run",
+                new_callable=AsyncMock,
+            ) as mock_interrupt,
             patch("aegra_api.api.runs.active_runs", {}),
             patch("aegra_api.api.runs.streaming_service.stream_run_execution") as mock_stream_exec,
             patch("aegra_api.api.runs._get_session_maker", return_value=_make_session_maker(mock_session)),
@@ -114,6 +119,7 @@ class TestRunsStreamingEndpoints:
 
             # Verify background execution submission
             mock_submit.assert_awaited_once()
+            mock_interrupt.assert_not_awaited()
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(
@@ -272,6 +278,7 @@ class TestRunsStreamingEndpoints:
         assert ctx.resource == "threads"
         assert ctx.action == "create_run"
         assert value["thread_id"] == thread_id
+        assert "openswe_background_admission" not in mock_prepare.await_args.kwargs
 
     @pytest.mark.asyncio
     async def test_create_and_stream_run_auth_handler_denies_with_403(

--- a/libs/aegra-api/tests/unit/test_api/test_runs_wait.py
+++ b/libs/aegra-api/tests/unit/test_api/test_runs_wait.py
@@ -58,6 +58,7 @@ def _make_request() -> MagicMock:
     request.interrupt_before = None
     request.interrupt_after = None
     request.multitask_strategy = None
+    request.durability = None
     request.stream_subgraphs = False
     request.metadata = None
     return request

--- a/libs/aegra-api/tests/unit/test_api/test_runs_wait.py
+++ b/libs/aegra-api/tests/unit/test_api/test_runs_wait.py
@@ -416,6 +416,7 @@ class TestWaitForRunAuthHandlers:
         assert ctx.resource == "threads"
         assert ctx.action == "create_run"
         assert value["thread_id"] == thread_id
+        assert "openswe_background_admission" not in mock_prepare.await_args.kwargs
 
     @pytest.mark.asyncio
     async def test_wait_for_run_auth_handler_denies_with_403(self) -> None:

--- a/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_commands.py
+++ b/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_commands.py
@@ -55,6 +55,7 @@ class TestRunStart:
         assert request.config == {"c": 2}
         # v2 runs are flagged for the native v3 stream path.
         assert prepared_run.call_args.kwargs["event_streaming_v2"] is True
+        assert "openswe_background_admission" not in prepared_run.call_args.kwargs
 
     async def test_run_start_forwards_interrupt_breakpoints(self, prepared_run: AsyncMock, user: User) -> None:
         """interrupt_before/after must reach RunCreate so v2 clients can set HITL breakpoints."""

--- a/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_native_stream.py
+++ b/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_native_stream.py
@@ -85,12 +85,18 @@ class TestStreamNativeV3Events:
 
         # v3 is requested with version="v3"
         assert graph.calls[0]["version"] == "v3"
+        assert "durability" not in graph.calls[0]
         # values forwarded as-is
         assert out[0][0] == "values"
         assert out[0][1]["params"]["data"] == {"messages": []}
         # messages: tuple unwrapped so params.data is the event dict
         assert out[1][0] == "messages"
         assert out[1][1]["params"]["data"] == {"event": "message-start", "id": "m1"}
+
+        sync_graph = _FakeGraph([])
+        async for _ in stream_native_v3_events(graph=sync_graph, input_data={}, config={}, durability="sync"):
+            pass
+        assert sync_graph.calls[0]["durability"] == "sync"
 
     async def test_skips_non_event_dicts(self) -> None:
         graph = _FakeGraph([{"not": "an event"}, _event("values", {"a": 1})])

--- a/libs/aegra-api/tests/unit/test_services/test_graph_streaming.py
+++ b/libs/aegra-api/tests/unit/test_services/test_graph_streaming.py
@@ -4,6 +4,9 @@ Tests message accumulation, interrupt filtering, subgraph handling,
 and event processing logic.
 """
 
+from collections.abc import AsyncIterator
+from typing import Any
+
 import pytest
 from langchain_core.messages import (
     AIMessage,
@@ -662,9 +665,11 @@ class TestStreamGraphEvents:
         from aegra_api.services.graph_streaming import stream_graph_events
 
         mock_graph = MagicMock()
+        call_kwargs = {}
 
         # Mock astream to yield tuples
-        async def mock_stream(*args, **kwargs):
+        async def mock_stream(*args: Any, **kwargs: Any) -> AsyncIterator[tuple[list[str], str, dict[str, str]]]:
+            call_kwargs.update(kwargs)
             yield (["sub"], "values", {"foo": "bar"})
 
         mock_graph.astream = mock_stream
@@ -687,6 +692,12 @@ class TestStreamGraphEvents:
         # Verify subgraph event
         assert events[1][0] == "values|sub"
         assert events[1][1] == {"foo": "bar"}
+        assert "durability" not in call_kwargs
+        async for _ in stream_graph_events(
+            mock_graph, {}, config, stream_mode=["values"], subgraphs=True, durability="sync"
+        ):
+            pass
+        assert call_kwargs["durability"] == "sync"
 
     @pytest.mark.asyncio
     async def test_stream_events_context_filtering(self):

--- a/libs/aegra-api/tests/unit/test_services/test_graph_streaming_events_mode.py
+++ b/libs/aegra-api/tests/unit/test_services/test_graph_streaming_events_mode.py
@@ -198,12 +198,14 @@ class TestEventsMode:
             {"messages": []},
             config,
             stream_mode=["events"],
+            durability="sync",
         ):
             pass
 
         assert graph.astream_events_kwargs is not None
         assert graph.astream_events_kwargs["interrupt_before"] == ["agent"]
         assert graph.astream_events_kwargs["interrupt_after"] == ["tools"]
+        assert graph.astream_events_kwargs["durability"] == "sync"
 
     @pytest.mark.asyncio
     async def test_preserves_all_nodes_interrupt_sentinel(self) -> None:

--- a/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
+++ b/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
@@ -865,33 +865,32 @@ class TestDequeue:
         executor._poll_postgres.assert_not_awaited()
 
     @pytest.mark.asyncio
-    async def test_returns_none_when_blpop_returns_none(self) -> None:
+    async def test_idle_blpop_polls_pending_postgres_rows(self) -> None:
         blpop = AsyncMock(return_value=None)
         executor = self._make_executor_with_blpop(blpop)
 
         with patch(f"{MODULE}.redis_manager.get_client", return_value=self._client):
             result = await executor._dequeue()
 
-        assert result is None
-        executor._poll_postgres.assert_not_awaited()
+        assert result == "from-postgres"
+        executor._poll_postgres.assert_awaited_once_with(idempotent_only=True)
 
     @pytest.mark.asyncio
-    async def test_idle_socket_timeout_returns_none_without_fallback(self) -> None:
-        """A blocking BLPOP that hits the socket timeout raises redis TimeoutError
-        (a RedisError subclass). That is a normal idle expiry, not a connectivity
-        failure: it must return None silently, never poll Postgres (GH #bug)."""
+    async def test_idle_socket_timeout_polls_only_idempotent_rows(self) -> None:
         blpop = AsyncMock(side_effect=RedisTimeoutError("Timeout reading from redis:6379"))
         executor = self._make_executor_with_blpop(blpop)
 
         with (
             patch(f"{MODULE}.redis_manager.get_client", return_value=self._client),
+            patch(f"{MODULE}.asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
             patch(f"{MODULE}.logger.warning") as mock_warning,
         ):
             result = await executor._dequeue()
 
-        assert result is None
-        executor._poll_postgres.assert_not_awaited()
+        assert result == "from-postgres"
+        executor._poll_postgres.assert_awaited_once_with(idempotent_only=True)
         mock_warning.assert_not_called()
+        mock_sleep.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_connection_error_falls_back_to_postgres(self) -> None:
@@ -908,5 +907,5 @@ class TestDequeue:
             result = await executor._dequeue()
 
         assert result == "from-postgres"
-        executor._poll_postgres.assert_awaited_once()
+        executor._poll_postgres.assert_awaited_once_with()
         mock_warning.assert_called_once()

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.10.0"
+version = "0.10.1"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.10.0"
+version = "0.10.1"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -100,7 +100,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.10.0"
+version = "0.10.1"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
## Description

Add the smallest Agent Protocol delta needed by OpenSWE's production runtime:

- idempotent threaded background creation across ambiguous HTTP/Redis boundaries;
- ordered `multitask_strategy="interrupt"` admission without implementing the other strategy state machines; and
- explicit `durability="sync"` propagation through legacy and Agent Protocol v2 execution.

The three runtime changes are isolated commits. Omitted fields preserve current behavior. This adds no ORM model, table, migration, generic cancellation framework, or cross-retention replay mechanism.

## Type of Change

- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [x] `docs`: Documentation changes
- [ ] `style`: Code style/formatting
- [ ] `refactor`: Code refactoring
- [ ] `perf`: Performance improvement
- [x] `test`: Tests added/updated
- [ ] `chore`: Maintenance (dependencies, build, etc.)
- [ ] `ci`: CI/CD changes

## Related Issues

- Refs #501 — retry-safe run creation
- Refs #253 — implements only the `interrupt` behavior used by OpenSWE
- Refs #500 — implements only explicit per-run `sync`; server defaults, crons, `async`, and `exit` remain out of scope
- Related #462 — this deliberately does not compete with its full four-strategy/migration design

## Changes Made

- Accept `Idempotency-Key` only on `POST /threads/{thread_id}/runs`, derive a tenant/thread/key-scoped deterministic run ID, fingerprint the auth-adjusted request, serialize same-thread admission with a PostgreSQL advisory transaction lock, and return the existing run or `409` before mutable thread work.
- Recover the narrow commit-before-Redis-submit boundary by polling only pending rows carrying the idempotency fingerprint during healthy idle dequeue; the existing broad PostgreSQL fallback remains limited to Redis failures.
- For `multitask_strategy="interrupt"`, terminalize pending predecessors or require a running predecessor to reach a terminal PostgreSQL state before persisting the successor. Other existing strategy inputs retain their prior compatibility behavior.
- Persist and forward explicit `durability="sync"` through worker serialization, legacy graph streaming, and native v2 streaming. Omission does not send a durability kwarg.
- Bump both packages and the lock to `0.10.1`, document the contract, and regenerate OpenAPI.

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing performed

Validated locally:

- isolated first commit against migrated PostgreSQL: `1 passed`, including concurrent same-key creation, mismatch-without-thread-mutation, commit-before-submit recovery, ordinary-row exclusion, and resume replay after thread state changes;
- full API unit + integration CI selection against migrated PostgreSQL: `1803 passed`;
- unit suite: `1462 passed`;
- Ruff format/check, Bandit, lock/version consistency, OpenAPI regeneration/no-diff, and `git diff --check`: passed;
- local `make e2e-both` could not provision services because this noninteractive macOS session cannot access Docker's credential helper; no E2E test ran locally and all Compose/disposable resources were cleaned. The repository E2E workflow remains the decisive provisioned proof.

## Checklist

- [x] Code follows project style (Ruff formatting)
- [x] All linting checks pass (`make lint`)
- [ ] Type checking passes (`make type-check`) — current `main` reports pre-existing `ty` diagnostics; changed paths were narrowed so this PR adds no new durability/admission diagnostics
- [x] All tests pass (`make test` equivalent API selection; CLI is untouched except synchronized version)
- [x] Documentation updated (if needed)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] PR title follows Conventional Commits format

## Screenshots (if applicable)

Not applicable.

## Additional Notes

OpenSWE will carry the three v0.9.25 backports only until an Aegra release contains the required fixes. General lease fencing, generic durable cancellation, unsupported-field hardening, and indefinite/cross-retention SSE replay were intentionally removed from the production compatibility series.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added retry-safe background run submission with idempotency keys.
  - Duplicate submissions are safely recognized, while conflicting requests return an error.
  - Added optional synchronous durability for run execution and streaming.
  - Improved interrupt-based run replacement and recovery of interrupted or stalled runs.
  - Enhanced recovery of idempotent runs when queue polling is interrupted.
  - Added validation for idempotency keys and durability options.

- **Documentation**
  - Documented idempotency, conflict handling, interrupt behavior, and durability options.
  - Updated API documentation to version 0.10.1.

- **Chores**
  - Updated API and CLI package versions to 0.10.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds retry-safe threaded run admission, interrupt ordering, and explicit synchronous durability propagation.
- Scopes deterministic idempotency to authenticated users and threads, with request-fingerprint conflict detection and PostgreSQL-backed recovery.
- Serializes interrupt admission and waits for active predecessors to become terminal before persisting successors.
- Carries explicit `durability="sync"` through persisted run jobs and both legacy and native streaming paths.
- Updates CI database provisioning, documentation, OpenAPI, versions, and regression coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/services/run_preparation.py | Implements deterministic idempotent admission, fingerprint conflicts, serialized interrupt handling, and durability persistence. |
| libs/aegra-api/src/aegra_api/services/worker_executor.py | Adds idle-dequeue PostgreSQL recovery restricted to pending idempotent runs. |
| libs/aegra-api/src/aegra_api/services/graph_streaming.py | Conditionally forwards explicit synchronous durability while preserving omission behavior. |
| libs/aegra-api/src/aegra_api/services/event_streaming/native_stream.py | Propagates explicit durability through the native Agent Protocol streaming path. |
| libs/aegra-api/tests/unit/test_services/test_graph_streaming.py | Correctly annotates the previously reported async helper and verifies durability forwarding and omission. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant API as Runs API
    participant Prep as Run Preparation
    participant DB as PostgreSQL
    participant Redis
    participant Worker
    Client->>API: POST threaded run + optional Idempotency-Key
    API->>Prep: Auth-adjusted RunCreate
    Prep->>DB: Advisory transaction lock
    Prep->>DB: Check deterministic run ID and fingerprint
    alt Matching retry
        DB-->>Prep: Existing run
        Prep-->>Client: Original run
    else Conflicting retry
        Prep-->>Client: 409 Conflict
    else New request
        Prep->>DB: Resolve interrupt predecessors
        Prep->>DB: Persist pending run and execution parameters
        Prep->>Redis: Submit run ID
        Redis->>Worker: Dequeue run
        Worker->>DB: Claim run
        Worker->>Worker: "Execute with optional durability=sync"
        Worker->>DB: Persist terminal status
        Prep-->>Client: Pending run
    end
```
</details>

<sub>Reviews (3): Last reviewed commit: ["docs(api): regenerate OpenAPI contract"](https://github.com/aegra/aegra/commit/f4471bb40ae39158be9a9c7eb724b78202c28f66) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52346363)</sub>

<!-- /greptile_comment -->