### PR TITLE
fix: Windows event loop, cron 500 on missing input, store namespace auth dispatch

### DIFF
--- a/docs/guides/cron.mdx
+++ b/docs/guides/cron.mdx
@@ -54,6 +54,8 @@ asyncio.run(main())
 
 Aegra accepts the graph ID directly in `assistant_id` for cron creation and resolves it to the default assistant for that graph at request time.
 
+`input` is required: every firing starts a run built from the cron payload, so a request without `input` is rejected with a 422. Pass `input={}` for graphs that need no input.
+
 By default, each stateless cron run deletes its ephemeral thread after the run completes, including the immediate first run that is triggered when the cron is created.
 
 <Note>

--- a/docs/installation.mdx
+++ b/docs/installation.mdx
@@ -65,7 +65,7 @@ Docker is required for local development (`aegra dev` starts a PostgreSQL contai
 
 ### Windows
 
-`aegra dev` and `aegra up` work on Windows. However, `aegra serve` (production mode without Docker) is not supported on Windows because psycopg requires `SelectorEventLoop` while Windows defaults to `ProactorEventLoop`. For production deployments, use Docker or a Linux server.
+`aegra dev`, `aegra up`, and `aegra serve` work on Windows. The CLI passes uvicorn a `SelectorEventLoop` factory on Windows, since psycopg cannot connect on the `ProactorEventLoop` that uvicorn otherwise defaults to without `--reload`. For production deployments we still recommend Docker or a Linux server.
 
 ## Project structure
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Aegra",
     "description": "Production-ready Agent Protocol server",
-    "version": "0.10.0"
+    "version": "0.10.2"
   },
   "paths": {
     "/info": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Aegra",
     "description": "Production-ready Agent Protocol server",
-    "version": "0.10.1"
+    "version": "0.10.0"
   },
   "paths": {
     "/info": {
@@ -3771,15 +3771,8 @@
             "title": "Schedule"
           },
           "input": {
-            "anyOf": [
-              {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "additionalProperties": true,
+            "type": "object",
             "title": "Input"
           },
           "metadata": {
@@ -3960,7 +3953,8 @@
         "type": "object",
         "required": [
           "assistant_id",
-          "schedule"
+          "schedule",
+          "input"
         ],
         "title": "CronCreate",
         "description": "Request body for creating a cron job (stateless or thread-bound)."

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.10.1"
+version = "0.10.2"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -19,7 +19,8 @@ classifiers = [
 dependencies = [
     # Core
     "fastapi>=0.110.1",
-    "uvicorn>=0.35.0",
+    # >=0.36.0: --loop accepts import strings (Windows selector loop, #513)
+    "uvicorn>=0.36.0",
     "pydantic>=2.11.7",
     "pydantic-settings>=2.14.2",
     "sse-starlette>=3.3.4,<4.0.0",

--- a/libs/aegra-api/src/aegra_api/api/store.py
+++ b/libs/aegra-api/src/aegra_api/api/store.py
@@ -72,20 +72,23 @@ async def get_store_item(
 
     Returns 404 if no item exists at the given namespace and key.
     """
-    # Authorization check
+    # Normalize before dispatch: handlers must see the parsed list, not the
+    # raw dot-string query form, or they judge a different namespace than
+    # the one PUT/DELETE dispatched (#515).
     ctx = build_auth_context(user, "store", "get")
-    value = {"key": key, "namespace": namespace}
+    namespace_list = _normalize_namespace(namespace)
+    value = {"key": key, "namespace": namespace_list}
     filters = await handle_event(ctx, value)
 
     # If handler modified namespace/key, update
     if filters:
         if "namespace" in filters:
-            namespace = filters["namespace"]
+            namespace_list = _normalize_namespace(filters["namespace"])
         if "key" in filters:
             key = filters["key"]
 
     # Apply user namespace scoping
-    scoped_namespace = apply_namespace_scoping(_normalize_namespace(namespace), user)
+    scoped_namespace = apply_namespace_scoping(namespace_list, user)
 
     store = db_manager.get_store()
 
@@ -233,12 +236,17 @@ async def list_namespaces(
 
 
 def _normalize_namespace(value: str | list[str] | None) -> list[str]:
-    """Normalize namespace input to a clean list, filtering out empty parts."""
+    """Normalize namespace input to a clean list, filtering out empty parts.
+
+    Splits dots inside list items too: FastAPI may coerce a single
+    ``?namespace=a.b`` into ``["a.b"]`` depending on version, and the query
+    interface documents the dot as a separator.
+    """
     if isinstance(value, str):
-        return [part for part in value.split(".") if part]
-    if isinstance(value, list):
-        return [part for part in value if part]
-    return []
+        value = [value]
+    if not isinstance(value, list):
+        return []
+    return [part for item in value if isinstance(item, str) for part in item.split(".") if part]
 
 
 def _scope(prefix: str, scope_ids: list[str], namespace: list[str]) -> list[str]:

--- a/libs/aegra-api/src/aegra_api/api/store.py
+++ b/libs/aegra-api/src/aegra_api/api/store.py
@@ -72,9 +72,8 @@ async def get_store_item(
 
     Returns 404 if no item exists at the given namespace and key.
     """
-    # Normalize before dispatch: handlers must see the parsed list, not the
-    # raw dot-string query form, or they judge a different namespace than
-    # the one PUT/DELETE dispatched (#515).
+    # Handlers must see the parsed list; the raw dot-string form judges a
+    # different namespace than PUT/DELETE dispatched (#515).
     ctx = build_auth_context(user, "store", "get")
     namespace_list = _normalize_namespace(namespace)
     value = {"key": key, "namespace": namespace_list}
@@ -238,9 +237,8 @@ async def list_namespaces(
 def _normalize_namespace(value: str | list[str] | None) -> list[str]:
     """Normalize namespace input to a clean list, filtering out empty parts.
 
-    Splits dots inside list items too: FastAPI may coerce a single
-    ``?namespace=a.b`` into ``["a.b"]`` depending on version, and the query
-    interface documents the dot as a separator.
+    Dots split inside list items too: FastAPI may coerce ``?namespace=a.b``
+    into ``["a.b"]`` depending on version.
     """
     if isinstance(value, str):
         value = [value]

--- a/libs/aegra-api/src/aegra_api/models/crons.py
+++ b/libs/aegra-api/src/aegra_api/models/crons.py
@@ -67,6 +67,10 @@ class CronCreate(BaseModel):
 
     @model_validator(mode="after")
     def _check(self) -> "CronCreate":
+        # Every firing builds a RunCreate from this payload, and RunCreate
+        # rejects an empty one — fail at the API boundary instead (#514).
+        if self.input is None:
+            raise ValueError("Field 'input' is required: each cron firing starts a run from it")
         self.webhook = _validate_webhook_url(self.webhook)
         if isinstance(self.stream_mode, str) and len(self.stream_mode) > _STREAM_MODE_MAX_LEN:
             raise ValueError("stream_mode is too long")

--- a/libs/aegra-api/src/aegra_api/models/crons.py
+++ b/libs/aegra-api/src/aegra_api/models/crons.py
@@ -47,7 +47,9 @@ class CronCreate(BaseModel):
 
     assistant_id: str = Field(..., max_length=_STR_FIELD_MAX_LEN)
     schedule: str = Field(..., max_length=_SCHEDULE_MAX_LEN)
-    input: dict[str, Any] | None = None
+    # Required: every firing builds a RunCreate from this payload, and
+    # RunCreate rejects an empty input — fail at the API boundary (#514).
+    input: dict[str, Any]
     metadata: dict[str, Any] | None = None
     config: dict[str, Any] | None = None
     context: dict[str, Any] | None = None
@@ -67,10 +69,6 @@ class CronCreate(BaseModel):
 
     @model_validator(mode="after")
     def _check(self) -> "CronCreate":
-        # Every firing builds a RunCreate from this payload, and RunCreate
-        # rejects an empty one — fail at the API boundary instead (#514).
-        if self.input is None:
-            raise ValueError("Field 'input' is required: each cron firing starts a run from it")
         self.webhook = _validate_webhook_url(self.webhook)
         if isinstance(self.stream_mode, str) and len(self.stream_mode) > _STREAM_MODE_MAX_LEN:
             raise ValueError("stream_mode is too long")

--- a/libs/aegra-api/src/aegra_api/utils/event_loop.py
+++ b/libs/aegra-api/src/aegra_api/utils/event_loop.py
@@ -4,10 +4,9 @@ import asyncio
 
 
 def selector_loop_factory() -> asyncio.AbstractEventLoop:
-    """Selector event loop, importable via ``--loop aegra_api.utils.event_loop:selector_loop_factory``.
+    """Selector event loop for uvicorn ``--loop``; works on every platform.
 
-    Windows uvicorn defaults to the Proactor loop when run without --reload,
-    and the LangGraph psycopg pool cannot connect on it (#513). The selector
-    loop works on every platform.
+    Windows uvicorn defaults to the Proactor loop without --reload, and the
+    LangGraph psycopg pool cannot connect on it (#513).
     """
     return asyncio.SelectorEventLoop()

--- a/libs/aegra-api/src/aegra_api/utils/event_loop.py
+++ b/libs/aegra-api/src/aegra_api/utils/event_loop.py
@@ -1,0 +1,13 @@
+"""Event loop factory for uvicorn's ``--loop`` option."""
+
+import asyncio
+
+
+def selector_loop_factory() -> asyncio.AbstractEventLoop:
+    """Selector event loop, importable via ``--loop aegra_api.utils.event_loop:selector_loop_factory``.
+
+    Windows uvicorn defaults to the Proactor loop when run without --reload,
+    and the LangGraph psycopg pool cannot connect on it (#513). The selector
+    loop works on every platform.
+    """
+    return asyncio.SelectorEventLoop()

--- a/libs/aegra-api/tests/integration/test_api/test_crons_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_crons_crud.py
@@ -349,7 +349,7 @@ class TestCreateCronExtended:
         )
         assert resp.status_code == 422
 
-    def test_missing_input_returns_422_not_500(self, client, mock_cron_service: AsyncMock) -> None:
+    def test_missing_input_returns_422_not_500(self, client: TestClient, mock_cron_service: AsyncMock) -> None:
         """Regression for #514: this body used to pass route validation and
         blow up as a 500 when the first firing built its RunCreate."""
         resp = client.post(

--- a/libs/aegra-api/tests/integration/test_api/test_crons_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_crons_crud.py
@@ -101,6 +101,7 @@ class TestCreateCron:
         resp = client.post(
             "/runs/crons",
             json={
+                "input": {"q": 1},
                 "assistant_id": "asst-001",
                 "schedule": "*/5 * * * *",
             },
@@ -117,6 +118,7 @@ class TestCreateCron:
         resp = client.post(
             "/runs/crons",
             json={
+                "input": {"q": 1},
                 "assistant_id": "asst-001",
                 "schedule": "0 * * * *",
                 "metadata": {"env": "prod"},
@@ -139,6 +141,7 @@ class TestCreateCronForThread:
         resp = client.post(
             "/threads/thread-001/runs/crons",
             json={
+                "input": {"q": 1},
                 "assistant_id": "asst-001",
                 "schedule": "*/10 * * * *",
             },
@@ -165,7 +168,7 @@ class TestUpdateCron:
 
         resp = client.patch(
             "/runs/crons/cron-001",
-            json={"schedule": "*/10 * * * *"},
+            json={"input": {"q": 1}, "schedule": "*/10 * * * *"},
         )
 
         assert resp.status_code == 200
@@ -335,7 +338,7 @@ class TestCreateCronExtended:
     def test_missing_assistant_id_returns_422(self, client, mock_cron_service: AsyncMock) -> None:
         resp = client.post(
             "/runs/crons",
-            json={"schedule": "*/5 * * * *"},
+            json={"input": {"q": 1}, "schedule": "*/5 * * * *"},
         )
         assert resp.status_code == 422
 
@@ -346,12 +349,22 @@ class TestCreateCronExtended:
         )
         assert resp.status_code == 422
 
+    def test_missing_input_returns_422_not_500(self, client, mock_cron_service: AsyncMock) -> None:
+        """Regression for #514: this body used to pass route validation and
+        blow up as a 500 when the first firing built its RunCreate."""
+        resp = client.post(
+            "/runs/crons",
+            json={"assistant_id": "asst-001", "schedule": "*/5 * * * *"},
+        )
+        assert resp.status_code == 422
+        assert "input" in resp.text
+
     def test_service_422_propagates(self, client, mock_cron_service: AsyncMock) -> None:
         mock_cron_service.create_cron.side_effect = HTTPException(422, "Invalid cron schedule: bad")
 
         resp = client.post(
             "/runs/crons",
-            json={"assistant_id": "asst-001", "schedule": "bad"},
+            json={"input": {"q": 1}, "assistant_id": "asst-001", "schedule": "bad"},
         )
         assert resp.status_code == 422
 
@@ -360,7 +373,7 @@ class TestCreateCronExtended:
 
         resp = client.post(
             "/runs/crons",
-            json={"assistant_id": "missing", "schedule": "*/5 * * * *"},
+            json={"input": {"q": 1}, "assistant_id": "missing", "schedule": "*/5 * * * *"},
         )
         assert resp.status_code == 404
 
@@ -402,7 +415,7 @@ class TestCreateCronForThreadOwnership:
             test_client = make_client(app)
             resp = test_client.post(
                 "/threads/victim-thread/runs/crons",
-                json={"assistant_id": "asst-001", "schedule": "*/5 * * * *"},
+                json={"input": {"q": 1}, "assistant_id": "asst-001", "schedule": "*/5 * * * *"},
             )
 
         assert resp.status_code == 404
@@ -433,7 +446,7 @@ class TestCreateCronForThreadOwnership:
             test_client = make_client(app)
             resp = test_client.post(
                 "/threads/ghost-thread/runs/crons",
-                json={"assistant_id": "asst-001", "schedule": "*/5 * * * *"},
+                json={"input": {"q": 1}, "assistant_id": "asst-001", "schedule": "*/5 * * * *"},
             )
 
         assert resp.status_code == 404
@@ -449,6 +462,7 @@ class TestCreateCronForThreadExtended:
         resp = client.post(
             "/threads/t-001/runs/crons",
             json={
+                "input": {"q": 1},
                 "assistant_id": "asst-001",
                 "schedule": "0 * * * *",
                 "metadata": {"team": "backend"},
@@ -479,6 +493,7 @@ class TestUpdateCronExtended:
         resp = client.patch(
             "/runs/crons/cron-001",
             json={
+                "input": {"q": 1},
                 "schedule": "0 12 * * *",
                 "enabled": False,
                 "on_run_completed": "keep",
@@ -606,6 +621,7 @@ class TestTimezoneField:
         resp = client.post(
             "/runs/crons",
             json={
+                "input": {"q": 1},
                 "assistant_id": "asst-001",
                 "schedule": "0 9 * * *",
                 "timezone": "America/New_York",
@@ -623,6 +639,7 @@ class TestTimezoneField:
         resp = client.post(
             "/threads/t-001/runs/crons",
             json={
+                "input": {"q": 1},
                 "assistant_id": "asst-001",
                 "schedule": "0 9 * * *",
                 "timezone": "Europe/London",
@@ -652,7 +669,7 @@ class TestTimezoneField:
 
         resp = client.post(
             "/runs/crons",
-            json={"assistant_id": "asst-001", "schedule": "*/5 * * * *"},
+            json={"input": {"q": 1}, "assistant_id": "asst-001", "schedule": "*/5 * * * *"},
         )
 
         assert resp.status_code == 200

--- a/libs/aegra-api/tests/integration/test_auth_enforcement_routes.py
+++ b/libs/aegra-api/tests/integration/test_auth_enforcement_routes.py
@@ -26,6 +26,7 @@ from aegra_api.core.auth_enforcement import (
     build_auth_enforcer,
     reset_dispatch_state,
 )
+from aegra_api.core.database import db_manager
 from aegra_api.models.auth import User
 from tests.fixtures.session_fixtures import ThreadSession, override_session_dependency
 
@@ -268,6 +269,37 @@ def test_store_get_handler_receives_parsed_namespace(monkeypatch: pytest.MonkeyP
         client.get("/store/items", params=[("key", "k"), ("namespace", "a"), ("namespace", "b")])
 
     assert seen == [["a", "b"], ["a", "b"]], f"handler saw {seen}; both query forms must dispatch the parsed list"
+
+
+def test_store_get_normalizes_handler_returned_namespace(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A namespace the handler returns as a filter is normalized before scoping.
+
+    Handlers may redirect the lookup with {"namespace": "other.place"}; the
+    store must see the split list under the user scope, not the raw string.
+    """
+    auth = Auth()
+
+    @auth.on.store
+    async def redirect(ctx: Any, value: Any) -> dict[str, Any]:
+        return {"namespace": "other.place"}
+
+    app = _build_app(auth, monkeypatch)
+    seen: list[tuple[str, ...]] = []
+
+    class _RecordingStore:
+        async def aget(self, namespace: tuple[str, ...], key: str) -> None:
+            seen.append(namespace)
+            return None
+
+    monkeypatch.setattr(db_manager, "get_store", lambda: _RecordingStore())
+
+    with TestClient(app) as client:
+        response = client.get("/store/items", params={"key": "k", "namespace": "a.b"})
+
+    assert response.status_code == 404, response.text
+    assert seen == [("users", "test-user", "other", "place")], (
+        f"store received {seen}; the handler-returned dot-string must be normalized before scoping"
+    )
 
 
 def test_store_delete_handler_receives_namespace_and_key(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/libs/aegra-api/tests/integration/test_auth_enforcement_routes.py
+++ b/libs/aegra-api/tests/integration/test_auth_enforcement_routes.py
@@ -239,11 +239,35 @@ def test_cron_create_authorizes_every_layer_of_its_chain(monkeypatch: pytest.Mon
     # Stateless cron create: no thread row needed, and it still walks the full
     # crons.create -> assistants.read -> threads.search chain.
     with TestClient(app, raise_server_exceptions=False) as client:
-        client.post("/runs/crons", json={"assistant_id": "agent", "schedule": "0 0 * * *"})
+        client.post("/runs/crons", json={"assistant_id": "agent", "schedule": "0 0 * * *", "input": {"q": 1}})
 
     assert ("crons", "create") in seen
     assert ("assistants", "read") in seen, "cron create stopped authorizing the assistant"
     assert ("threads", "search") in seen, "cron create stopped authorizing the thread layer"
+
+
+def test_store_get_handler_receives_parsed_namespace(monkeypatch: pytest.MonkeyPatch) -> None:
+    """GET must dispatch the parsed namespace list, not the raw dot-string.
+
+    Regression for #515: a handler comparing namespace[0] to the user judged
+    ["a.b"] on GET but ["a", "b"] on PUT, denying reads of items it allowed
+    writing.
+    """
+    auth = Auth()
+    seen: list[Any] = []
+
+    @auth.on.store
+    async def record(ctx: Any, value: Any) -> bool:
+        seen.append(value.get("namespace"))
+        return False
+
+    app = _build_app(auth, monkeypatch)
+
+    with TestClient(app) as client:
+        client.get("/store/items", params={"key": "k", "namespace": "a.b"})
+        client.get("/store/items", params=[("key", "k"), ("namespace", "a"), ("namespace", "b")])
+
+    assert seen == [["a", "b"], ["a", "b"]], f"handler saw {seen}; both query forms must dispatch the parsed list"
 
 
 def test_store_delete_handler_receives_namespace_and_key(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/libs/aegra-api/tests/unit/test_api/test_crons.py
+++ b/libs/aegra-api/tests/unit/test_api/test_crons.py
@@ -147,7 +147,7 @@ class TestAuthorizeCronCreate:
 
     @pytest.fixture
     def request_body(self) -> CronCreate:
-        return CronCreate(assistant_id="agent-1", schedule="*/5 * * * *")
+        return CronCreate(input={"q": 1}, assistant_id="agent-1", schedule="*/5 * * * *")
 
     @pytest.mark.asyncio
     async def test_stateless_create_fires_full_chain(self, user: User, request_body: CronCreate) -> None:

--- a/libs/aegra-api/tests/unit/test_core/test_redis_manager.py
+++ b/libs/aegra-api/tests/unit/test_core/test_redis_manager.py
@@ -46,11 +46,15 @@ class TestRedisManager:
         PING — must carry a retry that covers ConnectionError, plus a
         health-check interval. Non-default settings prove the values come
         from RedisSettings rather than literals.
-        """
-        from aegra_api.settings import settings
 
-        monkeypatch.setattr(settings.redis, "REDIS_HEALTH_CHECK_INTERVAL", 45)
-        monkeypatch.setattr(settings.redis, "REDIS_RETRY_ATTEMPTS", 5)
+        Patch through the module's own settings reference: a sibling test
+        reloads aegra_api.settings, so the freshly imported object can differ
+        from the one redis_manager holds.
+        """
+        from aegra_api.core import redis_manager as redis_manager_module
+
+        monkeypatch.setattr(redis_manager_module.settings.redis, "REDIS_HEALTH_CHECK_INTERVAL", 45)
+        monkeypatch.setattr(redis_manager_module.settings.redis, "REDIS_RETRY_ATTEMPTS", 5)
         manager = RedisManager()
         mock_client = AsyncMock()
 
@@ -76,10 +80,10 @@ class TestRedisManager:
     async def test_real_pool_connections_carry_retry(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """End-to-end through the real ConnectionPool: connections built from
         the pool's kwargs must have retries (asyncio default is 0)."""
-        from aegra_api.settings import settings
+        from aegra_api.core import redis_manager as redis_manager_module
 
-        monkeypatch.setattr(settings.redis, "REDIS_HEALTH_CHECK_INTERVAL", 45)
-        monkeypatch.setattr(settings.redis, "REDIS_RETRY_ATTEMPTS", 5)
+        monkeypatch.setattr(redis_manager_module.settings.redis, "REDIS_HEALTH_CHECK_INTERVAL", 45)
+        monkeypatch.setattr(redis_manager_module.settings.redis, "REDIS_RETRY_ATTEMPTS", 5)
         manager = RedisManager()
         mock_client = AsyncMock()
         real_from_url = aioredis.ConnectionPool.from_url

--- a/libs/aegra-api/tests/unit/test_core/test_redis_manager.py
+++ b/libs/aegra-api/tests/unit/test_core/test_redis_manager.py
@@ -8,6 +8,7 @@ from redis.asyncio.retry import Retry
 from redis.backoff import ExponentialBackoff
 from redis.exceptions import ConnectionError as RedisConnectionError
 
+from aegra_api.core import redis_manager as redis_manager_module
 from aegra_api.core.redis_manager import RedisManager
 
 
@@ -51,8 +52,6 @@ class TestRedisManager:
         reloads aegra_api.settings, so the freshly imported object can differ
         from the one redis_manager holds.
         """
-        from aegra_api.core import redis_manager as redis_manager_module
-
         monkeypatch.setattr(redis_manager_module.settings.redis, "REDIS_HEALTH_CHECK_INTERVAL", 45)
         monkeypatch.setattr(redis_manager_module.settings.redis, "REDIS_RETRY_ATTEMPTS", 5)
         manager = RedisManager()
@@ -80,8 +79,6 @@ class TestRedisManager:
     async def test_real_pool_connections_carry_retry(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """End-to-end through the real ConnectionPool: connections built from
         the pool's kwargs must have retries (asyncio default is 0)."""
-        from aegra_api.core import redis_manager as redis_manager_module
-
         monkeypatch.setattr(redis_manager_module.settings.redis, "REDIS_HEALTH_CHECK_INTERVAL", 45)
         monkeypatch.setattr(redis_manager_module.settings.redis, "REDIS_RETRY_ATTEMPTS", 5)
         manager = RedisManager()

--- a/libs/aegra-api/tests/unit/test_core/test_redis_manager.py
+++ b/libs/aegra-api/tests/unit/test_core/test_redis_manager.py
@@ -43,14 +43,9 @@ class TestRedisManager:
     async def test_initialize_configures_retry_and_health_checks(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Pooled connections must survive server-side idle disconnects (#505).
 
-        Every connection — including the one created by initialize()'s own
-        PING — must carry a retry that covers ConnectionError, plus a
-        health-check interval. Non-default settings prove the values come
-        from RedisSettings rather than literals.
-
-        Patch through the module's own settings reference: a sibling test
-        reloads aegra_api.settings, so the freshly imported object can differ
-        from the one redis_manager holds.
+        Non-default settings prove the values come from RedisSettings rather
+        than literals. Patched through the settings object redis_manager
+        holds, since a sibling test reloads aegra_api.settings.
         """
         monkeypatch.setattr(redis_manager_module.settings.redis, "REDIS_HEALTH_CHECK_INTERVAL", 45)
         monkeypatch.setattr(redis_manager_module.settings.redis, "REDIS_RETRY_ATTEMPTS", 5)

--- a/libs/aegra-api/tests/unit/test_cors_config.py
+++ b/libs/aegra-api/tests/unit/test_cors_config.py
@@ -55,9 +55,11 @@ def isolated_module_reload(tmp_path, monkeypatch):
         if mod not in original_modules:
             del sys.modules[mod]
 
-    # Then restore any modules that were removed
+    # Then restore removed AND replaced modules: reload_main_module swaps in
+    # fresh aegra_api.config/main objects, and leaking those breaks any later
+    # test that patched globals on the originals.
     for mod, module in original_modules.items():
-        if mod not in sys.modules:
+        if sys.modules.get(mod) is not module:
             sys.modules[mod] = module
 
 

--- a/libs/aegra-api/tests/unit/test_cors_config.py
+++ b/libs/aegra-api/tests/unit/test_cors_config.py
@@ -55,9 +55,8 @@ def isolated_module_reload(tmp_path, monkeypatch):
         if mod not in original_modules:
             del sys.modules[mod]
 
-    # Then restore removed AND replaced modules: reload_main_module swaps in
-    # fresh aegra_api.config/main objects, and leaking those breaks any later
-    # test that patched globals on the originals.
+    # Restore replaced modules too: reload_main_module swaps in fresh
+    # aegra_api.config/main objects that would leak into later tests.
     for mod, module in original_modules.items():
         if sys.modules.get(mod) is not module:
             sys.modules[mod] = module

--- a/libs/aegra-api/tests/unit/test_models/test_cron_validation.py
+++ b/libs/aegra-api/tests/unit/test_models/test_cron_validation.py
@@ -27,11 +27,11 @@ class TestWebhookValidation:
     )
     def test_rejects_non_http_or_malformed_scheme(self, url: str) -> None:
         with pytest.raises(ValidationError):
-            CronCreate(assistant_id="a", schedule="* * * * *", webhook=url)
+            CronCreate(input={"q": 1}, assistant_id="a", schedule="* * * * *", webhook=url)
 
     @pytest.mark.parametrize("url", ["http://example.com/hook", "https://example.com/hook"])
     def test_accepts_http_https(self, url: str) -> None:
-        req = CronCreate(assistant_id="a", schedule="* * * * *", webhook=url)
+        req = CronCreate(input={"q": 1}, assistant_id="a", schedule="* * * * *", webhook=url)
         assert req.webhook == url
 
 
@@ -39,6 +39,7 @@ class TestEndTimeMustBeFuture:
     def test_rejects_past_end_time_on_create(self) -> None:
         with pytest.raises(ValidationError, match="future"):
             CronCreate(
+                input={"q": 1},
                 assistant_id="a",
                 schedule="* * * * *",
                 end_time=datetime.now(UTC) - timedelta(seconds=1),
@@ -46,7 +47,7 @@ class TestEndTimeMustBeFuture:
 
     def test_accepts_future_end_time_on_create(self) -> None:
         end = datetime.now(UTC) + timedelta(days=1)
-        req = CronCreate(assistant_id="a", schedule="* * * * *", end_time=end)
+        req = CronCreate(input={"q": 1}, assistant_id="a", schedule="* * * * *", end_time=end)
         assert req.end_time == end
 
     def test_rejects_past_end_time_on_update(self) -> None:
@@ -71,6 +72,7 @@ class TestOnRunCompletedLiteral:
     def test_rejects_unknown_value(self) -> None:
         with pytest.raises(ValidationError):
             CronCreate(
+                input={"q": 1},
                 assistant_id="a",
                 schedule="* * * * *",
                 on_run_completed="create_new",  # type: ignore[arg-type]
@@ -79,6 +81,7 @@ class TestOnRunCompletedLiteral:
     @pytest.mark.parametrize("value", ["delete", "keep"])
     def test_accepts_allowed_values(self, value: str) -> None:
         req = CronCreate(
+            input={"q": 1},
             assistant_id="a",
             schedule="* * * * *",
             on_run_completed=value,  # type: ignore[arg-type]
@@ -89,16 +92,33 @@ class TestOnRunCompletedLiteral:
 class TestMaxLengthGuards:
     def test_rejects_oversized_schedule(self) -> None:
         with pytest.raises(ValidationError):
-            CronCreate(assistant_id="a", schedule="*" * 1024)
+            CronCreate(input={"q": 1}, assistant_id="a", schedule="*" * 1024)
 
     def test_rejects_oversized_timezone(self) -> None:
         with pytest.raises(ValidationError):
-            CronCreate(assistant_id="a", schedule="* * * * *", timezone="X" * 256)
+            CronCreate(input={"q": 1}, assistant_id="a", schedule="* * * * *", timezone="X" * 256)
 
     def test_rejects_oversized_webhook(self) -> None:
         with pytest.raises(ValidationError):
             CronCreate(
+                input={"q": 1},
                 assistant_id="a",
                 schedule="* * * * *",
                 webhook="https://example.com/" + ("x" * 4096),
             )
+
+
+class TestInputRequired:
+    """Regression for #514: a cron without input 500ed at first-firing validation."""
+
+    def test_rejects_missing_input(self) -> None:
+        with pytest.raises(ValidationError, match="'input' is required"):
+            CronCreate(assistant_id="a", schedule="* * * * *")
+
+    def test_rejects_explicit_none_input(self) -> None:
+        with pytest.raises(ValidationError, match="'input' is required"):
+            CronCreate(assistant_id="a", schedule="* * * * *", input=None)
+
+    def test_accepts_empty_dict_input(self) -> None:
+        req = CronCreate(assistant_id="a", schedule="* * * * *", input={})
+        assert req.input == {}

--- a/libs/aegra-api/tests/unit/test_models/test_cron_validation.py
+++ b/libs/aegra-api/tests/unit/test_models/test_cron_validation.py
@@ -112,12 +112,12 @@ class TestInputRequired:
     """Regression for #514: a cron without input 500ed at first-firing validation."""
 
     def test_rejects_missing_input(self) -> None:
-        with pytest.raises(ValidationError, match="'input' is required"):
+        with pytest.raises(ValidationError, match="input"):
             CronCreate(assistant_id="a", schedule="* * * * *")
 
     def test_rejects_explicit_none_input(self) -> None:
-        with pytest.raises(ValidationError, match="'input' is required"):
-            CronCreate(assistant_id="a", schedule="* * * * *", input=None)
+        with pytest.raises(ValidationError, match="input"):
+            CronCreate(assistant_id="a", schedule="* * * * *", input=None)  # type: ignore[arg-type]
 
     def test_accepts_empty_dict_input(self) -> None:
         req = CronCreate(assistant_id="a", schedule="* * * * *", input={})

--- a/libs/aegra-api/tests/unit/test_services/test_cron_review_fixes.py
+++ b/libs/aegra-api/tests/unit/test_services/test_cron_review_fixes.py
@@ -131,7 +131,7 @@ class TestSecondsScheduleGate:
         mock_session: AsyncMock,
     ) -> None:
         mock_session.scalar.return_value = _make_assistant_orm()
-        req = CronCreate(assistant_id="asst-001", schedule="*/30 * * * * *")
+        req = CronCreate(input={"q": 1}, assistant_id="asst-001", schedule="*/30 * * * * *")
         with pytest.raises(HTTPException) as exc:
             await cron_service.create_cron(req, "tenant-A")
         assert exc.value.status_code == 422
@@ -147,7 +147,7 @@ class TestSecondsScheduleGate:
 
         monkeypatch.setattr(_cs.settings.cron, "CRON_ALLOW_SECONDS_SCHEDULE", True)
         mock_session.scalar.return_value = _make_assistant_orm()
-        req = CronCreate(assistant_id="asst-001", schedule="*/30 * * * * *")
+        req = CronCreate(input={"q": 1}, assistant_id="asst-001", schedule="*/30 * * * * *")
         await cron_service.create_cron(req, "tenant-A")
         mock_session.add.assert_called_once()
 

--- a/libs/aegra-api/tests/unit/test_services/test_cron_service.py
+++ b/libs/aegra-api/tests/unit/test_services/test_cron_service.py
@@ -128,10 +128,13 @@ class TestBuildPayload:
         assert payload["webhook"] == "https://example.com"
 
     def test_skips_none_fields(self) -> None:
-        req = CronCreate(assistant_id="a", schedule="* * * * *")
+        # input is required at the API boundary (#514); only the other run
+        # fields can be None, so those are what the skip covers now.
+        req = CronCreate(input={"q": 1}, assistant_id="a", schedule="* * * * *")
         payload = _build_payload(req)
-        assert "input" not in payload
+        assert payload["input"] == {"q": 1}
         assert "config" not in payload
+        assert "webhook" not in payload
 
 
 class TestComputeNextRun:
@@ -200,7 +203,7 @@ class TestCreateCron:
         self,
         cron_service: CronService,
     ) -> None:
-        req = CronCreate(assistant_id="a", schedule="not-a-cron")
+        req = CronCreate(input={"q": 1}, assistant_id="a", schedule="not-a-cron")
         with pytest.raises(HTTPException) as exc:
             await cron_service.create_cron(req, "test-user")
         assert exc.value.status_code == 422
@@ -666,6 +669,7 @@ class TestCreateCronExtended:
     ) -> None:
         mock_session.scalar.return_value = _make_assistant_orm()
         req = CronCreate(
+            input={"q": 1},
             assistant_id="asst-001",
             schedule="*/5 * * * *",
             enabled=False,
@@ -685,6 +689,7 @@ class TestCreateCronExtended:
         mock_session.scalar.return_value = _make_assistant_orm()
         end = datetime.now(UTC) + timedelta(days=365)
         req = CronCreate(
+            input={"q": 1},
             assistant_id="asst-001",
             schedule="*/5 * * * *",
             end_time=end,
@@ -703,6 +708,7 @@ class TestCreateCronExtended:
     ) -> None:
         mock_session.scalar.return_value = _make_assistant_orm()
         req = CronCreate(
+            input={"q": 1},
             assistant_id="asst-001",
             schedule="*/5 * * * *",
             on_run_completed="keep",
@@ -747,7 +753,7 @@ class TestCreateCronExtended:
         should therefore start from the SECOND occurrence to avoid a double-fire.
         """
         mock_session.scalar.return_value = _make_assistant_orm()
-        req = CronCreate(assistant_id="asst-001", schedule="*/5 * * * *")
+        req = CronCreate(input={"q": 1}, assistant_id="asst-001", schedule="*/5 * * * *")
 
         before = datetime.now(UTC)
         await cron_service.create_cron(req, "test-user")
@@ -765,6 +771,7 @@ class TestCreateCronExtended:
     ) -> None:
         mock_session.scalar.return_value = _make_assistant_orm()
         req = CronCreate(
+            input={"q": 1},
             assistant_id="asst-001",
             schedule="*/5 * * * *",
             metadata={"team": "backend", "priority": "high"},
@@ -782,7 +789,7 @@ class TestCreateCronExtended:
         mock_session: AsyncMock,
     ) -> None:
         mock_session.scalar.return_value = _make_assistant_orm()
-        req = CronCreate(assistant_id="asst-001", schedule="*/5 * * * *")
+        req = CronCreate(input={"q": 1}, assistant_id="asst-001", schedule="*/5 * * * *")
 
         await cron_service.create_cron(req, "test-user")
 
@@ -1188,6 +1195,7 @@ class TestCreateCronTimezone:
     ) -> None:
         mock_session.scalar.return_value = _make_assistant_orm()
         req = CronCreate(
+            input={"q": 1},
             assistant_id="asst-001",
             schedule="0 9 * * *",
             timezone="America/New_York",
@@ -1206,6 +1214,7 @@ class TestCreateCronTimezone:
     ) -> None:
         mock_session.scalar.return_value = _make_assistant_orm()
         req = CronCreate(
+            input={"q": 1},
             assistant_id="asst-001",
             schedule="0 9 * * *",
             timezone="Not/Valid",
@@ -1224,6 +1233,7 @@ class TestCreateCronTimezone:
         """next_run_date should reflect the timezone-shifted schedule."""
         mock_session.scalar.return_value = _make_assistant_orm()
         req = CronCreate(
+            input={"q": 1},
             assistant_id="asst-001",
             schedule="0 9 * * *",
             timezone="America/New_York",

--- a/libs/aegra-api/tests/unit/test_services/test_langgraph_service.py
+++ b/libs/aegra-api/tests/unit/test_services/test_langgraph_service.py
@@ -57,9 +57,8 @@ class TestLangGraphServiceConfig:
         config_data = {"graphs": {"test": "./graphs/test.py:graph"}}
         env_path = "/env/path/config.json"
 
-        # Patch through the consumer's settings reference: a sibling test
-        # reloads aegra_api.settings, so the freshly imported object can differ
-        # from the one aegra_api.config (which resolves AEGRA_CONFIG) holds (#512).
+        # A sibling test reloads aegra_api.settings, so patch the settings
+        # object aegra_api.config actually holds (#512).
         with (
             patch.object(config_module.settings.app, "AEGRA_CONFIG", env_path),
             patch("pathlib.Path.exists", return_value=True),

--- a/libs/aegra-api/tests/unit/test_services/test_langgraph_service.py
+++ b/libs/aegra-api/tests/unit/test_services/test_langgraph_service.py
@@ -57,10 +57,13 @@ class TestLangGraphServiceConfig:
         config_data = {"graphs": {"test": "./graphs/test.py:graph"}}
         env_path = "/env/path/config.json"
 
-        # Patch the settings object directly. This ensures the service sees the change
-        # without needing to reload modules.
+        # Patch through the consumer's settings reference: a sibling test
+        # reloads aegra_api.settings, so the freshly imported object can differ
+        # from the one aegra_api.config (which resolves AEGRA_CONFIG) holds (#512).
+        from aegra_api import config as config_module
+
         with (
-            patch.object(settings.app, "AEGRA_CONFIG", env_path),
+            patch.object(config_module.settings.app, "AEGRA_CONFIG", env_path),
             patch("pathlib.Path.exists", return_value=True),
             patch("pathlib.Path.open", mock_open(read_data=json.dumps(config_data))),
             patch("aegra_api.services.langgraph_service.LangGraphService._ensure_default_assistants"),

--- a/libs/aegra-api/tests/unit/test_services/test_langgraph_service.py
+++ b/libs/aegra-api/tests/unit/test_services/test_langgraph_service.py
@@ -7,14 +7,14 @@ from unittest.mock import Mock, mock_open, patch
 
 import pytest
 
+# Import the settings singleton directly to patch it
+from aegra_api import config as config_module
 from aegra_api.services.langgraph_service import (
     LangGraphService,
     create_run_config,
     create_thread_config,
     inject_user_context,
 )
-
-# Import the settings singleton directly to patch it
 from aegra_api.settings import settings
 
 
@@ -60,8 +60,6 @@ class TestLangGraphServiceConfig:
         # Patch through the consumer's settings reference: a sibling test
         # reloads aegra_api.settings, so the freshly imported object can differ
         # from the one aegra_api.config (which resolves AEGRA_CONFIG) holds (#512).
-        from aegra_api import config as config_module
-
         with (
             patch.object(config_module.settings.app, "AEGRA_CONFIG", env_path),
             patch("pathlib.Path.exists", return_value=True),

--- a/libs/aegra-api/tests/unit/test_utils/test_event_loop.py
+++ b/libs/aegra-api/tests/unit/test_utils/test_event_loop.py
@@ -1,0 +1,23 @@
+"""The uvicorn --loop factory must produce a psycopg-compatible loop (#513)."""
+
+import asyncio
+
+from aegra_api.utils.event_loop import selector_loop_factory
+
+
+def test_factory_returns_a_selector_event_loop() -> None:
+    loop = selector_loop_factory()
+    try:
+        assert isinstance(loop, asyncio.SelectorEventLoop)
+    finally:
+        loop.close()
+
+
+def test_factory_returns_a_fresh_loop_each_call() -> None:
+    first = selector_loop_factory()
+    second = selector_loop_factory()
+    try:
+        assert first is not second
+    finally:
+        first.close()
+        second.close()

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.10.1"
+version = "0.10.2"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-cli/src/aegra_cli/cli.py
+++ b/libs/aegra-cli/src/aegra_cli/cli.py
@@ -34,6 +34,17 @@ _DEFAULT_SERVE_HOST = "0.0.0.0"  # noqa: S104  # nosec B104 - intentional for Do
 _DEFAULT_PORT = 2026
 
 
+def _windows_loop_args() -> list[str]:
+    """Extra uvicorn args forcing a psycopg-compatible event loop on Windows.
+
+    Without --reload, uvicorn's Windows default is the Proactor loop, which the
+    LangGraph psycopg pool cannot connect on (#513).
+    """
+    if sys.platform != "win32":
+        return []
+    return ["--loop", "aegra_api.utils.event_loop:selector_loop_factory"]
+
+
 def _resolve_server_option(
     ctx: click.Context,
     param_name: str,
@@ -399,6 +410,7 @@ def dev(
     cmd_uvicorn = ["-m", "uvicorn", app, "--host", host, "--port", str(port)]
     if not no_reload:
         cmd_uvicorn.append("--reload")
+    cmd_uvicorn.extend(_windows_loop_args())
 
     if debug_port is not None:
         if importlib.util.find_spec("debugpy") is None:
@@ -590,6 +602,7 @@ def serve(ctx: click.Context, host: str, port: int, app: str, config_file: Path 
         host,
         "--port",
         str(port),
+        *_windows_loop_args(),
     ]
 
     try:

--- a/libs/aegra-cli/src/aegra_cli/cli.py
+++ b/libs/aegra-cli/src/aegra_cli/cli.py
@@ -37,9 +37,8 @@ _DEFAULT_PORT = 2026
 def _windows_loop_args() -> list[str]:
     """Extra uvicorn args forcing a psycopg-compatible event loop on Windows.
 
-    Without --reload, uvicorn's Windows default is the Proactor loop, which the
-    LangGraph psycopg pool cannot connect on (#513). Skipped when the installed
-    aegra-api predates the factory module, so startup never dies on the import.
+    The default Proactor loop breaks the LangGraph psycopg pool (#513).
+    Skipped when the installed aegra-api predates the factory module.
     """
     if sys.platform != "win32":
         return []

--- a/libs/aegra-cli/src/aegra_cli/cli.py
+++ b/libs/aegra-cli/src/aegra_cli/cli.py
@@ -38,9 +38,12 @@ def _windows_loop_args() -> list[str]:
     """Extra uvicorn args forcing a psycopg-compatible event loop on Windows.
 
     Without --reload, uvicorn's Windows default is the Proactor loop, which the
-    LangGraph psycopg pool cannot connect on (#513).
+    LangGraph psycopg pool cannot connect on (#513). Skipped when the installed
+    aegra-api predates the factory module, so startup never dies on the import.
     """
     if sys.platform != "win32":
+        return []
+    if importlib.util.find_spec("aegra_api.utils.event_loop") is None:
         return []
     return ["--loop", "aegra_api.utils.event_loop:selector_loop_factory"]
 

--- a/libs/aegra-cli/tests/test_cli.py
+++ b/libs/aegra-cli/tests/test_cli.py
@@ -128,7 +128,10 @@ class TestDevCommand:
                 result = cli_runner.invoke(cli, ["dev", "--no-db-check"])
 
                 assert result.exit_code == 0
-                assert "--loop" in mock_popen.call_args[0][0]
+                cmd = mock_popen.call_args[0][0]
+                assert "--loop" in cmd
+                loop_idx = cmd.index("--loop")
+                assert cmd[loop_idx + 1] == "aegra_api.utils.event_loop:selector_loop_factory"
 
     def test_dev_default_host_and_port(self, cli_runner: CliRunner, tmp_path: Path) -> None:
         """Test that dev command uses default host and port."""

--- a/libs/aegra-cli/tests/test_cli.py
+++ b/libs/aegra-cli/tests/test_cli.py
@@ -96,6 +96,40 @@ class TestDevCommand:
                 call_args = mock_popen.call_args[0][0]
                 assert "--reload" not in call_args
 
+    def test_dev_no_reload_forces_selector_loop_on_windows(
+        self, cli_runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """dev --no-reload hits the same Proactor default as serve (#513)."""
+        monkeypatch.setattr("aegra_cli.cli.sys.platform", "win32")
+        with cli_runner.isolated_filesystem(temp_dir=tmp_path):
+            Path("aegra.json").write_text('{"graphs": {}}')
+
+            with patch("aegra_cli.cli.subprocess.Popen") as mock_popen:
+                mock_popen.return_value = create_mock_popen(0)
+                result = cli_runner.invoke(cli, ["dev", "--no-db-check", "--no-reload"])
+
+                assert result.exit_code == 0
+                cmd = mock_popen.call_args[0][0]
+                assert "--loop" in cmd
+                loop_idx = cmd.index("--loop")
+                assert cmd[loop_idx + 1] == "aegra_api.utils.event_loop:selector_loop_factory"
+
+    def test_dev_reload_also_forces_selector_loop_on_windows(
+        self, cli_runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Reload mode gets the same explicit loop: it is the loop the reload
+        subprocess would pick anyway, and uniform args are easier to reason about."""
+        monkeypatch.setattr("aegra_cli.cli.sys.platform", "win32")
+        with cli_runner.isolated_filesystem(temp_dir=tmp_path):
+            Path("aegra.json").write_text('{"graphs": {}}')
+
+            with patch("aegra_cli.cli.subprocess.Popen") as mock_popen:
+                mock_popen.return_value = create_mock_popen(0)
+                result = cli_runner.invoke(cli, ["dev", "--no-db-check"])
+
+                assert result.exit_code == 0
+                assert "--loop" in mock_popen.call_args[0][0]
+
     def test_dev_default_host_and_port(self, cli_runner: CliRunner, tmp_path: Path) -> None:
         """Test that dev command uses default host and port."""
         with cli_runner.isolated_filesystem(temp_dir=tmp_path):
@@ -1183,6 +1217,24 @@ class TestServeCommand:
             Path("aegra.json").write_text('{"graphs": {}}')
 
             with patch("aegra_cli.cli.subprocess.run") as mock_run:
+                mock_run.return_value.returncode = 0
+                result = cli_runner.invoke(cli, ["serve"])
+
+                assert result.exit_code == 0
+                assert "--loop" not in mock_run.call_args[0][0]
+
+    def test_serve_skips_loop_when_api_lacks_factory(
+        self, cli_runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An older aegra-api without the factory module must not break startup."""
+        monkeypatch.setattr("aegra_cli.cli.sys.platform", "win32")
+        with cli_runner.isolated_filesystem(temp_dir=tmp_path):
+            Path("aegra.json").write_text('{"graphs": {}}')
+
+            with (
+                patch("aegra_cli.cli.importlib.util.find_spec", return_value=None),
+                patch("aegra_cli.cli.subprocess.run") as mock_run,
+            ):
                 mock_run.return_value.returncode = 0
                 result = cli_runner.invoke(cli, ["serve"])
 

--- a/libs/aegra-cli/tests/test_cli.py
+++ b/libs/aegra-cli/tests/test_cli.py
@@ -1153,6 +1153,42 @@ class TestServeCommand:
                 # No --reload flag (production mode)
                 assert "--reload" not in cmd
 
+    def test_serve_forces_selector_loop_on_windows(
+        self, cli_runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Windows serve must pass a psycopg-compatible loop factory (#513).
+
+        uvicorn picks the Proactor loop on win32 without --reload; the
+        LangGraph psycopg pool cannot connect on it.
+        """
+        monkeypatch.setattr("aegra_cli.cli.sys.platform", "win32")
+        with cli_runner.isolated_filesystem(temp_dir=tmp_path):
+            Path("aegra.json").write_text('{"graphs": {}}')
+
+            with patch("aegra_cli.cli.subprocess.run") as mock_run:
+                mock_run.return_value.returncode = 0
+                result = cli_runner.invoke(cli, ["serve"])
+
+                assert result.exit_code == 0
+                cmd = mock_run.call_args[0][0]
+                assert "--loop" in cmd
+                assert "aegra_api.utils.event_loop:selector_loop_factory" in cmd
+
+    def test_serve_keeps_default_loop_off_windows(
+        self, cli_runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Linux/macOS keep uvicorn's auto loop (uvloop stays available)."""
+        monkeypatch.setattr("aegra_cli.cli.sys.platform", "linux")
+        with cli_runner.isolated_filesystem(temp_dir=tmp_path):
+            Path("aegra.json").write_text('{"graphs": {}}')
+
+            with patch("aegra_cli.cli.subprocess.run") as mock_run:
+                mock_run.return_value.returncode = 0
+                result = cli_runner.invoke(cli, ["serve"])
+
+                assert result.exit_code == 0
+                assert "--loop" not in mock_run.call_args[0][0]
+
     def test_serve_port_from_env_var(self, cli_runner: CliRunner, tmp_path: Path) -> None:
         """Test that serve command picks up PORT from env var when no CLI flag is passed."""
         with cli_runner.isolated_filesystem(temp_dir=tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -80,7 +80,7 @@ requires-dist = [
     { name = "sqlalchemy", specifier = ">=2.0.0" },
     { name = "sse-starlette", specifier = ">=3.3.4,<4.0.0" },
     { name = "structlog", specifier = ">=25.4.0" },
-    { name = "uvicorn", specifier = ">=0.35.0" },
+    { name = "uvicorn", specifier = ">=0.36.0" },
 ]
 
 [package.metadata.requires-dev]

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.10.1"
+version = "0.10.2"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -100,7 +100,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.10.1"
+version = "0.10.2"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
Fixes the three bugs found in the 0.10.1 e2e shakedown, plus the order-dependent test flake. Bumps version to 0.10.2.

Closes #513, closes #514, closes #515, closes #512.

## #513 — Windows: `serve` and `dev --no-reload` hang and die with PoolTimeout

uvicorn creates the event loop before the app imports, and its Windows default without `--reload` is the Proactor loop, which the LangGraph psycopg pool cannot connect on. Reload mode already worked because the reload subprocess gets a selector loop.

Fix: new importable factory `aegra_api.utils.event_loop:selector_loop_factory`, passed via `--loop` on win32 for `serve` and `dev --no-reload`. Other platforms are untouched (no `--loop` arg added).

Verified live on Windows 11: `aegra dev --no-reload` now completes startup and `/health` reports all pools connected, where 0.10.1 hangs at pool init.

## #514 — cron create without `input` returns 500

Every cron firing builds a `RunCreate` from the cron payload, and `RunCreate` requires `input`. `CronCreate` left it optional, so the immediate first firing crashed with a 500. Now validated at the API boundary: missing `input` returns 422 with a clear message. `input: {}` remains valid.

Verified live: `POST /runs/crons` without `input` returns 422.

## #515 — store GET dispatches unparsed namespace to auth handlers

`GET /store/items?namespace=a.b` forwarded `["a.b"]` to `@auth.on.store.get` handlers while PUT/DELETE dispatched `["a", "b"]`, so handlers comparing namespaces rejected reads of items the same user had just written. Normalization now happens before dispatch, and dots inside list items are split (FastAPI may coerce a single dot-string into a one-element list depending on version).

Verified live: dot-string and repeated-param forms both return the item, and the new integration test asserts handlers receive the identical parsed list for both forms.

## #512 — order-dependent unit test failures

`test_log_exclude_paths` reloads `aegra_api.settings`, so tests running after it patched a settings object the module under test no longer reads. The redis retry tests and `test_initialize_env_var_override` now patch through the consumer module's own settings reference.

## Tests

- aegra-api: 1859 passed, 0 failed (full suite, both former flakes cured)
- aegra-cli: 189 passed
- New coverage: loop factory unit tests, CLI arg tests for win32/non-win32, cron input validation at unit + integration level (422 regression test), store namespace parity integration test
- ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Store retrieval now handles namespace formats consistently, including dot-separated and repeated namespace values.
  * Cron creation now requires an input payload and returns a validation error when it is missing.
* **Compatibility**
  * Improved Windows development and server compatibility with a suitable event-loop configuration.
* **Documentation**
  * Updated API and cron documentation for required input payloads.
  * Clarified Windows installation and serving guidance.
* **Tests**
  * Added coverage for namespace parsing, cron validation, authorization, and Windows behavior.
* **Release**
  * Updated API and CLI versions to 0.10.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR fixes Windows uvicorn event-loop selection, validates required cron input at the API boundary, normalizes Store namespaces before authorization dispatch, and repairs order-dependent test state.

- Adds a selector-loop factory and conditionally passes it to uvicorn on Windows while preserving compatibility with older API installations.
- Requires cron input and updates tests, documentation, and OpenAPI output accordingly.
- Aligns Store GET namespace handling with PUT and DELETE authorization behavior.
- Restores replaced modules after reload-based tests and patches settings through consumer-module references.
- Bumps the API and CLI packages to 0.10.2.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/aegra-cli/src/aegra_cli/cli.py | Adds guarded Windows selector-loop arguments to dev and serve, including the compatibility fix requested by the prior review. |
| libs/aegra-api/src/aegra_api/models/crons.py | Makes cron input required and non-null so malformed requests fail validation before first-run construction. |
| libs/aegra-api/src/aegra_api/api/store.py | Normalizes namespaces before authorization dispatch and re-normalizes handler-supplied namespace filters before scoping. |
| libs/aegra-api/tests/unit/test_cors_config.py | Restores both removed and replaced module objects after reload-based tests. |
| libs/aegra-api/tests/unit/test_services/test_langgraph_service.py | Moves the required config import to module scope and patches the consumer module’s settings reference. |
| docs/openapi.json | Updates the API version and accurately marks cron input as a required non-null object. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    CLI[Windows aegra dev/serve] --> Probe{Loop factory available?}
    Probe -->|Yes| Selector[Pass selector loop to uvicorn]
    Probe -->|No| Default[Keep previous uvicorn behavior]
    Cron[Create cron request] --> Validate{Input supplied?}
    Validate -->|No| Reject[Return 422]
    Validate -->|Yes| Run[Create cron and first run]
    Store[Store GET namespace] --> Normalize[Normalize namespace segments]
    Normalize --> Auth[Dispatch authorization]
    Auth --> Scope[Apply user namespace scope]
    Scope --> Lookup[Read Store item]
```
</details>

<sub>Reviews (5): Last reviewed commit: ["style: trim comments to the constraint t..."](https://github.com/aegra/aegra/commit/40627e83797d867aebe7d87022483733cdec8b78) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53615395)</sub>

<!-- /greptile_comment -->