### PR TITLE
fix(api): emit dual interrupt payload fields

### DIFF
--- a/docs/guides/streaming.mdx
+++ b/docs/guides/streaming.mdx
@@ -311,6 +311,26 @@ data: {"type":"event","seq":3,"event_id":"...:3","method":"lifecycle","params":{
 
 `values`, `updates`, `messages`, `tools`, `lifecycle`, `input`, `checkpoints`, `tasks`, and `custom` (plus `custom:<name>`). Message streams arrive as content-block events (`message-start` → `content-block-delta` → `message-finish`); lifecycle reports `started` / `completed` / `failed` / `interrupted`.
 
+### Human-in-the-loop interrupts
+
+When you subscribe to the `input` channel, a graph interrupt arrives as an `input.requested` event. Its `params.data` includes the interrupt id and two identical content fields:
+
+```json
+{
+  "method": "input.requested",
+  "params": {
+    "data": {
+      "interrupt_id": "interrupt-id",
+      "payload": {"question": "Approve?"},
+      "value": {"question": "Approve?"}
+    },
+    "namespace": []
+  }
+}
+```
+
+`payload` is the Agent Protocol field consumed by the JavaScript SDK and Vue/React `useStream()` integrations. `value` mirrors it for current Python SDKs, including `ts.interrupts[].value`. If the source interrupt has no value, both content fields are omitted; explicit `null`, empty, and falsy values are preserved under both fields.
+
 <Note>
   This first release covers the HTTP SSE + commands path the JS/Python SDKs use, verified end-to-end against the stock `langgraph-sdk`. The WebSocket transport and the `agent.getTree` / `state.fork` / `subscription.*` commands are not yet implemented; SSE filtering via the POST body covers the `useStream()` path without them.
 </Note>

--- a/docs/guides/streaming.mdx
+++ b/docs/guides/streaming.mdx
@@ -317,6 +317,9 @@ When you subscribe to the `input` channel, a graph interrupt arrives as an `inpu
 
 ```json
 {
+  "type": "event",
+  "seq": 4,
+  "event_id": "...:4",
   "method": "input.requested",
   "params": {
     "data": {

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.10.2"
+version = "0.10.3"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-api/src/aegra_api/services/event_streaming/normalizers.py
+++ b/libs/aegra-api/src/aegra_api/services/event_streaming/normalizers.py
@@ -67,11 +67,7 @@ def _as_values(value: Any) -> Any:
 
 
 def normalize_input_requested(payload: Any) -> list[dict[str, Any]]:
-    """Project interrupt entries into ``{interrupt_id, value?}`` requests.
-
-    ``value`` (not ``payload``) is the SDK's ``InterruptPayload`` field — it is
-    what ``thread.interrupts[].value`` surfaces to the client.
-    """
+    """Project interrupts with protocol ``payload`` and Python-SDK ``value`` fields."""
     requests: list[dict[str, Any]] = []
     for entry in _interrupt_array(payload):
         if not isinstance(entry, dict) or not isinstance(entry.get("id"), str):
@@ -79,6 +75,7 @@ def normalize_input_requested(payload: Any) -> list[dict[str, Any]]:
         request: dict[str, Any] = {"interrupt_id": entry["id"]}
         if "value" in entry:
             request["value"] = entry["value"]
+            request["payload"] = entry["value"]
         requests.append(request)
     return requests
 

--- a/libs/aegra-api/tests/e2e/test_event_streaming/test_sdk_v2_e2e.py
+++ b/libs/aegra-api/tests/e2e/test_event_streaming/test_sdk_v2_e2e.py
@@ -10,10 +10,12 @@ Uses the ``stress_test`` graph (no LLM) so the run is hermetic.
 
 import asyncio
 import json
+from typing import Any
 
 import httpx
 import pytest
 from langgraph_sdk import get_client
+from langgraph_sdk._async.stream import AsyncThreadStream, InterruptPayload
 
 from aegra_api.settings import settings
 from tests.e2e._utils import elog
@@ -180,7 +182,8 @@ async def test_sdk_hitl_interrupt_surfaces_on_input_channel_and_resumes() -> Non
     assistant_id = await _ensure_graph("agent_hitl")
     client = get_client(url=_base_url())
 
-    input_requested: list[dict] = []
+    input_requested: list[dict[str, Any]] = []
+    sdk_interrupt: InterruptPayload | None = None
     resumed = False
     lifecycle_after_resume: list[str] = []
     async with client.threads.stream(assistant_id=assistant_id) as ts:
@@ -197,7 +200,7 @@ async def test_sdk_hitl_interrupt_surfaces_on_input_channel_and_resumes() -> Non
                 # Resume on the SAME open stream — the SDK does not reopen it.
                 # Proves the session keeps the stream alive across the run gap
                 # and that resume works without re-supplying an assistant.
-                await _resume_via_sdk(ts, data["interrupt_id"])
+                sdk_interrupt = await _resume_via_sdk(ts, data["interrupt_id"], {"action": "approve"})
                 resumed = True
                 continue
             if resumed and method == "lifecycle":
@@ -209,8 +212,9 @@ async def test_sdk_hitl_interrupt_surfaces_on_input_channel_and_resumes() -> Non
     elog("hitl lifecycle after resume", lifecycle_after_resume)
     assert input_requested, "interrupt did not surface on the input channel"
     assert isinstance(input_requested[0].get("interrupt_id"), str)
-    # value (not payload) is the SDK's InterruptPayload field.
-    assert "value" in input_requested[0], "interrupt value missing from input.requested"
+    assert input_requested[0]["payload"] == input_requested[0]["value"]
+    assert sdk_interrupt is not None
+    assert sdk_interrupt["value"] == input_requested[0]["value"]
     assert "completed" in lifecycle_after_resume, (
         f"resume did not run to completion on the same stream; got {lifecycle_after_resume}"
     )
@@ -387,17 +391,19 @@ async def test_sdk_subgraph_emits_nested_lifecycle_events() -> None:
     assert root_terminal == ["completed"], f"run did not reach root completed; got {root_terminal}"
 
 
-async def _resume_via_sdk(ts: object, interrupt_id: str, response: object = {"action": "approve"}) -> None:  # noqa: B006
+async def _resume_via_sdk(ts: AsyncThreadStream, interrupt_id: str, response: object) -> InterruptPayload:
     """Call ``ts.run.respond`` once the SDK's lifecycle watcher has registered the
     interrupt. The watcher runs on a separate SSE, so the main stream can surface
     ``input.requested`` a beat before ``ts.interrupts`` is populated."""
     for _ in range(50):
-        if any(p.get("interrupt_id") == interrupt_id for p in ts.interrupts):  # type: ignore[attr-defined]
+        interrupt = next((payload for payload in ts.interrupts if payload.get("interrupt_id") == interrupt_id), None)
+        if interrupt is not None:
             break
         await asyncio.sleep(0.1)
     else:
-        raise AssertionError(f"SDK never registered interrupt {interrupt_id}: {ts.interrupts!r}")  # type: ignore[attr-defined]
-    await ts.run.respond(response, interrupt_id=interrupt_id)  # type: ignore[attr-defined]
+        raise AssertionError(f"SDK never registered interrupt {interrupt_id}: {ts.interrupts!r}")
+    await ts.run.respond(response, interrupt_id=interrupt_id)
+    return interrupt
 
 
 @pytest.mark.e2e

--- a/libs/aegra-api/tests/integration/test_api/test_event_streaming.py
+++ b/libs/aegra-api/tests/integration/test_api/test_event_streaming.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import uuid
 from collections.abc import Iterator
+from functools import partial
 from typing import Any
 
 import pytest
@@ -14,9 +16,11 @@ from fastapi.testclient import TestClient
 from aegra_api.api import event_streaming as es_module
 from aegra_api.core.auth_deps import get_current_user, require_auth
 from aegra_api.models.auth import User
+from aegra_api.models.event_streaming import EventStreamRequest
 from aegra_api.services.broker import broker_manager
 from aegra_api.services.event_streaming import capabilities as caps
 from aegra_api.services.event_streaming import commands as cmd_module
+from aegra_api.services.event_streaming.session import ThreadEventSession
 
 _USER = "test-user"
 
@@ -175,3 +179,51 @@ class TestStreamRoute:
         assert "content-block-delta" in body
         assert "event: lifecycle" in body
         assert "completed" in body
+
+    async def test_stream_emits_dual_sdk_interrupt_fields(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        run_id = f"run-{uuid.uuid4().hex[:8]}"
+        interrupt_value = {"question": "Approve?"}
+
+        async def seed() -> None:
+            broker = broker_manager.get_or_create_broker(run_id)
+            event = {
+                "type": "event",
+                "method": "updates",
+                "params": {
+                    "namespace": [],
+                    "data": {"__interrupt__": [{"id": "int-1", "value": interrupt_value}]},
+                },
+            }
+            await broker.put(f"{run_id}_event_1", ("updates", event))
+            await broker.put(f"{run_id}_event_2", ("end", {"status": "interrupted"}))
+
+        await seed()
+        monkeypatch.setattr(
+            es_module,
+            "ThreadEventSession",
+            partial(ThreadEventSession, idle_grace_seconds=0.01),
+        )
+        monkeypatch.setattr(
+            es_module,
+            "_get_session_maker",
+            lambda: lambda: _Session(owner=_USER, run_ids=[run_id]),
+        )
+        response = await es_module.stream_thread_events(
+            "t1",
+            EventStreamRequest(channels=["input"], namespaces=None, depth=None, since=None),
+            User(identity=_USER),
+        )
+        chunks: list[str] = []
+        async for chunk in response.body_iterator:
+            assert isinstance(chunk, (bytes, str))
+            chunks.append(chunk.decode() if isinstance(chunk, bytes) else chunk)
+        body = "".join(chunks)
+
+        input_frame = next(frame for frame in body.split("\n\n") if frame.startswith("event: input.requested"))
+        data_line = next(line for line in input_frame.splitlines() if line.startswith("data: "))
+        envelope = json.loads(data_line.removeprefix("data: "))
+        assert envelope["params"]["data"] == {
+            "interrupt_id": "int-1",
+            "value": interrupt_value,
+            "payload": interrupt_value,
+        }

--- a/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_normalizers.py
+++ b/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_normalizers.py
@@ -43,9 +43,22 @@ class TestNormalizeUpdates:
 class TestNormalizeInputRequested:
     def test_interrupt_entry_to_request(self) -> None:
         entries = [{"id": "int-1", "value": {"question": "ok?"}}]
-        assert normalize_input_requested(entries) == [{"interrupt_id": "int-1", "value": {"question": "ok?"}}]
+        assert normalize_input_requested(entries) == [
+            {"interrupt_id": "int-1", "value": {"question": "ok?"}, "payload": {"question": "ok?"}}
+        ]
 
-    def test_entry_without_value_omits_value(self) -> None:
+    def test_explicit_none_is_preserved_in_both_fields(self) -> None:
+        entries = [{"id": "int-none", "value": None}]
+        assert normalize_input_requested(entries) == [{"interrupt_id": "int-none", "value": None, "payload": None}]
+
+    def test_falsy_values_are_preserved_in_both_fields(self) -> None:
+        for value in (False, 0, "", []):
+            entries = [{"id": "int-falsy", "value": value}]
+            assert normalize_input_requested(entries) == [
+                {"interrupt_id": "int-falsy", "value": value, "payload": value}
+            ]
+
+    def test_entry_without_value_omits_content_fields(self) -> None:
         assert normalize_input_requested([{"id": "int-2"}]) == [{"interrupt_id": "int-2"}]
 
     def test_entry_without_string_id_skipped(self) -> None:
@@ -53,7 +66,7 @@ class TestNormalizeInputRequested:
 
     def test_dunder_interrupt_wrapper_accepted(self) -> None:
         wrapped = {"__interrupt__": [{"id": "int-3", "value": "v"}]}
-        assert normalize_input_requested(wrapped) == [{"interrupt_id": "int-3", "value": "v"}]
+        assert normalize_input_requested(wrapped) == [{"interrupt_id": "int-3", "value": "v", "payload": "v"}]
 
     def test_non_interrupt_value_yields_nothing(self) -> None:
         assert normalize_input_requested({"messages": []}) == []
@@ -63,7 +76,7 @@ class TestStripInterrupts:
     def test_separates_interrupt_from_values(self) -> None:
         payload = {"messages": [], "__interrupt__": [{"id": "int-1", "value": "v"}]}
         requests, cleaned = strip_interrupts(payload)
-        assert requests == [{"interrupt_id": "int-1", "value": "v"}]
+        assert requests == [{"interrupt_id": "int-1", "value": "v", "payload": "v"}]
         assert cleaned == {"messages": []}
         assert "__interrupt__" not in cleaned
 

--- a/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_session.py
+++ b/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_session.py
@@ -147,7 +147,11 @@ class TestForwarding:
         )
         events = await _collect(_make_session("t1", channels={"input", "updates"}, run_ids=("run-1",)))
         input_events = [e for e in events if e["method"] == "input.requested"]
-        assert input_events[0]["params"]["data"] == {"interrupt_id": "int-9", "value": {"q": "ok?"}}
+        assert input_events[0]["params"]["data"] == {
+            "interrupt_id": "int-9",
+            "value": {"q": "ok?"},
+            "payload": {"q": "ok?"},
+        }
         assert not [e for e in events if e["method"] == "updates"]
 
 
@@ -233,7 +237,11 @@ class TestInterruptsToInputChannel:
         events = await _collect(_make_session("t1", channels={"input", "values"}, run_ids=("run-1",)))
         input_events = [e for e in events if e["method"] == "input.requested"]
         assert input_events
-        assert input_events[0]["params"]["data"] == {"interrupt_id": "int-1", "value": interrupt_payload}
+        assert input_events[0]["params"]["data"] == {
+            "interrupt_id": "int-1",
+            "value": interrupt_payload,
+            "payload": interrupt_payload,
+        }
 
     async def test_interrupt_stripped_from_values_payload(self, manager: BrokerManager) -> None:
         """__interrupt__ never leaks into the forwarded values data."""
@@ -377,7 +385,10 @@ class TestResumeAcrossRuns:
         await asyncio.wait_for(seeder, timeout=1.0)
 
         methods = [(e["method"], e["params"]["data"]) for e in events]
-        assert ("input.requested", {"interrupt_id": "int-1", "value": {"q": "ok?"}}) in methods
+        assert (
+            "input.requested",
+            {"interrupt_id": "int-1", "value": {"q": "ok?"}, "payload": {"q": "ok?"}},
+        ) in methods
         # run-b's completion proves the stream stayed open across the run gap.
         assert any(e["method"] == "lifecycle" and e["params"]["data"] == {"event": "completed"} for e in events)
 

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.10.2"
+version = "0.10.3"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.10.2"
+version = "0.10.3"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -100,7 +100,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.10.2"
+version = "0.10.3"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
## Description
Emit both `payload` and `value` in Protocol v2 `input.requested` events. This preserves the current Python SDK interrupt representation while restoring JavaScript SDK and React compatibility.

## Type of Change
- [x] `fix`: Bug fix
- [x] `docs`: Documentation changes
- [x] `test`: Tests added/updated

## Related Issues
Fixes #491

## Changes Made
- Add the protocol/JavaScript-facing `payload` field alongside the Python SDK-facing `value` field.
- Preserve validation and handling of missing, null, empty, and falsy interrupt values.
- Add normalizer, session projection, SSE route, and live Python SDK HITL regression coverage.
- Document the dual-field `input.requested` wire contract in the streaming guide.
- Bump `aegra-api`, `aegra-cli`, and the lockfile together from `0.10.0` to `0.10.1`.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] E2E tests added/updated
- [ ] Manual testing performed

Results:
- Targeted unit/session/integration suite: 80 passed
- LocalExecutor E2E suite: 117 passed, 3 skipped
- Python SDK HITL E2E: passed with LocalExecutor and WorkerExecutor
- Ruff and targeted type checks: passed
- `uv lock --check`: passed

## Checklist
- [x] Code follows project style (Ruff formatting)
- [x] All linting checks pass (`make lint`)
- [ ] Type checking passes (`make type-check`)
- [ ] All tests pass (`make test`)
- [x] Documentation updated
- [x] Package versions updated together
- [x] Commit messages follow the repository `[component] Brief description` format
- [x] PR title follows the repository `[component] Brief description` format

## Screenshots (if applicable)
Not applicable.

## Additional Notes
Repository-wide type checking has pre-existing diagnostics. `make ci-check` completed formatting, linting, and security checks, but its broad test phase invokes E2E tests without provisioning their required services in this local environment. No dependency constraints, resume commands, thread-state representation, or Node tooling were changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `input.requested` events now include a `payload` field alongside `value`, providing complete interrupt details.
  * Resume workflows return and validate interrupt responses for more reliable approval handling.

* **Bug Fixes**
  * Preserved interrupt payload data across streaming, session handling, and cross-run resume flows.
  * Improved handling for empty, falsy, and wrapped interrupt values.

* **Documentation**
  * Added guidance for handling human-in-the-loop interrupts over SSE, including payload formats and value behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR restores JavaScript and React compatibility by emitting identical `payload` and `value` fields for Protocol v2 `input.requested` events while preserving Python SDK behavior.

- Documents the dual-field wire contract and missing, null, empty, and falsy-value semantics.
- Adds unit, session, integration, and live SDK regression coverage.
- Coordinates the patch release across `aegra-api`, `aegra-cli`, and `uv.lock`.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/services/event_streaming/normalizers.py | Mirrors each present interrupt `value` into the protocol-facing `payload` field while preserving absent and falsy-value semantics. |
| docs/guides/streaming.mdx | Accurately documents the dual-field `input.requested` wire contract and edge-case behavior. |
| libs/aegra-api/tests/e2e/test_event_streaming/test_sdk_v2_e2e.py | Verifies that the live Python SDK retains its interrupt value and can resume on the same stream. |
| libs/aegra-api/tests/integration/test_api/test_event_streaming.py | Verifies the serialized SSE envelope contains identical `payload` and `value` fields. |
| libs/aegra-api/pyproject.toml | Applies the coordinated API package patch-version bump to 0.10.3. |
| libs/aegra-cli/pyproject.toml | Keeps the CLI package version synchronized with the API package at 0.10.3. |
| uv.lock | Synchronizes the two local editable package versions without changing third-party dependency versions. |

</details>

<sub>Reviews (4): Last reviewed commit: ["docs(streaming): show complete interrupt..."](https://github.com/aegra/aegra/commit/3485183bebff1667195f0ff1a7f6a27296577186) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52622615)</sub>

**Context used:**

- Knowledge Base — [Streaming: from LangGraph execution to SSE wire events](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/streaming.md)

<!-- /greptile_comment -->