### PR TITLE
fix(worker): requeue in-flight runs on graceful shutdown

### DIFF
--- a/docs/guides/deployment.mdx
+++ b/docs/guides/deployment.mdx
@@ -158,7 +158,7 @@ containers:
 
 PostgreSQL should be a managed service (CloudSQL, RDS, etc.) or a StatefulSet with persistent volumes. Redis should be a managed service (ElastiCache, Memorystore, etc.) or a separate Deployment.
 
-Set `terminationGracePeriodSeconds` a few seconds above `WORKER_DRAIN_TIMEOUT` (default 30). On SIGTERM the pod waits that long for in-flight runs to finish, then hands the rest back to the queue for other pods to resume from the last checkpoint. If the pod is killed before the hand-off completes, the lease reaper recovers the runs after lease expiry instead — see the [worker architecture guide](/guides/worker-architecture#graceful-shutdown).
+Set `terminationGracePeriodSeconds` a few seconds above `WORKER_DRAIN_TIMEOUT` (default 30). On SIGTERM the pod waits that long for in-flight runs to finish, then hands the rest back to the queue for other pods to resume from the last checkpoint. A pod killed mid-hand-off still recovers: before the database reset, the lease reaper reclaims the runs after lease expiry; after the reset but before the queue push, the stuck-pending scan re-enqueues them after `STUCK_PENDING_THRESHOLD_SECONDS`. See the [worker architecture guide](/guides/worker-architecture#graceful-shutdown).
 
 ## Database configuration
 

--- a/docs/guides/deployment.mdx
+++ b/docs/guides/deployment.mdx
@@ -158,6 +158,8 @@ containers:
 
 PostgreSQL should be a managed service (CloudSQL, RDS, etc.) or a StatefulSet with persistent volumes. Redis should be a managed service (ElastiCache, Memorystore, etc.) or a separate Deployment.
 
+Set `terminationGracePeriodSeconds` a few seconds above `WORKER_DRAIN_TIMEOUT` (default 30). On SIGTERM the pod waits that long for in-flight runs to finish, then hands the rest back to the queue for other pods to resume from the last checkpoint. If the pod is killed before the hand-off completes, the lease reaper recovers the runs after lease expiry instead — see the [worker architecture guide](/guides/worker-architecture#graceful-shutdown).
+
 ## Database configuration
 
 Two ways to configure the database connection:

--- a/docs/guides/worker-architecture.mdx
+++ b/docs/guides/worker-architecture.mdx
@@ -225,6 +225,16 @@ sequenceDiagram
 
 The reaper runs on every instance (default every 15 seconds). This is safe — the atomic lease acquisition prevents duplicate execution.
 
+## Graceful shutdown
+
+On SIGTERM (rolling deploy, pod reschedule, node drain) the executor waits up to `WORKER_DRAIN_TIMEOUT` (default 30s) for in-flight runs to finish. Runs still executing when the window closes are **handed back to the queue**, not finalized: the run is reset to `pending` with its lease cleared and re-enqueued, so another instance resumes it from the last checkpoint — the same guarantee the crash path provides. Clients streaming the run stay connected and pick up events from the resuming worker.
+
+- A user-initiated cancel that races the shutdown still wins: explicitly cancelled runs are finalized as `interrupted`, never resurrected.
+- If Redis is unreachable during the hand-off, the rows are already `pending` and unclaimed, so a surviving instance's reaper re-enqueues them after `STUCK_PENDING_THRESHOLD_SECONDS`.
+- Drain hand-offs do not consume the crash retry budget (`BG_JOB_MAX_RETRIES`).
+
+Set your orchestrator's grace period a few seconds above `WORKER_DRAIN_TIMEOUT` (on Kubernetes: `terminationGracePeriodSeconds`), so the requeue completes before the pod is killed. Runs longer than the drain window survive the deploy either way; the timeout only decides how long the old pod waits before handing them off.
+
 ## Cross-instance cancellation
 
 Cancel requests can arrive at any instance, but the run may be executing on a different one.
@@ -306,7 +316,7 @@ All worker settings are configured via environment variables. See the [environme
 | `HEARTBEAT_INTERVAL_SECONDS` | `10` | Lease extension frequency |
 | `REAPER_INTERVAL_SECONDS` | `15` | Expired lease scan frequency |
 | `POSTGRES_POLL_INTERVAL_SECONDS` | `5` | Fallback poll interval when Redis is unavailable |
-| `WORKER_DRAIN_TIMEOUT` | `30.0` | Graceful shutdown wait time (seconds) |
+| `WORKER_DRAIN_TIMEOUT` | `30.0` | Graceful shutdown wait (seconds) before in-flight runs are requeued for another instance |
 
 <Note>
   When Redis is unavailable, workers fall back to polling PostgreSQL for pending runs at `POSTGRES_POLL_INTERVAL_SECONDS` intervals. This keeps the system functional during Redis outages, though with higher latency.

--- a/libs/aegra-api/src/aegra_api/services/run_executor.py
+++ b/libs/aegra-api/src/aegra_api/services/run_executor.py
@@ -30,6 +30,7 @@ _DEFAULT_STREAM_MODES = ["values"]
 
 # Cancellation provenance prevents infrastructure stops from looking user-initiated.
 _lease_loss_cancellations: set[str] = set()
+_shutdown_cancellations: set[str] = set()
 _timeout_cancellations: set[str] = set()
 
 _TIMEOUT_ERROR = "Job exceeded maximum execution time"
@@ -45,7 +46,7 @@ async def execute_run(job: RunJob) -> None:
     run_id = job.identity.run_id
     thread_id = job.identity.thread_id
     user_id = job.user.identity
-    is_lease_loss = False
+    resumes_elsewhere = False
     finalized = False
 
     try:
@@ -76,8 +77,13 @@ async def execute_run(job: RunJob) -> None:
 
     except asyncio.CancelledError:
         if run_id in _lease_loss_cancellations:
-            is_lease_loss = True
+            resumes_elsewhere = True
             logger.info("Lease-loss cancel, skipping finalize", run_id=run_id)
+        elif run_id in _shutdown_cancellations:
+            # Drain cancel: the run goes back to the queue, so finalizing here
+            # would destroy work a plain crash (SIGKILL) recovers (#474).
+            resumes_elsewhere = True
+            logger.info("Shutdown drain cancel, skipping finalize for requeue", run_id=run_id)
         elif run_id in _timeout_cancellations:
             finalized = await finalize_run(
                 run_id,
@@ -127,9 +133,10 @@ async def execute_run(job: RunJob) -> None:
             await _best_effort_signal(_signal_end_event, run_id, status)
     finally:
         _lease_loss_cancellations.discard(run_id)
+        _shutdown_cancellations.discard(run_id)
         _timeout_cancellations.discard(run_id)
         active_runs.pop(run_id, None)
-        if not is_lease_loss:
+        if not resumes_elsewhere:
             await streaming_service.cleanup_run(run_id)
             await _signal_run_done(run_id)
 

--- a/libs/aegra-api/src/aegra_api/services/worker_executor.py
+++ b/libs/aegra-api/src/aegra_api/services/worker_executor.py
@@ -93,7 +93,9 @@ class WorkerExecutor(BaseExecutor):
 
     def __init__(self) -> None:
         self._worker_tasks: list[asyncio.Task[None]] = []
-        self._job_tasks: set[asyncio.Task[None]] = set()
+        # Task -> run_id, mapped at creation: a task cancelled before it ever
+        # runs has no active_runs entry, yet its run still needs the drain requeue.
+        self._job_tasks: dict[asyncio.Task[None], str] = {}
         self._running = False
         self._instance_id = f"{socket.gethostname()}-{os.getpid()}"
 
@@ -167,30 +169,32 @@ class WorkerExecutor(BaseExecutor):
         drain_timeout = settings.worker.WORKER_DRAIN_TIMEOUT
 
         # Wait for in-flight job tasks to finish
+        drained: list[str] = []
         if self._job_tasks:
             logger.info("Draining in-flight jobs", count=len(self._job_tasks))
-            _, pending = await asyncio.wait(self._job_tasks, timeout=drain_timeout)
-            drained: list[str] = []
+            _, pending = await asyncio.wait(set(self._job_tasks), timeout=drain_timeout)
             if pending:
-                # Runs outliving the drain window go back to the queue. Finalizing
-                # them here would destroy work a plain crash recovers (#474).
+                # Requeue drain survivors instead of finalizing work that a
+                # plain crash would recover (#474).
                 drained = [
                     run_id
-                    for run_id, task in active_runs.items()
+                    for task, run_id in self._job_tasks.items()
                     if task in pending and run_id not in explicit_run_cancellations
                 ]
                 _shutdown_cancellations.update(drained)
                 for task in pending:
                     task.cancel()
                 await asyncio.gather(*pending, return_exceptions=True)
-            if drained:
-                await _requeue_drained_runs(drained)
 
-        # Cancel worker loops
+        # Cancel worker loops before the requeue push: a loop still blocked in
+        # BLPOP would steal the handed-off jobs back onto this dying instance.
         for task in self._worker_tasks:
             task.cancel()
         if self._worker_tasks:
             await asyncio.gather(*self._worker_tasks, return_exceptions=True)
+
+        if drained:
+            await _requeue_drained_runs(drained)
 
         self._worker_tasks.clear()
         self._job_tasks.clear()
@@ -235,9 +239,16 @@ class WorkerExecutor(BaseExecutor):
                     semaphore.release()
                     continue
 
+                if not self._running:
+                    # Dequeued while shutdown was already underway: hand it back
+                    # rather than start untracked work on a terminating instance.
+                    await _push_back(run_id)
+                    semaphore.release()
+                    break
+
                 task = asyncio.create_task(self._execute_and_release(run_id, worker_name, semaphore))
-                self._job_tasks.add(task)
-                task.add_done_callback(self._job_tasks.discard)
+                self._job_tasks[task] = run_id
+                task.add_done_callback(lambda t: self._job_tasks.pop(t, None))
 
             except asyncio.CancelledError:
                 break
@@ -468,6 +479,16 @@ async def _acquire_and_load(run_id: str, worker_name: str) -> _LoadedRun | None:
         job = RunJob.from_run_orm(run_orm)
         trace = run_orm.execution_params.get("trace", {})
         return _LoadedRun(job=job, trace=trace)
+
+
+async def _push_back(run_id: str) -> None:
+    """Best-effort return of a dequeued-but-unstarted run to the queue."""
+    try:
+        client = redis_manager.get_client()
+        await client.rpush(settings.worker.WORKER_QUEUE_KEY, run_id)  # type: ignore[arg-type]
+    except RedisError:
+        # Row is still pending/unclaimed; the stuck-pending reaper recovers it.
+        logger.warning("Could not push back dequeued run at shutdown", run_id=run_id)
 
 
 async def _requeue_drained_runs(run_ids: list[str]) -> None:

--- a/libs/aegra-api/src/aegra_api/services/worker_executor.py
+++ b/libs/aegra-api/src/aegra_api/services/worker_executor.py
@@ -29,7 +29,12 @@ from aegra_api.core.redis_manager import redis_manager
 from aegra_api.models.run_job import RunJob
 from aegra_api.observability.span_enrichment import merge_run_metadata, set_trace_context
 from aegra_api.services.base_executor import BaseExecutor
-from aegra_api.services.run_executor import _lease_loss_cancellations, _timeout_cancellations, execute_run
+from aegra_api.services.run_executor import (
+    _lease_loss_cancellations,
+    _shutdown_cancellations,
+    _timeout_cancellations,
+    execute_run,
+)
 from aegra_api.services.run_status import finalize_run
 from aegra_api.settings import settings
 
@@ -165,10 +170,21 @@ class WorkerExecutor(BaseExecutor):
         if self._job_tasks:
             logger.info("Draining in-flight jobs", count=len(self._job_tasks))
             _, pending = await asyncio.wait(self._job_tasks, timeout=drain_timeout)
-            for task in pending:
-                task.cancel()
+            drained: list[str] = []
             if pending:
+                # Runs outliving the drain window go back to the queue. Finalizing
+                # them here would destroy work a plain crash recovers (#474).
+                drained = [
+                    run_id
+                    for run_id, task in active_runs.items()
+                    if task in pending and run_id not in explicit_run_cancellations
+                ]
+                _shutdown_cancellations.update(drained)
+                for task in pending:
+                    task.cancel()
                 await asyncio.gather(*pending, return_exceptions=True)
+            if drained:
+                await _requeue_drained_runs(drained)
 
         # Cancel worker loops
         for task in self._worker_tasks:
@@ -284,6 +300,7 @@ class WorkerExecutor(BaseExecutor):
             logger.exception("Unexpected error in job execution", run_id=run_id)
         finally:
             _timeout_cancellations.discard(run_id)
+            _shutdown_cancellations.discard(run_id)
             explicit_run_cancellations.discard(run_id)
             active_runs.pop(run_id, None)
             semaphore.release()
@@ -451,6 +468,42 @@ async def _acquire_and_load(run_id: str, worker_name: str) -> _LoadedRun | None:
         job = RunJob.from_run_orm(run_orm)
         trace = run_orm.execution_params.get("trace", {})
         return _LoadedRun(job=job, trace=trace)
+
+
+async def _requeue_drained_runs(run_ids: list[str]) -> None:
+    """Hand runs cancelled at the drain deadline back to the queue.
+
+    Rows still 'running' were mid-execution with finalize skipped; rows still
+    'pending' were dequeued but never claimed. Both must reach another instance.
+    """
+    maker = _get_session_maker()
+    async with maker() as session:
+        result = await session.execute(
+            update(RunORM)
+            .where(RunORM.run_id.in_(run_ids), RunORM.status.in_(["running", "pending"]))
+            .values(status="pending", claimed_by=None, lease_expires_at=None)
+            .returning(RunORM.run_id)
+        )
+        reset_ids = [row[0] for row in result.fetchall()]
+        await session.commit()
+
+    if not reset_ids:
+        return
+
+    logger.info("Requeueing drained runs for another instance", count=len(reset_ids), run_ids=reset_ids)
+    pushed = 0
+    try:
+        client = redis_manager.get_client()
+        for run_id in reset_ids:
+            await client.rpush(settings.worker.WORKER_QUEUE_KEY, run_id)  # type: ignore[arg-type]
+            pushed += 1
+    except RedisError:
+        # Rows are already pending + unclaimed: the stuck-pending reaper or the
+        # Postgres poll fallback on a surviving instance picks them up.
+        logger.warning(
+            "Redis unavailable during drain requeue, reaper will recover",
+            run_ids=reset_ids[pushed:],
+        )
 
 
 async def _release_lease(run_id: str, worker_name: str) -> None:

--- a/libs/aegra-api/tests/unit/test_services/test_run_executor.py
+++ b/libs/aegra-api/tests/unit/test_services/test_run_executor.py
@@ -11,6 +11,7 @@ from aegra_api.services import run_executor as run_executor_module
 from aegra_api.services.run_executor import (
     _GraphResult,
     _lease_loss_cancellations,
+    _shutdown_cancellations,
     _signal_end_event,
     _signal_run_done,
     _stream_native_v2,
@@ -371,6 +372,69 @@ class TestLeaseLossCancellation:
         # Done-key and cleanup MUST happen on normal cancel
         mock_signal_done.assert_awaited_once_with("run-1")
         mock_streaming.cleanup_run.assert_awaited_once_with("run-1")
+
+
+class TestShutdownDrainCancellation:
+    @pytest.mark.asyncio
+    async def test_shutdown_cancel_skips_finalize_and_signal(self) -> None:
+        """A drain cancel goes back to the queue: finalizing it as interrupted
+        would make graceful shutdown lose runs a plain crash recovers (#474)."""
+        mock_start = AsyncMock(return_value=True)
+        mock_finalize = AsyncMock()
+        mock_signal_done = AsyncMock()
+
+        with (
+            patch("aegra_api.services.run_executor.start_run", mock_start),
+            patch("aegra_api.services.run_executor.finalize_run", mock_finalize),
+            patch("aegra_api.services.run_executor.streaming_service") as mock_streaming,
+            patch("aegra_api.services.run_executor._signal_run_done", mock_signal_done),
+            patch(
+                "aegra_api.services.run_executor._stream_graph",
+                new_callable=AsyncMock,
+                side_effect=asyncio.CancelledError,
+            ),
+        ):
+            mock_streaming.signal_run_cancelled = AsyncMock()
+            mock_streaming.cleanup_run = AsyncMock()
+
+            _shutdown_cancellations.add("run-1")
+            try:
+                with pytest.raises(asyncio.CancelledError):
+                    await execute_run(_make_job())
+            finally:
+                _shutdown_cancellations.discard("run-1")
+
+        # finalize_run must NOT be called — the run is requeued for another instance
+        mock_finalize.assert_not_awaited()
+        # SSE cancel signal must NOT be sent — clients should stay connected
+        mock_streaming.signal_run_cancelled.assert_not_awaited()
+        # Done-key must NOT be set — wait_for_completion would return early
+        mock_signal_done.assert_not_awaited()
+        # Broker must NOT be cleaned up — the resuming worker needs it
+        mock_streaming.cleanup_run.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_shutdown_flag_is_cleared_after_cancel(self) -> None:
+        """The provenance flag must not leak into a later run with the same id."""
+        with (
+            patch("aegra_api.services.run_executor.start_run", new_callable=AsyncMock, return_value=True),
+            patch("aegra_api.services.run_executor.finalize_run", new_callable=AsyncMock),
+            patch("aegra_api.services.run_executor.streaming_service") as mock_streaming,
+            patch("aegra_api.services.run_executor._signal_run_done", new_callable=AsyncMock),
+            patch(
+                "aegra_api.services.run_executor._stream_graph",
+                new_callable=AsyncMock,
+                side_effect=asyncio.CancelledError,
+            ),
+        ):
+            mock_streaming.signal_run_cancelled = AsyncMock()
+            mock_streaming.cleanup_run = AsyncMock()
+
+            _shutdown_cancellations.add("run-1")
+            with pytest.raises(asyncio.CancelledError):
+                await execute_run(_make_job())
+
+        assert "run-1" not in _shutdown_cancellations
 
 
 class TestTerminalStateRaces:

--- a/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
+++ b/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
@@ -1003,8 +1003,9 @@ class TestStopRequeuesDrainedRuns:
         await asyncio.sleep(0)  # let it start
 
         executor = WorkerExecutor()
-        executor._job_tasks = {hung_task}
-        active_runs["run-hung"] = hung_task
+        # Mapped at creation, deliberately absent from active_runs: a task
+        # cancelled before it runs must still reach the requeue.
+        executor._job_tasks = {hung_task: "run-hung"}
 
         seen_in_flag_set: list[bool] = []
 
@@ -1025,7 +1026,6 @@ class TestStopRequeuesDrainedRuns:
             # The flag was set before the cancel reached the task
             assert seen_in_flag_set == [True]
         finally:
-            active_runs.pop("run-hung", None)
             _shutdown_cancellations.discard("run-hung")
 
     @pytest.mark.asyncio
@@ -1041,9 +1041,7 @@ class TestStopRequeuesDrainedRuns:
         await asyncio.sleep(0)
 
         executor = WorkerExecutor()
-        executor._job_tasks = {hung_task, cancelled_task}
-        active_runs["run-hung"] = hung_task
-        active_runs["run-user-cancel"] = cancelled_task
+        executor._job_tasks = {hung_task: "run-hung", cancelled_task: "run-user-cancel"}
         explicit_run_cancellations.add("run-user-cancel")
 
         try:
@@ -1057,8 +1055,6 @@ class TestStopRequeuesDrainedRuns:
             mock_requeue.assert_awaited_once_with(["run-hung"])
             assert "run-user-cancel" not in _shutdown_cancellations
         finally:
-            active_runs.pop("run-hung", None)
-            active_runs.pop("run-user-cancel", None)
             explicit_run_cancellations.discard("run-user-cancel")
             _shutdown_cancellations.discard("run-hung")
 
@@ -1071,17 +1067,71 @@ class TestStopRequeuesDrainedRuns:
 
         quick_task = asyncio.create_task(_quick())
         executor = WorkerExecutor()
-        executor._job_tasks = {quick_task}
-        active_runs["run-quick"] = quick_task
+        executor._job_tasks = {quick_task: "run-quick"}
+
+        with (
+            patch(f"{MODULE}._requeue_drained_runs", new_callable=AsyncMock) as mock_requeue,
+            patch(f"{MODULE}.settings") as mock_settings,
+        ):
+            mock_settings.worker.WORKER_DRAIN_TIMEOUT = 1.0
+            await executor.stop()
+
+        mock_requeue.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_stop_cancels_worker_loops_before_requeue_push(self) -> None:
+        """A loop still blocked in BLPOP would steal the requeue push back onto
+        this dying instance, so loops must be gone before the push happens."""
+
+        async def _hang() -> None:
+            await asyncio.Event().wait()
+
+        job_task = asyncio.create_task(_hang())
+        loop_task = asyncio.create_task(_hang())
+        await asyncio.sleep(0)
+
+        events: list[str] = []
+        loop_task.add_done_callback(lambda _t: events.append("loops-stopped"))
+
+        async def _fake_requeue(run_ids: list[str]) -> None:
+            events.append("requeue")
+
+        executor = WorkerExecutor()
+        executor._job_tasks = {job_task: "run-hung"}
+        executor._worker_tasks = [loop_task]
 
         try:
             with (
-                patch(f"{MODULE}._requeue_drained_runs", new_callable=AsyncMock) as mock_requeue,
+                patch(f"{MODULE}._requeue_drained_runs", side_effect=_fake_requeue),
                 patch(f"{MODULE}.settings") as mock_settings,
             ):
-                mock_settings.worker.WORKER_DRAIN_TIMEOUT = 1.0
+                mock_settings.worker.WORKER_DRAIN_TIMEOUT = 0.05
                 await executor.stop()
 
-            mock_requeue.assert_not_awaited()
+            assert events == ["loops-stopped", "requeue"]
         finally:
-            active_runs.pop("run-quick", None)
+            _shutdown_cancellations.discard("run-hung")
+
+    @pytest.mark.asyncio
+    async def test_worker_loop_pushes_back_run_dequeued_during_shutdown(self) -> None:
+        """A loop that comes out of BLPOP after shutdown began must hand the
+        run back instead of starting untracked work."""
+        run_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        executor = WorkerExecutor()
+        executor._running = True
+
+        async def _dequeue_then_shutdown() -> str:
+            executor._running = False
+            return run_id
+
+        executor._dequeue = _dequeue_then_shutdown  # type: ignore[method-assign]
+
+        with (
+            patch(f"{MODULE}._push_back", new_callable=AsyncMock) as mock_push_back,
+            patch(f"{MODULE}.settings") as mock_settings,
+        ):
+            mock_settings.worker.N_JOBS_PER_WORKER = 1
+            await executor._worker_loop("test-worker")
+
+        mock_push_back.assert_awaited_once_with(run_id)
+        assert not executor._job_tasks

--- a/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
+++ b/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
@@ -11,7 +11,7 @@ from redis import TimeoutError as RedisTimeoutError
 from aegra_api.core.active_runs import active_runs, explicit_run_cancellations
 from aegra_api.models.auth import User
 from aegra_api.models.run_job import RunBehavior, RunExecution, RunIdentity, RunJob
-from aegra_api.services.run_executor import _timeout_cancellations
+from aegra_api.services.run_executor import _shutdown_cancellations, _timeout_cancellations
 from aegra_api.services.worker_executor import (
     WorkerExecutor,
     _acquire_and_load,
@@ -20,6 +20,7 @@ from aegra_api.services.worker_executor import (
     _is_valid_run_id,
     _LoadedRun,
     _release_lease,
+    _requeue_drained_runs,
     _restore_trace_context,
 )
 
@@ -910,3 +911,177 @@ class TestDequeue:
         assert result == "from-postgres"
         executor._poll_postgres.assert_awaited_once()
         mock_warning.assert_called_once()
+
+
+# ------------------------------------------------------------------
+# Drain requeue (#474)
+# ------------------------------------------------------------------
+
+
+class TestRequeueDrainedRuns:
+    @pytest.mark.asyncio
+    async def test_resets_rows_and_pushes_to_queue(self) -> None:
+        session = AsyncMock()
+        result = MagicMock()
+        result.fetchall.return_value = [("run-1",), ("run-2",)]
+        session.execute = AsyncMock(return_value=result)
+        mock_client = AsyncMock()
+
+        with (
+            patch(f"{MODULE}._get_session_maker", return_value=_make_session_maker(session)),
+            patch(f"{MODULE}.redis_manager") as mock_redis,
+            patch(f"{MODULE}.settings") as mock_settings,
+        ):
+            mock_redis.get_client.return_value = mock_client
+            mock_settings.worker.WORKER_QUEUE_KEY = "aegra:jobs"
+
+            await _requeue_drained_runs(["run-1", "run-2"])
+
+        session.commit.assert_awaited_once()
+        stmt = session.execute.await_args.args[0]
+        sql = str(stmt.compile())
+        assert "UPDATE runs SET" in sql
+        assert "runs.status IN" in sql
+        assert "RETURNING runs.run_id" in sql
+        assert mock_client.rpush.await_count == 2
+        pushed = [call.args for call in mock_client.rpush.await_args_list]
+        assert pushed == [("aegra:jobs", "run-1"), ("aegra:jobs", "run-2")]
+
+    @pytest.mark.asyncio
+    async def test_redis_outage_does_not_raise_after_rows_reset(self) -> None:
+        """The DB reset commits first, so the stuck-pending reaper can recover
+        even when the queue push fails."""
+        session = AsyncMock()
+        result = MagicMock()
+        result.fetchall.return_value = [("run-1",)]
+        session.execute = AsyncMock(return_value=result)
+        mock_client = AsyncMock()
+        mock_client.rpush = AsyncMock(side_effect=RedisConnectionError("down"))
+
+        with (
+            patch(f"{MODULE}._get_session_maker", return_value=_make_session_maker(session)),
+            patch(f"{MODULE}.redis_manager") as mock_redis,
+            patch(f"{MODULE}.settings") as mock_settings,
+            patch(f"{MODULE}.logger.warning") as mock_warning,
+        ):
+            mock_redis.get_client.return_value = mock_client
+            mock_settings.worker.WORKER_QUEUE_KEY = "aegra:jobs"
+
+            await _requeue_drained_runs(["run-1"])
+
+        session.commit.assert_awaited_once()
+        mock_warning.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_no_rows_reset_skips_queue_push(self) -> None:
+        """Runs that finalized during the drain (user cancel, completion) are
+        terminal, so nothing is reset and nothing is pushed."""
+        session = AsyncMock()
+        result = MagicMock()
+        result.fetchall.return_value = []
+        session.execute = AsyncMock(return_value=result)
+
+        with (
+            patch(f"{MODULE}._get_session_maker", return_value=_make_session_maker(session)),
+            patch(f"{MODULE}.redis_manager") as mock_redis,
+        ):
+            await _requeue_drained_runs(["run-1"])
+
+        mock_redis.get_client.assert_not_called()
+
+
+class TestStopRequeuesDrainedRuns:
+    @pytest.mark.asyncio
+    async def test_stop_requeues_jobs_alive_at_drain_deadline(self) -> None:
+        """Jobs still executing when the drain window closes are cancelled with
+        shutdown provenance and handed to the requeue path, not finalized (#474)."""
+
+        async def _hang() -> None:
+            await asyncio.Event().wait()
+
+        hung_task = asyncio.create_task(_hang())
+        await asyncio.sleep(0)  # let it start
+
+        executor = WorkerExecutor()
+        executor._job_tasks = {hung_task}
+        active_runs["run-hung"] = hung_task
+
+        seen_in_flag_set: list[bool] = []
+
+        async def _fake_requeue(run_ids: list[str]) -> None:
+            seen_in_flag_set.append("run-hung" in _shutdown_cancellations)
+            assert run_ids == ["run-hung"]
+
+        try:
+            with (
+                patch(f"{MODULE}._requeue_drained_runs", side_effect=_fake_requeue) as mock_requeue,
+                patch(f"{MODULE}.settings") as mock_settings,
+            ):
+                mock_settings.worker.WORKER_DRAIN_TIMEOUT = 0.05
+                await executor.stop()
+
+            mock_requeue.assert_called_once()
+            assert hung_task.cancelled()
+            # The flag was set before the cancel reached the task
+            assert seen_in_flag_set == [True]
+        finally:
+            active_runs.pop("run-hung", None)
+            _shutdown_cancellations.discard("run-hung")
+
+    @pytest.mark.asyncio
+    async def test_stop_excludes_explicitly_cancelled_runs_from_requeue(self) -> None:
+        """A user cancel that races the shutdown stays a cancel: the run must
+        not be resurrected by the drain requeue."""
+
+        async def _hang() -> None:
+            await asyncio.Event().wait()
+
+        hung_task = asyncio.create_task(_hang())
+        cancelled_task = asyncio.create_task(_hang())
+        await asyncio.sleep(0)
+
+        executor = WorkerExecutor()
+        executor._job_tasks = {hung_task, cancelled_task}
+        active_runs["run-hung"] = hung_task
+        active_runs["run-user-cancel"] = cancelled_task
+        explicit_run_cancellations.add("run-user-cancel")
+
+        try:
+            with (
+                patch(f"{MODULE}._requeue_drained_runs", new_callable=AsyncMock) as mock_requeue,
+                patch(f"{MODULE}.settings") as mock_settings,
+            ):
+                mock_settings.worker.WORKER_DRAIN_TIMEOUT = 0.05
+                await executor.stop()
+
+            mock_requeue.assert_awaited_once_with(["run-hung"])
+            assert "run-user-cancel" not in _shutdown_cancellations
+        finally:
+            active_runs.pop("run-hung", None)
+            active_runs.pop("run-user-cancel", None)
+            explicit_run_cancellations.discard("run-user-cancel")
+            _shutdown_cancellations.discard("run-hung")
+
+    @pytest.mark.asyncio
+    async def test_stop_does_not_requeue_jobs_that_finish_in_time(self) -> None:
+        """Jobs completing inside the drain window finalize normally."""
+
+        async def _quick() -> None:
+            await asyncio.sleep(0)
+
+        quick_task = asyncio.create_task(_quick())
+        executor = WorkerExecutor()
+        executor._job_tasks = {quick_task}
+        active_runs["run-quick"] = quick_task
+
+        try:
+            with (
+                patch(f"{MODULE}._requeue_drained_runs", new_callable=AsyncMock) as mock_requeue,
+                patch(f"{MODULE}.settings") as mock_settings,
+            ):
+                mock_settings.worker.WORKER_DRAIN_TIMEOUT = 1.0
+                await executor.stop()
+
+            mock_requeue.assert_not_awaited()
+        finally:
+            active_runs.pop("run-quick", None)


### PR DESCRIPTION
## Description
A graceful shutdown (SIGTERM, i.e. every rolling deploy) permanently finalized any run still executing after `WORKER_DRAIN_TIMEOUT` as `interrupted`/`idle` with its lease released — a terminal state the reaper never revisits. A SIGKILL of the same pod recovered its runs via lease expiry, so the orderly path was the only way an instance could die and lose work.

Drained runs now carry shutdown provenance (mirroring the existing lease-loss mechanism): `execute_run` skips finalize, the SSE cancel signal, broker cleanup and the done-key, and `WorkerExecutor.stop()` then resets those rows to `pending`/unclaimed and pushes them back on the queue. Another instance resumes from the last checkpoint — the same guarantee the crash path already provides.

- Explicit user cancels racing the shutdown still win: they finalize as `interrupted` and are excluded from the requeue.
- Runs dequeued but not yet claimed at the deadline are pushed back too (they would otherwise sit `pending` until the stuck-pending scan).
- If Redis is down during the hand-off, the rows are already `pending` and unclaimed, so the stuck-pending reaper or the Postgres poll fallback recovers them.
- Drain hand-offs do not charge the crash retry budget.

## Type of Change
- [x] `fix`: Bug fix
- [x] `docs`: Documentation changes
- [x] `test`: Tests added/updated

## Related Issues
Fixes #474

## Testing
- Unit: shutdown-cancel provenance in `execute_run` (no finalize / SSE cancel / cleanup / done-key, flag cleared after), `stop()` drain semantics (requeues stragglers, excludes explicit cancels, leaves fast jobs alone), `_requeue_drained_runs` (row reset + RPUSH, Redis-outage fallback, no-op when nothing reset).
- Full non-e2e suite: 1871 passed.
- Live verification against docker compose in broker mode with `WORKER_DRAIN_TIMEOUT=3`: started a 60s `stress_test` run, sent SIGTERM mid-step. After the drain the DB row read `pending | claimed_by=NULL | lease_expires_at=NULL`; the replacement container picked the run up and drove it to `success` (transitions: running → server down → running → success). Before this change the same sequence left the run `interrupted`/`idle` with empty output, permanently.

## Additional Notes
No version bump — batched release flow. Docs updated: worker-architecture.mdx gains a Graceful shutdown section; deployment.mdx explains sizing `terminationGracePeriodSeconds` against `WORKER_DRAIN_TIMEOUT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved worker shutdown handling so in-flight runs can finish draining or return safely to the queue.
  * Runs that exceed the shutdown drain timeout are requeued for later processing.
  * Added recovery behavior when the queue service is temporarily unavailable.

* **Documentation**
  * Added Kubernetes configuration guidance for graceful worker termination.
  * Documented cancellation precedence, recovery behavior, and retry handling during shutdown.

* **Bug Fixes**
  * Prevented shutdown-cancelled runs from being incorrectly finalized or cleaned up before recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR changes graceful worker shutdown so unfinished runs retain their streaming state and are handed back to another worker rather than finalized.
- Tracks shutdown cancellation separately from lease loss, timeout, and user cancellation.
- Drains active jobs, resets eligible rows to pending, and re-enqueues them after worker loops stop.
- Adds Redis-outage recovery behavior, regression tests, and deployment guidance.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because a user cancellation arriving late in the shutdown drain can still be lost and the cancelled run resumed.

The cancellation listener remains active while the executor drains, but cancellation registration can return after the active task has finished; the drain handoff then has no final cancellation guard and resets the run to pending for execution elsewhere.

**Files Needing Attention:** libs/aegra-api/src/aegra_api/services/worker_executor.py and libs/aegra-api/src/aegra_api/services/redis_broker.py

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/services/worker_executor.py | Implements drain-time cancellation and requeue handoff, but the previously reported late explicit-cancellation race remains. |
| libs/aegra-api/src/aegra_api/services/run_executor.py | Adds shutdown provenance so drain cancellations skip terminal signaling and broker cleanup before resumption. |
| libs/aegra-api/tests/unit/test_services/test_worker_executor.py | Covers normal drain handoff, pre-existing explicit cancellations, Redis failure, and shutdown dequeue behavior, but not the outstanding late-cancellation interleaving. |
| docs/guides/worker-architecture.mdx | Documents the intended graceful-shutdown handoff, cancellation precedence, and recovery behavior. |
| docs/guides/deployment.mdx | Documents how to size the orchestrator grace period around the worker drain timeout. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant API as Cancellation API
    participant Broker as Redis cancel listener
    participant Old as Draining worker
    participant DB as PostgreSQL
    participant Queue as Redis queue
    participant New as Replacement worker
    Old->>Old: Snapshot explicit cancellations
    Old->>Old: Mark drain survivors and cancel tasks
    API->>Broker: User cancellation
    Broker->>Broker: Active task already done
    Broker-->>API: Cancellation discarded
    Old->>DB: Reset run to pending and clear lease
    Old->>Queue: Re-enqueue run
    New->>Queue: Dequeue run
    New->>DB: Claim and resume cancelled work
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(worker): close drain races - loop st..."](https://github.com/aegra/aegra/commit/601324c4c41c91d7821dfb16fb7391461b904171) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53763998)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Execution Engine: Broker, Executors, Leases, and Cleanup](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/execution-engine.md)
- Knowledge Base — [Threads and Runs](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/threads-and-runs.md)
- Knowledge Base — [Streaming: from LangGraph execution to SSE wire events](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/streaming.md)
</details>

<!-- /greptile_comment -->