### PR TITLE
fix(api): release DB session before thread state/history checkpoint reads

### DIFF
--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.10.3"
+version = "0.10.4"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-api/src/aegra_api/api/threads.py
+++ b/libs/aegra-api/src/aegra_api/api/threads.py
@@ -21,7 +21,7 @@ from aegra_api.core.auth_handlers import build_auth_context, handle_event
 from aegra_api.core.database import db_manager
 from aegra_api.core.orm import Run as RunORM
 from aegra_api.core.orm import Thread as ThreadORM
-from aegra_api.core.orm import get_session
+from aegra_api.core.orm import _get_session_maker, get_session
 from aegra_api.models import (
     Thread,
     ThreadCheckpoint,
@@ -45,6 +45,22 @@ router = APIRouter(tags=["Threads"], dependencies=auth_dependency)
 logger = structlog.getLogger(__name__)
 
 thread_state_service = ThreadStateService()
+
+
+async def _get_thread_graph_id(thread_id: str, user: User) -> str | None:
+    """Look up a thread's graph_id via a short-lived session.
+
+    Releases the pooled connection before the caller starts any long-running
+    LangGraph checkpoint operation, so an aborted request can't leak it.
+    """
+    maker = _get_session_maker()
+    async with maker() as session:
+        stmt = select(ThreadORM).where(ThreadORM.thread_id == thread_id, ThreadORM.user_id == user.identity)
+        thread = await session.scalar(stmt)
+        if not thread:
+            raise HTTPException(404, f"Thread '{thread_id}' not found")
+        thread_metadata = thread.metadata_json or {}
+        return thread_metadata.get("graph_id")
 
 
 # --- Sort resolution for /threads/search ---
@@ -337,22 +353,18 @@ async def get_thread_state(
     subgraphs: bool = Query(False, description="Include states from subgraphs"),
     checkpoint_ns: str | None = Query(None, description="Checkpoint namespace to scope lookup"),
     user: User = Depends(get_current_user),
-    session: AsyncSession = Depends(get_session),
 ) -> ThreadState:
     """Get the current state of a thread.
 
     Returns the latest checkpoint's values, pending next nodes, interrupt
     data, and metadata. If the thread has no associated graph yet (no runs
     executed), returns an empty state.
+
+    Sessions are managed manually (not via ``Depends``) so the pool
+    connection is released before the LangGraph checkpoint read starts.
     """
     try:
-        stmt = select(ThreadORM).where(ThreadORM.thread_id == thread_id, ThreadORM.user_id == user.identity)
-        thread = await session.scalar(stmt)
-        if not thread:
-            raise HTTPException(404, f"Thread '{thread_id}' not found")
-
-        thread_metadata = thread.metadata_json or {}
-        graph_id = thread_metadata.get("graph_id")
+        graph_id = await _get_thread_graph_id(thread_id, user)
         if not graph_id:
             logger.info(
                 "state GET: no graph_id set for thread %s, returning empty state",
@@ -437,7 +449,6 @@ async def update_thread_state(
     thread_id: str,
     request: ThreadStateUpdate,
     user: User = Depends(get_current_user),
-    session: AsyncSession = Depends(get_session),
 ) -> ThreadState | ThreadStateUpdateResponse:
     """Update thread state or retrieve it via POST.
 
@@ -460,17 +471,10 @@ async def update_thread_state(
             subgraphs=request.subgraphs or False,
             checkpoint_ns=request.checkpoint_ns,
             user=user,
-            session=session,
         )
 
     try:
-        stmt = select(ThreadORM).where(ThreadORM.thread_id == thread_id, ThreadORM.user_id == user.identity)
-        thread = await session.scalar(stmt)
-        if not thread:
-            raise HTTPException(404, f"Thread '{thread_id}' not found")
-
-        thread_metadata = thread.metadata_json or {}
-        graph_id = thread_metadata.get("graph_id")
+        graph_id = await _get_thread_graph_id(thread_id, user)
         if not graph_id:
             raise HTTPException(
                 400,
@@ -583,7 +587,6 @@ async def get_thread_state_at_checkpoint(
     subgraphs: bool | None = Query(False, description="Include states from subgraphs"),
     checkpoint_ns: str | None = Query(None, description="Checkpoint namespace to scope lookup"),
     user: User = Depends(get_current_user),
-    session: AsyncSession = Depends(get_session),
 ) -> ThreadState:
     """Get the thread state at a specific checkpoint.
 
@@ -591,13 +594,7 @@ async def get_thread_state_at_checkpoint(
     execution history. Returns 404 if the checkpoint does not exist.
     """
     try:
-        stmt = select(ThreadORM).where(ThreadORM.thread_id == thread_id, ThreadORM.user_id == user.identity)
-        thread = await session.scalar(stmt)
-        if not thread:
-            raise HTTPException(404, f"Thread '{thread_id}' not found")
-
-        thread_metadata = thread.metadata_json or {}
-        graph_id = thread_metadata.get("graph_id")
+        graph_id = await _get_thread_graph_id(thread_id, user)
         if not graph_id:
             raise HTTPException(404, f"Thread '{thread_id}' has no associated graph")
 
@@ -662,7 +659,6 @@ async def get_thread_state_at_checkpoint_post(
     thread_id: str,
     request: ThreadCheckpointPostRequest,
     user: User = Depends(get_current_user),
-    session: AsyncSession = Depends(get_session),
 ) -> ThreadState:
     """Get the thread state at a specific checkpoint (POST variant).
 
@@ -683,7 +679,6 @@ async def get_thread_state_at_checkpoint_post(
         subgraphs,
         checkpoint_ns,
         user,
-        session,
     )
     return output
 
@@ -693,12 +688,14 @@ async def get_thread_history_post(
     thread_id: str,
     request: ThreadHistoryRequest,
     user: User = Depends(get_current_user),
-    session: AsyncSession = Depends(get_session),
 ) -> list[ThreadState]:
     """Get the checkpoint history for a thread (POST variant).
 
     Returns a list of past states ordered from newest to oldest. Use `limit`
     to control how many states are returned and `before` to paginate.
+
+    Sessions are managed manually (not via ``Depends``) so the pool
+    connection is released before ``aget_state_history`` starts iterating.
     """
     try:
         limit = request.limit or 10
@@ -711,13 +708,7 @@ async def get_thread_history_post(
         subgraphs = bool(request.subgraphs) if request.subgraphs is not None else False
         checkpoint_ns = request.checkpoint_ns
 
-        stmt = select(ThreadORM).where(ThreadORM.thread_id == thread_id, ThreadORM.user_id == user.identity)
-        thread = await session.scalar(stmt)
-        if not thread:
-            raise HTTPException(404, f"Thread '{thread_id}' not found")
-
-        thread_metadata = thread.metadata_json or {}
-        graph_id = thread_metadata.get("graph_id")
+        graph_id = await _get_thread_graph_id(thread_id, user)
         if not graph_id:
             logger.info(f"history POST: no graph_id set for thread {thread_id}")
             return []
@@ -796,7 +787,6 @@ async def get_thread_history_get(
     checkpoint_ns: str | None = Query(None, description="Checkpoint namespace"),
     metadata: str | None = Query(None, description="JSON-encoded metadata filter"),
     user: User = Depends(get_current_user),
-    session: AsyncSession = Depends(get_session),
 ) -> list[ThreadState]:
     """Get the checkpoint history for a thread.
 
@@ -819,7 +809,7 @@ async def get_thread_history_get(
         subgraphs=subgraphs,
         checkpoint_ns=checkpoint_ns,
     )
-    return await get_thread_history_post(thread_id, req, user, session)
+    return await get_thread_history_post(thread_id, req, user)
 
 
 @router.delete(

--- a/libs/aegra-api/tests/integration/test_api/test_threads_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_threads_crud.py
@@ -642,7 +642,7 @@ class TestSearchThreads:
 class TestThreadGetState:
     """Test GET /threads/{thread_id}/state endpoint"""
 
-    def test_get_latest_state_thread_not_found(self):
+    def test_get_latest_state_thread_not_found(self, monkeypatch: pytest.MonkeyPatch):
         """Thread lookup should 404 when record is missing."""
         app = create_test_app(include_runs=False, include_threads=True)
 
@@ -651,13 +651,14 @@ class TestThreadGetState:
                 return None
 
         app.dependency_overrides[core_get_session] = override_get_session_dep(Session)
+        monkeypatch.setattr(threads_module, "_get_session_maker", lambda: Session)
         client = make_client(app)
 
         resp = client.get("/threads/missing/state")
         assert resp.status_code == 404
         assert "not found" in resp.json()["detail"].lower()
 
-    def test_get_latest_state_no_graph_id(self):
+    def test_get_latest_state_no_graph_id(self, monkeypatch: pytest.MonkeyPatch):
         """Threads without graph metadata should return empty state."""
         app = create_test_app(include_runs=False, include_threads=True)
 
@@ -668,6 +669,7 @@ class TestThreadGetState:
                 return thread
 
         app.dependency_overrides[core_get_session] = override_get_session_dep(Session)
+        monkeypatch.setattr(threads_module, "_get_session_maker", lambda: Session)
         client = make_client(app)
 
         resp = client.get("/threads/test-123/state")
@@ -677,7 +679,7 @@ class TestThreadGetState:
         assert "checkpoint" in state
         assert state["checkpoint"]["checkpoint_id"] is None
 
-    def test_get_latest_state_success(self):
+    def test_get_latest_state_success(self, monkeypatch: pytest.MonkeyPatch):
         """Test getting latest state successfully."""
         app = create_test_app(include_runs=False, include_threads=True)
         thread = _thread_row("test-123", metadata={"graph_id": "test-graph"})
@@ -687,6 +689,7 @@ class TestThreadGetState:
                 return thread
 
         app.dependency_overrides[core_get_session] = override_get_session_dep(Session)
+        monkeypatch.setattr(threads_module, "_get_session_maker", lambda: Session)
         client = make_client(app)
 
         # Mock langgraph service and agent
@@ -718,7 +721,7 @@ class TestThreadGetState:
 class TestThreadUpdateState:
     """Test POST /threads/{thread_id}/state endpoint"""
 
-    def test_update_state_as_get(self):
+    def test_update_state_as_get(self, monkeypatch: pytest.MonkeyPatch):
         """Test POST without values behaves like GET."""
         app = create_test_app(include_runs=False, include_threads=True)
         thread = _thread_row("test-123", metadata={"graph_id": "test-graph"})
@@ -728,6 +731,7 @@ class TestThreadUpdateState:
                 return thread
 
         app.dependency_overrides[core_get_session] = override_get_session_dep(Session)
+        monkeypatch.setattr(threads_module, "_get_session_maker", lambda: Session)
         client = make_client(app)
 
         mock_agent = AsyncMock()
@@ -754,7 +758,7 @@ class TestThreadUpdateState:
             state = resp.json()
             assert state["values"]["key"] == "val"
 
-    def test_update_state_success(self):
+    def test_update_state_success(self, monkeypatch: pytest.MonkeyPatch):
         """Test updating state successfully."""
         app = create_test_app(include_runs=False, include_threads=True)
         thread = _thread_row("test-123", metadata={"graph_id": "test-graph"})
@@ -764,6 +768,7 @@ class TestThreadUpdateState:
                 return thread
 
         app.dependency_overrides[core_get_session] = override_get_session_dep(Session)
+        monkeypatch.setattr(threads_module, "_get_session_maker", lambda: Session)
         client = make_client(app)
 
         mock_agent = AsyncMock()
@@ -790,7 +795,7 @@ class TestThreadUpdateState:
             call_args = mock_agent.aupdate_state.call_args
             assert call_args[0][1] == {"foo": "bar"}  # values
 
-    def test_update_state_no_graph(self):
+    def test_update_state_no_graph(self, monkeypatch: pytest.MonkeyPatch):
         """Test updating state when thread has no graph."""
         app = create_test_app(include_runs=False, include_threads=True)
         thread = _thread_row("test-123", metadata={})  # No graph_id
@@ -800,6 +805,7 @@ class TestThreadUpdateState:
                 return thread
 
         app.dependency_overrides[core_get_session] = override_get_session_dep(Session)
+        monkeypatch.setattr(threads_module, "_get_session_maker", lambda: Session)
         client = make_client(app)
 
         resp = client.post(
@@ -809,7 +815,7 @@ class TestThreadUpdateState:
         assert resp.status_code == 400
         assert "no associated graph" in resp.json()["detail"]
 
-    def test_update_state_copy_checkpoint_with_as_node(self):
+    def test_update_state_copy_checkpoint_with_as_node(self, monkeypatch: pytest.MonkeyPatch):
         """values=None + as_node must create a copy checkpoint via aupdate_state.
 
         Regression test: LangGraph Studio posts {"values": null,
@@ -827,6 +833,7 @@ class TestThreadUpdateState:
                 return thread
 
         app.dependency_overrides[core_get_session] = override_get_session_dep(Session)
+        monkeypatch.setattr(threads_module, "_get_session_maker", lambda: Session)
         client = make_client(app)
 
         mock_agent = AsyncMock()
@@ -858,7 +865,7 @@ class TestThreadUpdateState:
             assert cfg["configurable"]["checkpoint_id"] == "original-cp"
             assert mock_agent.aupdate_state.call_args[1]["as_node"] == "__copy__"
 
-    def test_update_state_body_checkpoint_id_routes_to_update_path(self):
+    def test_update_state_body_checkpoint_id_routes_to_update_path(self, monkeypatch: pytest.MonkeyPatch):
         """Body-only checkpoint_id must flow to aupdate_state, not the GET shim
         which reads query params and would silently drop the body field."""
         app = create_test_app(include_runs=False, include_threads=True)
@@ -869,6 +876,7 @@ class TestThreadUpdateState:
                 return thread
 
         app.dependency_overrides[core_get_session] = override_get_session_dep(Session)
+        monkeypatch.setattr(threads_module, "_get_session_maker", lambda: Session)
         client = make_client(app)
 
         mock_agent = AsyncMock()
@@ -890,7 +898,7 @@ class TestThreadUpdateState:
             assert values is None
             assert cfg["configurable"]["checkpoint_id"] == "body-cp"
 
-    def test_update_state_body_checkpoint_dict_routes_to_update_path(self):
+    def test_update_state_body_checkpoint_dict_routes_to_update_path(self, monkeypatch: pytest.MonkeyPatch):
         """Mirror of the checkpoint_id case for the `checkpoint` dict variant
         so neither half of the gate condition can regress silently."""
         app = create_test_app(include_runs=False, include_threads=True)
@@ -901,6 +909,7 @@ class TestThreadUpdateState:
                 return thread
 
         app.dependency_overrides[core_get_session] = override_get_session_dep(Session)
+        monkeypatch.setattr(threads_module, "_get_session_maker", lambda: Session)
         client = make_client(app)
 
         mock_agent = AsyncMock()
@@ -930,7 +939,7 @@ class TestThreadUpdateState:
 class TestThreadStateCheckpoint:
     """Test GET /threads/{thread_id}/state/{checkpoint_id} endpoint"""
 
-    def test_get_state_thread_not_found(self):
+    def test_get_state_thread_not_found(self, monkeypatch: pytest.MonkeyPatch):
         """Test getting state when thread doesn't exist"""
         app = create_test_app(include_runs=False, include_threads=True)
 
@@ -939,12 +948,13 @@ class TestThreadStateCheckpoint:
                 return None
 
         app.dependency_overrides[core_get_session] = override_get_session_dep(Session)
+        monkeypatch.setattr(threads_module, "_get_session_maker", lambda: Session)
         client = make_client(app)
 
         resp = client.get("/threads/nonexistent/state/checkpoint-1")
         assert resp.status_code == 404
 
-    def test_get_state_no_graph_id(self):
+    def test_get_state_no_graph_id(self, monkeypatch: pytest.MonkeyPatch):
         """Test getting state when thread has no associated graph"""
         app = create_test_app(include_runs=False, include_threads=True)
 
@@ -955,13 +965,14 @@ class TestThreadStateCheckpoint:
                 return thread
 
         app.dependency_overrides[core_get_session] = override_get_session_dep(Session)
+        monkeypatch.setattr(threads_module, "_get_session_maker", lambda: Session)
         client = make_client(app)
 
         resp = client.get("/threads/test-123/state/checkpoint-1")
         assert resp.status_code == 404
         assert "no associated graph" in resp.json()["detail"]
 
-    def test_get_state_with_subgraphs_param(self):
+    def test_get_state_with_subgraphs_param(self, monkeypatch: pytest.MonkeyPatch):
         """Test getting state with subgraphs query parameter"""
         app = create_test_app(include_runs=False, include_threads=True)
 
@@ -972,13 +983,14 @@ class TestThreadStateCheckpoint:
                 return thread
 
         app.dependency_overrides[core_get_session] = override_get_session_dep(Session)
+        monkeypatch.setattr(threads_module, "_get_session_maker", lambda: Session)
         client = make_client(app)
 
         # Should fail because no graph_id, but tests that param is accepted
         resp = client.get("/threads/test-123/state/checkpoint-1?subgraphs=true")
         assert resp.status_code == 404
 
-    def test_get_state_at_checkpoint_success(self):
+    def test_get_state_at_checkpoint_success(self, monkeypatch: pytest.MonkeyPatch):
         """Test getting state at specific checkpoint."""
         app = create_test_app(include_runs=False, include_threads=True)
         thread = _thread_row("test-123", metadata={"graph_id": "test-graph"})
@@ -988,6 +1000,7 @@ class TestThreadStateCheckpoint:
                 return thread
 
         app.dependency_overrides[core_get_session] = override_get_session_dep(Session)
+        monkeypatch.setattr(threads_module, "_get_session_maker", lambda: Session)
         client = make_client(app)
 
         mock_agent = AsyncMock()
@@ -1018,7 +1031,7 @@ class TestThreadStateCheckpoint:
 class TestThreadStateCheckpointPost:
     """Test POST /threads/{thread_id}/state/checkpoint endpoint"""
 
-    def test_post_checkpoint_thread_not_found(self):
+    def test_post_checkpoint_thread_not_found(self, monkeypatch: pytest.MonkeyPatch):
         """Test POST checkpoint when thread doesn't exist"""
         app = create_test_app(include_runs=False, include_threads=True)
 
@@ -1027,6 +1040,7 @@ class TestThreadStateCheckpointPost:
                 return None
 
         app.dependency_overrides[core_get_session] = override_get_session_dep(Session)
+        monkeypatch.setattr(threads_module, "_get_session_maker", lambda: Session)
         client = make_client(app)
 
         resp = client.post(
@@ -1035,7 +1049,7 @@ class TestThreadStateCheckpointPost:
         )
         assert resp.status_code == 404
 
-    def test_post_checkpoint_no_graph_id(self):
+    def test_post_checkpoint_no_graph_id(self, monkeypatch: pytest.MonkeyPatch):
         """Test POST checkpoint when thread has no graph"""
         app = create_test_app(include_runs=False, include_threads=True)
 
@@ -1046,6 +1060,7 @@ class TestThreadStateCheckpointPost:
                 return thread
 
         app.dependency_overrides[core_get_session] = override_get_session_dep(Session)
+        monkeypatch.setattr(threads_module, "_get_session_maker", lambda: Session)
         client = make_client(app)
 
         resp = client.post(
@@ -1054,7 +1069,7 @@ class TestThreadStateCheckpointPost:
         )
         assert resp.status_code == 404
 
-    def test_post_checkpoint_success(self):
+    def test_post_checkpoint_success(self, monkeypatch: pytest.MonkeyPatch):
         """Test POST checkpoint success."""
         app = create_test_app(include_runs=False, include_threads=True)
         thread = _thread_row("test-123", metadata={"graph_id": "test-graph"})
@@ -1064,6 +1079,7 @@ class TestThreadStateCheckpointPost:
                 return thread
 
         app.dependency_overrides[core_get_session] = override_get_session_dep(Session)
+        monkeypatch.setattr(threads_module, "_get_session_maker", lambda: Session)
         client = make_client(app)
 
         mock_agent = AsyncMock()

--- a/libs/aegra-api/tests/integration/test_api/test_threads_history.py
+++ b/libs/aegra-api/tests/integration/test_api/test_threads_history.py
@@ -46,7 +46,7 @@ def _thread_row():
 
 
 @pytest.fixture()
-def client() -> TestClient:
+def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
     # Build app with threads router only
     app = create_test_app(include_runs=False, include_threads=True)
 
@@ -55,8 +55,13 @@ def client() -> TestClient:
         async def scalar(self, _stmt):
             return _thread_row()
 
-    # Override the ORM get_session dependency
+    # Override the ORM get_session dependency (still used by POST /threads)
     app.dependency_overrides[core_get_session] = override_get_session_dep(Session)
+
+    # History endpoints manage their session manually via _get_session_maker
+    # (not Depends(get_session)), so the dependency override above doesn't
+    # reach them — patch the session-maker entry point directly instead.
+    monkeypatch.setattr("aegra_api.api.threads._get_session_maker", lambda: Session)
 
     return make_client(app)
 

--- a/libs/aegra-api/tests/integration/test_api/test_threads_history.py
+++ b/libs/aegra-api/tests/integration/test_api/test_threads_history.py
@@ -58,9 +58,8 @@ def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
     # Override the ORM get_session dependency (still used by POST /threads)
     app.dependency_overrides[core_get_session] = override_get_session_dep(Session)
 
-    # History endpoints manage their session manually via _get_session_maker
-    # (not Depends(get_session)), so the dependency override above doesn't
-    # reach them — patch the session-maker entry point directly instead.
+    # History endpoints use _get_session_maker rather than Depends(get_session),
+    # so patch the session-maker entry point directly.
     monkeypatch.setattr("aegra_api.api.threads._get_session_maker", lambda: Session)
 
     return make_client(app)

--- a/libs/aegra-api/tests/unit/test_threads/test_session_lifecycle.py
+++ b/libs/aegra-api/tests/unit/test_threads/test_session_lifecycle.py
@@ -1,0 +1,164 @@
+"""Regression tests for aegra/aegra#517.
+
+Aborting an in-flight thread history/state request could leave its
+SQLAlchemy session (and asyncpg connection) checked out, because the
+endpoint held the session open across the long-running, cancellable
+LangGraph checkpoint call. These endpoints now look up the thread's
+graph_id via a short-lived session that is closed *before* the LangGraph
+call starts, so a cancellation during that call can no longer leak the
+connection. Each test fails loudly if a future change reverses the order.
+"""
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from aegra_api.api.threads import (
+    get_thread_history_post,
+    get_thread_state,
+    get_thread_state_at_checkpoint,
+    update_thread_state,
+)
+from aegra_api.models import ThreadHistoryRequest, ThreadStateUpdate, ThreadStateUpdateResponse, User
+
+
+class _TrackingSession:
+    """Fake AsyncSession that records when it is closed via __aexit__."""
+
+    def __init__(self, thread_row: Any, closed_marker: list[bool]) -> None:
+        self._thread_row = thread_row
+        self._closed_marker = closed_marker
+
+    async def scalar(self, _stmt: Any) -> Any:
+        return self._thread_row
+
+    async def __aenter__(self) -> "_TrackingSession":
+        return self
+
+    async def __aexit__(self, *exc_info: object) -> bool:
+        self._closed_marker.append(True)
+        return False
+
+
+class _AssertsSessionClosedAgent:
+    """Fake LangGraph agent that fails the test if the session isn't closed yet."""
+
+    def __init__(self, closed_marker: list[bool], snapshots: list[Any] | None = None) -> None:
+        self._closed_marker = closed_marker
+        self._snapshots = snapshots or []
+
+    def with_config(self, _config: dict[str, Any]) -> "_AssertsSessionClosedAgent":
+        return self
+
+    async def aget_state(self, _config: dict[str, Any], **_kwargs: Any) -> None:
+        assert self._closed_marker, "session must be released before aget_state starts"
+        return None
+
+    async def aget_state_history(self, _config: dict[str, Any], **_kwargs: Any) -> AsyncIterator[Any]:
+        assert self._closed_marker, "session must be released before aget_state_history starts"
+        for snapshot in self._snapshots:
+            yield snapshot
+
+    async def aupdate_state(self, _config: dict[str, Any], _values: Any, as_node: str | None = None) -> dict:
+        assert self._closed_marker, "session must be released before aupdate_state starts"
+        return {"configurable": {"checkpoint_id": "cp-1", "checkpoint_ns": ""}}
+
+
+def _patch_session_maker(thread_row: Any, closed_marker: list[bool]) -> Any:
+    session = _TrackingSession(thread_row, closed_marker)
+    return patch("aegra_api.api.threads._get_session_maker", return_value=MagicMock(return_value=session))
+
+
+def _patch_langgraph_service(agent: _AssertsSessionClosedAgent) -> Any:
+    @asynccontextmanager
+    async def _get_graph(*_args: Any, **_kwargs: Any) -> AsyncIterator[_AssertsSessionClosedAgent]:
+        yield agent
+
+    mock_service = MagicMock()
+    mock_service.get_graph = _get_graph
+    return patch("aegra_api.services.langgraph_service.get_langgraph_service", return_value=mock_service)
+
+
+class TestSessionReleasedBeforeCheckpointRead:
+    @pytest.mark.asyncio
+    async def test_get_thread_state_releases_session_before_aget_state(self) -> None:
+        user = User(identity="user-1", scopes=[])
+        thread_row = MagicMock()
+        thread_row.metadata_json = {"graph_id": "graph-123"}
+        closed_marker: list[bool] = []
+        agent = _AssertsSessionClosedAgent(closed_marker)
+
+        with (
+            _patch_session_maker(thread_row, closed_marker),
+            _patch_langgraph_service(agent),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await get_thread_state("thread-123", user=user)
+
+        assert exc_info.value.status_code == 404
+        assert closed_marker == [True]
+
+    @pytest.mark.asyncio
+    async def test_get_thread_state_at_checkpoint_releases_session_before_aget_state(self) -> None:
+        user = User(identity="user-1", scopes=[])
+        thread_row = MagicMock()
+        thread_row.metadata_json = {"graph_id": "graph-123"}
+        closed_marker: list[bool] = []
+        agent = _AssertsSessionClosedAgent(closed_marker)
+
+        with (
+            _patch_session_maker(thread_row, closed_marker),
+            _patch_langgraph_service(agent),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await get_thread_state_at_checkpoint("thread-123", "checkpoint-1", user=user)
+
+        assert exc_info.value.status_code == 404
+        assert closed_marker == [True]
+
+    @pytest.mark.asyncio
+    async def test_update_thread_state_releases_session_before_aupdate_state(self) -> None:
+        user = User(identity="user-1", scopes=[])
+        thread_row = MagicMock()
+        thread_row.metadata_json = {"graph_id": "graph-123"}
+        closed_marker: list[bool] = []
+        agent = _AssertsSessionClosedAgent(closed_marker)
+
+        with (
+            _patch_session_maker(thread_row, closed_marker),
+            _patch_langgraph_service(agent),
+        ):
+            result = await update_thread_state(
+                "thread-123",
+                ThreadStateUpdate(values={"foo": "bar"}),
+                user=user,
+            )
+
+        assert isinstance(result, ThreadStateUpdateResponse)
+        assert result.checkpoint["checkpoint_id"] == "cp-1"
+        assert closed_marker == [True]
+
+    @pytest.mark.asyncio
+    async def test_get_thread_history_post_releases_session_before_aget_state_history(self) -> None:
+        user = User(identity="user-1", scopes=[])
+        thread_row = MagicMock()
+        thread_row.metadata_json = {"graph_id": "graph-123"}
+        closed_marker: list[bool] = []
+        agent = _AssertsSessionClosedAgent(closed_marker)
+
+        with (
+            _patch_session_maker(thread_row, closed_marker),
+            _patch_langgraph_service(agent),
+        ):
+            result = await get_thread_history_post(
+                "thread-123",
+                ThreadHistoryRequest(limit=10),
+                user=user,
+            )
+
+        assert result == []
+        assert closed_marker == [True]

--- a/libs/aegra-api/tests/unit/test_threads/test_state.py
+++ b/libs/aegra-api/tests/unit/test_threads/test_state.py
@@ -25,6 +25,19 @@ def create_get_graph_mock(return_value=None, side_effect=None):
     return get_graph
 
 
+def _make_session_maker(session: AsyncMock) -> MagicMock:
+    """Build a mock async_sessionmaker that always yields the given session.
+
+    get_thread_state manages its session manually via _get_session_maker
+    (not Depends(get_session)) so the pooled connection is released before
+    any LangGraph checkpoint read starts.
+    """
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=session)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    return MagicMock(return_value=ctx)
+
+
 class TestGetThreadState:
     """Exercise edge cases and success path for get_thread_state."""
 
@@ -35,8 +48,11 @@ class TestGetThreadState:
         session = AsyncMock()
         session.scalar.return_value = None
 
-        with pytest.raises(HTTPException) as exc_info:
-            await get_thread_state("thread-123", user=user, session=session)
+        with (
+            patch("aegra_api.api.threads._get_session_maker", return_value=_make_session_maker(session)),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await get_thread_state("thread-123", user=user)
 
         assert exc_info.value.status_code == 404
         assert "not found" in exc_info.value.detail.lower()
@@ -50,7 +66,8 @@ class TestGetThreadState:
         thread_row.metadata_json = {}
         session.scalar.return_value = thread_row
 
-        result = await get_thread_state("thread-123", user=user, session=session)
+        with patch("aegra_api.api.threads._get_session_maker", return_value=_make_session_maker(session)):
+            result = await get_thread_state("thread-123", user=user)
 
         # get_thread_state returns ThreadState Pydantic model
         assert hasattr(result, "values")
@@ -66,11 +83,14 @@ class TestGetThreadState:
         thread_row.metadata_json = {"graph_id": "graph-123"}
         session.scalar.return_value = thread_row
 
-        with patch("aegra_api.services.langgraph_service.get_langgraph_service") as mock_service:
+        with (
+            patch("aegra_api.api.threads._get_session_maker", return_value=_make_session_maker(session)),
+            patch("aegra_api.services.langgraph_service.get_langgraph_service") as mock_service,
+        ):
             mock_service.return_value.get_graph = create_get_graph_mock(side_effect=Exception("boom"))
 
             with pytest.raises(HTTPException) as exc_info:
-                await get_thread_state("thread-123", user=user, session=session)
+                await get_thread_state("thread-123", user=user)
 
         assert exc_info.value.status_code == 500
         assert "failed to retrieve thread state" in exc_info.value.detail.lower()
@@ -89,6 +109,7 @@ class TestGetThreadState:
         mock_agent.aget_state = AsyncMock(return_value=None)
 
         with (
+            patch("aegra_api.api.threads._get_session_maker", return_value=_make_session_maker(session)),
             patch("aegra_api.services.langgraph_service.get_langgraph_service") as mock_service,
             patch(
                 "aegra_api.services.langgraph_service.create_thread_config",
@@ -98,7 +119,7 @@ class TestGetThreadState:
             mock_service.return_value.get_graph = create_get_graph_mock(return_value=mock_agent)
 
             with pytest.raises(HTTPException) as exc_info:
-                await get_thread_state("thread-123", user=user, session=session)
+                await get_thread_state("thread-123", user=user)
 
         assert exc_info.value.status_code == 404
         assert "no state found" in exc_info.value.detail.lower()
@@ -117,6 +138,7 @@ class TestGetThreadState:
         mock_agent.aget_state = AsyncMock(return_value={"values": {}})
 
         with (
+            patch("aegra_api.api.threads._get_session_maker", return_value=_make_session_maker(session)),
             patch("aegra_api.services.langgraph_service.get_langgraph_service") as mock_service,
             patch(
                 "aegra_api.services.langgraph_service.create_thread_config",
@@ -130,7 +152,7 @@ class TestGetThreadState:
             mock_service.return_value.get_graph = create_get_graph_mock(return_value=mock_agent)
 
             with pytest.raises(HTTPException) as exc_info:
-                await get_thread_state("thread-123", user=user, session=session)
+                await get_thread_state("thread-123", user=user)
 
         assert exc_info.value.status_code == 500
         assert "failed to retrieve thread state" in exc_info.value.detail.lower()
@@ -155,6 +177,7 @@ class TestGetThreadState:
         config = {"configurable": {}}
 
         with (
+            patch("aegra_api.api.threads._get_session_maker", return_value=_make_session_maker(session)),
             patch("aegra_api.services.langgraph_service.get_langgraph_service") as mock_service,
             patch(
                 "aegra_api.services.langgraph_service.create_thread_config",
@@ -172,7 +195,6 @@ class TestGetThreadState:
                 subgraphs=True,
                 checkpoint_ns="ns-1",
                 user=user,
-                session=session,
             )
 
         assert result is mock_thread_state
@@ -194,6 +216,7 @@ class TestGetThreadState:
         mock_agent.aget_state = AsyncMock(side_effect=HTTPException(status_code=418, detail="teapot"))
 
         with (
+            patch("aegra_api.api.threads._get_session_maker", return_value=_make_session_maker(session)),
             patch("aegra_api.services.langgraph_service.get_langgraph_service") as mock_service,
             patch(
                 "aegra_api.services.langgraph_service.create_thread_config",
@@ -203,7 +226,7 @@ class TestGetThreadState:
             mock_service.return_value.get_graph = create_get_graph_mock(return_value=mock_agent)
 
             with pytest.raises(HTTPException) as exc_info:
-                await get_thread_state("thread-123", user=user, session=session)
+                await get_thread_state("thread-123", user=user)
 
         assert exc_info.value.status_code == 418
         assert exc_info.value.detail == "teapot"
@@ -215,8 +238,11 @@ class TestGetThreadState:
         session = AsyncMock()
         session.scalar.side_effect = Exception("database down")
 
-        with pytest.raises(HTTPException) as exc_info:
-            await get_thread_state("thread-123", user=user, session=session)
+        with (
+            patch("aegra_api.api.threads._get_session_maker", return_value=_make_session_maker(session)),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await get_thread_state("thread-123", user=user)
 
         assert exc_info.value.status_code == 500
         assert "error retrieving thread state" in exc_info.value.detail.lower()

--- a/libs/aegra-api/tests/unit/test_threads/test_state_checkpoint.py
+++ b/libs/aegra-api/tests/unit/test_threads/test_state_checkpoint.py
@@ -28,6 +28,19 @@ def create_get_graph_mock(return_value=None, side_effect=None):
     return get_graph
 
 
+def _make_session_maker(session: AsyncMock) -> MagicMock:
+    """Build a mock async_sessionmaker that always yields the given session.
+
+    get_thread_state_at_checkpoint manages its session manually via
+    _get_session_maker (not Depends(get_session)) so the pooled connection is
+    released before any LangGraph checkpoint read starts.
+    """
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=session)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    return MagicMock(return_value=ctx)
+
+
 class TestGetThreadStateAtCheckpoint:
     """Exercise edge cases and success path for get_thread_state_at_checkpoint."""
 
@@ -50,6 +63,7 @@ class TestGetThreadStateAtCheckpoint:
         config = {"configurable": {}}
 
         with (
+            patch("aegra_api.api.threads._get_session_maker", return_value=_make_session_maker(session)),
             patch("aegra_api.services.langgraph_service.get_langgraph_service") as mock_service,
             patch(
                 "aegra_api.services.langgraph_service.create_thread_config",
@@ -67,7 +81,6 @@ class TestGetThreadStateAtCheckpoint:
                 "checkpoint-1",
                 subgraphs=True,
                 user=user,
-                session=session,
             )
 
         assert result is mock_thread_state
@@ -94,6 +107,7 @@ class TestGetThreadStateAtCheckpoint:
         config = {"configurable": {}}
 
         with (
+            patch("aegra_api.api.threads._get_session_maker", return_value=_make_session_maker(session)),
             patch("aegra_api.services.langgraph_service.get_langgraph_service") as mock_service,
             patch(
                 "aegra_api.services.langgraph_service.create_thread_config",
@@ -112,7 +126,6 @@ class TestGetThreadStateAtCheckpoint:
                 subgraphs=False,
                 checkpoint_ns="my-namespace",
                 user=user,
-                session=session,
             )
 
         assert config["configurable"]["checkpoint_id"] == "checkpoint-1"
@@ -137,6 +150,7 @@ class TestGetThreadStateAtCheckpoint:
         config = {"configurable": {}}
 
         with (
+            patch("aegra_api.api.threads._get_session_maker", return_value=_make_session_maker(session)),
             patch("aegra_api.services.langgraph_service.get_langgraph_service") as mock_service,
             patch(
                 "aegra_api.services.langgraph_service.create_thread_config",
@@ -155,7 +169,6 @@ class TestGetThreadStateAtCheckpoint:
                 subgraphs=False,
                 checkpoint_ns=None,
                 user=user,
-                session=session,
             )
 
         assert config["configurable"]["checkpoint_id"] == "checkpoint-1"
@@ -169,7 +182,6 @@ class TestGetThreadStateAtCheckpointPost:
     async def test_success_with_checkpoint_ns(self):
         """Verify checkpoint_ns from request is passed to GET endpoint."""
         user = User(identity="user-1", scopes=[])
-        session = AsyncMock()
 
         checkpoint = ThreadCheckpoint(
             checkpoint_id="checkpoint-1",
@@ -184,7 +196,7 @@ class TestGetThreadStateAtCheckpointPost:
             "aegra_api.api.threads.get_thread_state_at_checkpoint",
             return_value=mock_thread_state,
         ) as mock_get:
-            result = await get_thread_state_at_checkpoint_post("thread-123", request, user=user, session=session)
+            result = await get_thread_state_at_checkpoint_post("thread-123", request, user=user)
 
         assert result is mock_thread_state
         # Verify GET endpoint was called with checkpoint_ns
@@ -194,14 +206,12 @@ class TestGetThreadStateAtCheckpointPost:
             True,  # subgraphs
             "my-namespace",  # checkpoint_ns
             user,
-            session,
         )
 
     @pytest.mark.asyncio
     async def test_success_without_checkpoint_ns(self):
         """Verify None checkpoint_ns is handled correctly."""
         user = User(identity="user-1", scopes=[])
-        session = AsyncMock()
 
         checkpoint = ThreadCheckpoint(
             checkpoint_id="checkpoint-1",
@@ -216,7 +226,7 @@ class TestGetThreadStateAtCheckpointPost:
             "aegra_api.api.threads.get_thread_state_at_checkpoint",
             return_value=mock_thread_state,
         ) as mock_get:
-            result = await get_thread_state_at_checkpoint_post("thread-123", request, user=user, session=session)
+            result = await get_thread_state_at_checkpoint_post("thread-123", request, user=user)
 
         assert result is mock_thread_state
         # Verify GET endpoint was called with None checkpoint_ns
@@ -226,14 +236,12 @@ class TestGetThreadStateAtCheckpointPost:
             False,  # subgraphs
             None,  # checkpoint_ns (empty string becomes None)
             user,
-            session,
         )
 
     @pytest.mark.asyncio
     async def test_missing_checkpoint_id_raises_error(self):
         """Verify missing checkpoint_id raises 400 error."""
         user = User(identity="user-1", scopes=[])
-        session = AsyncMock()
 
         checkpoint = ThreadCheckpoint(
             checkpoint_id=None,  # Missing checkpoint_id
@@ -243,7 +251,7 @@ class TestGetThreadStateAtCheckpointPost:
         request = ThreadCheckpointPostRequest(checkpoint=checkpoint, subgraphs=False)
 
         with pytest.raises(HTTPException) as exc_info:
-            await get_thread_state_at_checkpoint_post("thread-123", request, user=user, session=session)
+            await get_thread_state_at_checkpoint_post("thread-123", request, user=user)
 
         assert exc_info.value.status_code == 400
         assert "checkpoint_id is required" in exc_info.value.detail.lower()
@@ -252,7 +260,6 @@ class TestGetThreadStateAtCheckpointPost:
     async def test_subgraphs_passed_correctly(self):
         """Verify subgraphs parameter from request is passed through."""
         user = User(identity="user-1", scopes=[])
-        session = AsyncMock()
 
         checkpoint = ThreadCheckpoint(
             checkpoint_id="checkpoint-1",
@@ -267,7 +274,7 @@ class TestGetThreadStateAtCheckpointPost:
             "aegra_api.api.threads.get_thread_state_at_checkpoint",
             return_value=mock_thread_state,
         ) as mock_get:
-            await get_thread_state_at_checkpoint_post("thread-123", request, user=user, session=session)
+            await get_thread_state_at_checkpoint_post("thread-123", request, user=user)
 
         # Verify subgraphs=True was passed
         call_args = mock_get.call_args[0]

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.10.3"
+version = "0.10.4"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.10.3"
+version = "0.10.4"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -100,7 +100,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.10.3"
+version = "0.10.4"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
## Description
Aborting a thread history/state request could leave its SQLAlchemy session (and asyncpg connection) checked out, because the endpoint held a `Depends(get_session)` dependency open across a long-running, cancellable LangGraph checkpoint call. Repeated cancellations can exhaust the connection pool. This mirrors the fix already applied to the SSE run-streaming endpoints in #428: look up the thread's `graph_id` via a short-lived session, close it, then perform the LangGraph checkpoint operation with no pool connection held.

## Type of Change
- [x] `fix`: Bug fix
- [x] `test`: Tests added/updated

## Related Issues
Fixes #517

## Changes Made
- Added `_get_thread_graph_id(thread_id, user)` in `threads.py`: looks up a thread's `graph_id` via a short-lived session (`_get_session_maker()`), then closes it before returning.
- Removed `Depends(get_session)` from `get_thread_state`, `update_thread_state`, `get_thread_state_at_checkpoint`, `get_thread_state_at_checkpoint_post`, `get_thread_history_post`, and `get_thread_history_get`, replacing the inline ORM lookup with the helper above. Internal call sites updated to match the new signatures.
- Updated existing unit/integration tests that called these functions directly or overrode `Depends(get_session)` to instead patch `_get_session_maker`, matching the pattern already used for the run-streaming tests.
- Added `tests/unit/test_threads/test_session_lifecycle.py`: regression tests that fail if a future change holds the session open while `aget_state`, `aupdate_state`, or `aget_state_history` run.
- Patch version bump (`0.10.3` → `0.10.4`) in both `aegra-api` and `aegra-cli`, per repo versioning policy.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing performed

`uv run --package aegra-api pytest libs/aegra-api/tests/unit libs/aegra-api/tests/integration` — 1878 passed, 1 skipped.

## Checklist
- [x] Code follows project style (Ruff formatting)
- [x] All linting checks pass (`make lint`)
- [x] Type checking passes (`make type-check`) — zero new `ty` diagnostics vs. the pre-change baseline (same 10 pre-existing dict/RunnableConfig diagnostics unrelated to this change)
- [x] All tests pass (`make test-api`, unit + integration; E2E untouched by this change)
- [ ] Documentation updated (if needed) — not applicable; no user-facing API/behavior contract changed, only internal session lifecycle
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] PR title follows Conventional Commits format

## Additional Notes
Addressed both automated reviews on this PR:
- CodeRabbit: no actionable comments.
- Greptile: condensed a fixture comment to the repo's 2-line comment limit.