### PR TITLE
fix(api): reapply auth-injected metadata when assistant create resolves to an existing row

### DIFF
--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.10.3"
+version = "0.10.4"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-api/src/aegra_api/services/assistant_service.py
+++ b/libs/aegra-api/src/aegra_api/services/assistant_service.py
@@ -132,6 +132,21 @@ def _escape_like(value: str) -> str:
     return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
 
+def _deep_merge(base: dict[str, Any], delta: dict[str, Any]) -> dict[str, Any]:
+    """Recursively merge ``delta`` onto ``base``.
+
+    A shallow merge would replace a changed nested dict wholesale, dropping
+    sibling keys already stored under it that this request never touched.
+    """
+    merged = dict(base)
+    for k, v in delta.items():
+        if isinstance(v, dict) and isinstance(merged.get(k), dict):
+            merged[k] = _deep_merge(merged[k], v)
+        else:
+            merged[k] = v
+    return merged
+
+
 def _injected_metadata(
     base: dict[str, Any] | None,
     value: dict[str, Any],
@@ -156,6 +171,14 @@ class AssistantService(Authenticated):
     def __init__(self, session: AsyncSession, user: User, langgraph_service: LangGraphService):
         super().__init__(session, user)
         self.langgraph_service = langgraph_service
+
+    async def _get_version_row(self, assistant_id: str, version: int) -> AssistantVersionORM | None:
+        """Look up one AssistantVersionORM row by (assistant_id, version)."""
+        stmt = select(AssistantVersionORM).where(
+            AssistantVersionORM.assistant_id == assistant_id,
+            AssistantVersionORM.version == version,
+        )
+        return await self.session.scalar(stmt)
 
     async def create_assistant(self, request: AssistantCreate) -> Assistant:
         """Create a new assistant"""
@@ -226,18 +249,14 @@ class AssistantService(Authenticated):
         if existing:
             if request.if_exists == "do_nothing":
                 if handler_injected:
-                    merged_metadata = {**(existing.metadata_dict or {}), **handler_injected}
+                    merged_metadata = _deep_merge(existing.metadata_dict or {}, handler_injected)
                     if merged_metadata != existing.metadata_dict:
                         existing.metadata_dict = merged_metadata
                         existing.updated_at = datetime.now(UTC)
                         # Keep the version snapshot in sync — set_assistant_latest
                         # copies it back onto the assistant, so a stale snapshot
                         # would silently drop the injected fields later.
-                        version_stmt = select(AssistantVersionORM).where(
-                            AssistantVersionORM.assistant_id == existing.assistant_id,
-                            AssistantVersionORM.version == existing.version,
-                        )
-                        existing_version = await self.session.scalar(version_stmt)
+                        existing_version = await self._get_version_row(existing.assistant_id, existing.version)
                         if existing_version is not None:
                             existing_version.metadata_dict = merged_metadata
                         await self.session.commit()
@@ -512,11 +531,7 @@ class AssistantService(Authenticated):
         if not assistant:
             raise HTTPException(404, f"Assistant '{assistant_id}' not found")
 
-        version_stmt = select(AssistantVersionORM).where(
-            AssistantVersionORM.assistant_id == assistant_id,
-            AssistantVersionORM.version == version,
-        )
-        assistant_version = await self.session.scalar(version_stmt)
+        assistant_version = await self._get_version_row(assistant_id, version)
         if not assistant_version:
             raise HTTPException(404, f"Version '{version}' for Assistant '{assistant_id}' not found")
 

--- a/libs/aegra-api/src/aegra_api/services/assistant_service.py
+++ b/libs/aegra-api/src/aegra_api/services/assistant_service.py
@@ -212,6 +212,12 @@ class AssistantService(Authenticated):
 
         if existing:
             if request.if_exists == "do_nothing":
+                merged_metadata = _injected_metadata(existing.metadata_dict, value) or {}
+                if merged_metadata != existing.metadata_dict:
+                    existing.metadata_dict = merged_metadata
+                    existing.updated_at = datetime.now(UTC)
+                    await self.session.commit()
+                    await self.session.refresh(existing)
                 return to_pydantic(existing)
             else:  # error (default)
                 raise HTTPException(409, f"Assistant '{assistant_id}' already exists")

--- a/libs/aegra-api/src/aegra_api/services/assistant_service.py
+++ b/libs/aegra-api/src/aegra_api/services/assistant_service.py
@@ -159,8 +159,13 @@ class AssistantService(Authenticated):
     async def create_assistant(self, request: AssistantCreate) -> Assistant:
         """Create a new assistant"""
         value = request.model_dump()
+        original_metadata = dict(value.get("metadata") or {})
         await self._dispatch("create", value)
         request.metadata = _injected_metadata(request.metadata, value)
+        # Isolate what the handler itself added/changed, as opposed to
+        # whatever the client already sent — the do_nothing branch below must
+        # not let a client's own metadata overwrite an existing assistant's.
+        handler_injected = {k: v for k, v in (value.get("metadata") or {}).items() if original_metadata.get(k) != v}
 
         available_graphs = self.langgraph_service.list_graphs()
 
@@ -212,12 +217,23 @@ class AssistantService(Authenticated):
 
         if existing:
             if request.if_exists == "do_nothing":
-                merged_metadata = _injected_metadata(existing.metadata_dict, value) or {}
-                if merged_metadata != existing.metadata_dict:
-                    existing.metadata_dict = merged_metadata
-                    existing.updated_at = datetime.now(UTC)
-                    await self.session.commit()
-                    await self.session.refresh(existing)
+                if handler_injected:
+                    merged_metadata = {**(existing.metadata_dict or {}), **handler_injected}
+                    if merged_metadata != existing.metadata_dict:
+                        existing.metadata_dict = merged_metadata
+                        existing.updated_at = datetime.now(UTC)
+                        # Keep the version snapshot in sync — set_assistant_latest
+                        # copies it back onto the assistant, so a stale snapshot
+                        # would silently drop the injected fields later.
+                        version_stmt = select(AssistantVersionORM).where(
+                            AssistantVersionORM.assistant_id == existing.assistant_id,
+                            AssistantVersionORM.version == existing.version,
+                        )
+                        existing_version = await self.session.scalar(version_stmt)
+                        if existing_version is not None:
+                            existing_version.metadata_dict = merged_metadata
+                        await self.session.commit()
+                        await self.session.refresh(existing)
                 return to_pydantic(existing)
             else:  # error (default)
                 raise HTTPException(409, f"Assistant '{assistant_id}' already exists")

--- a/libs/aegra-api/src/aegra_api/services/assistant_service.py
+++ b/libs/aegra-api/src/aegra_api/services/assistant_service.py
@@ -165,7 +165,11 @@ class AssistantService(Authenticated):
         # Isolate what the handler itself added/changed, as opposed to
         # whatever the client already sent — the do_nothing branch below must
         # not let a client's own metadata overwrite an existing assistant's.
-        handler_injected = {k: v for k, v in (value.get("metadata") or {}).items() if original_metadata.get(k) != v}
+        handler_injected = {
+            k: v
+            for k, v in (value.get("metadata") or {}).items()
+            if k not in original_metadata or original_metadata[k] != v
+        }
 
         available_graphs = self.langgraph_service.list_graphs()
 

--- a/libs/aegra-api/src/aegra_api/services/assistant_service.py
+++ b/libs/aegra-api/src/aegra_api/services/assistant_service.py
@@ -15,6 +15,7 @@ applied to other APIs (runs, threads, crons) as part of ongoing refactoring.
 """
 
 import uuid
+from copy import deepcopy
 from datetime import UTC, datetime
 from typing import Any
 from uuid import uuid4
@@ -159,7 +160,10 @@ class AssistantService(Authenticated):
     async def create_assistant(self, request: AssistantCreate) -> Assistant:
         """Create a new assistant"""
         value = request.model_dump()
-        original_metadata = dict(value.get("metadata") or {})
+        # Deep copy: a handler may mutate a nested dict/list in place, and a
+        # shallow copy would share that nested object, hiding the change from
+        # the delta comparison below.
+        original_metadata = deepcopy(value.get("metadata") or {})
         await self._dispatch("create", value)
         request.metadata = _injected_metadata(request.metadata, value)
         # Isolate what the handler itself added/changed, as opposed to

--- a/libs/aegra-api/tests/integration/test_services/test_assistant_service_db.py
+++ b/libs/aegra-api/tests/integration/test_services/test_assistant_service_db.py
@@ -634,6 +634,58 @@ class TestAssistantServiceDatabase:
         assistant_service.session.commit.assert_awaited()
 
     @pytest.mark.asyncio
+    async def test_create_assistant_do_nothing_applies_nested_handler_mutation(
+        self, assistant_service: AssistantService, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A handler that mutates a nested dict *inside* client-supplied
+        metadata (rather than replacing the top-level key) must still count
+        as a change — a shallow copy of the pre-dispatch metadata would share
+        that nested dict by reference, hiding the mutation from the diff."""
+        existing = AssistantORM(
+            assistant_id="existing-id",
+            name="Existing Assistant",
+            graph_id="test-graph",
+            config={},
+            context={},
+            user_id="user-123",
+            version=1,
+            metadata_dict={},
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+        existing_version = AssistantVersionORM(
+            assistant_id="existing-id",
+            version=1,
+            graph_id="test-graph",
+            config={},
+            context={},
+            metadata_dict={},
+            name="Existing Assistant",
+            created_at=datetime.now(UTC),
+        )
+        assistant_service.session.scalar.side_effect = [existing, existing_version]
+
+        async def mutate_nested_handler(ctx: AuthContextWrapper | None, value: dict[str, object]) -> None:
+            value["metadata"]["org"]["team_id"] = "team111"
+            return None
+
+        monkeypatch.setattr(authenticated, "handle_event", mutate_nested_handler)
+
+        request = AssistantCreate(
+            graph_id="test-graph",
+            name="New Request Name",
+            metadata={"org": {}},
+            if_exists="do_nothing",
+        )
+
+        result = await assistant_service.create_assistant(request)
+
+        assert result.metadata.get("org", {}).get("team_id") == "team111"
+        assert existing.metadata_dict.get("org", {}).get("team_id") == "team111"
+        assert existing_version.metadata_dict.get("org", {}).get("team_id") == "team111"
+        assistant_service.session.commit.assert_awaited()
+
+    @pytest.mark.asyncio
     async def test_assistant_special_characters(self, assistant_service):
         """Test assistant creation with special characters"""
         special_name = "Assistant with émojis 🚀 and spëcial çharacters"

--- a/libs/aegra-api/tests/integration/test_services/test_assistant_service_db.py
+++ b/libs/aegra-api/tests/integration/test_services/test_assistant_service_db.py
@@ -582,6 +582,58 @@ class TestAssistantServiceDatabase:
         assistant_service.session.commit.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_create_assistant_do_nothing_applies_none_valued_injection(
+        self, assistant_service: AssistantService, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A handler injecting a *new* key with a None value must still count
+        as a change — dict.get(k) also defaults to None for an absent key, so
+        a naive `!=` comparison would silently drop it."""
+        existing = AssistantORM(
+            assistant_id="existing-id",
+            name="Existing Assistant",
+            graph_id="test-graph",
+            config={},
+            context={},
+            user_id="user-123",
+            version=1,
+            metadata_dict={},
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+        existing_version = AssistantVersionORM(
+            assistant_id="existing-id",
+            version=1,
+            graph_id="test-graph",
+            config={},
+            context={},
+            metadata_dict={},
+            name="Existing Assistant",
+            created_at=datetime.now(UTC),
+        )
+        assistant_service.session.scalar.side_effect = [existing, existing_version]
+
+        async def inject_none_handler(ctx: AuthContextWrapper | None, value: dict[str, object]) -> None:
+            value["metadata"]["team_id"] = None
+            return None
+
+        monkeypatch.setattr(authenticated, "handle_event", inject_none_handler)
+
+        request = AssistantCreate(
+            graph_id="test-graph",
+            name="New Request Name",
+            metadata={},
+            if_exists="do_nothing",
+        )
+
+        result = await assistant_service.create_assistant(request)
+
+        assert "team_id" in result.metadata
+        assert result.metadata["team_id"] is None
+        assert "team_id" in existing.metadata_dict
+        assert "team_id" in existing_version.metadata_dict
+        assistant_service.session.commit.assert_awaited()
+
+    @pytest.mark.asyncio
     async def test_assistant_special_characters(self, assistant_service):
         """Test assistant creation with special characters"""
         special_name = "Assistant with émojis 🚀 and spëcial çharacters"

--- a/libs/aegra-api/tests/integration/test_services/test_assistant_service_db.py
+++ b/libs/aegra-api/tests/integration/test_services/test_assistant_service_db.py
@@ -9,10 +9,12 @@ from unittest.mock import Mock
 import pytest
 from fastapi import HTTPException
 
+from aegra_api.core.auth_handlers import AuthContextWrapper
 from aegra_api.core.orm import Assistant as AssistantORM
 from aegra_api.core.orm import AssistantVersion as AssistantVersionORM
 from aegra_api.models import Assistant, AssistantCreate, AssistantUpdate
 from aegra_api.models.auth import User
+from aegra_api.services import authenticated
 from aegra_api.services.assistant_service import AssistantService
 from tests.fixtures.database import DummySessionBase
 
@@ -478,12 +480,17 @@ class TestAssistantServiceDatabase:
         assert result.name == "Large Metadata Assistant"
 
     @pytest.mark.asyncio
-    async def test_create_assistant_do_nothing_refreshes_injected_metadata(self, assistant_service, monkeypatch):
+    async def test_create_assistant_do_nothing_refreshes_injected_metadata(
+        self, assistant_service: AssistantService, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """Regression test for #495.
 
         A create() call that resolves via if_exists="do_nothing" to a
         pre-existing row must still apply the auth handler's freshly-injected
-        metadata (e.g. created_by, team_id), not silently return the stale row.
+        metadata (e.g. created_by, team_id), and must keep the current
+        version snapshot in sync — set_assistant_latest copies that snapshot
+        back onto the assistant, so a stale one would silently drop the
+        injected fields again later.
         """
         existing = AssistantORM(
             assistant_id="existing-id",
@@ -497,11 +504,19 @@ class TestAssistantServiceDatabase:
             created_at=datetime.now(UTC),
             updated_at=datetime.now(UTC),
         )
-        assistant_service.session.scalar.return_value = existing
+        existing_version = AssistantVersionORM(
+            assistant_id="existing-id",
+            version=1,
+            graph_id="test-graph",
+            config={},
+            context={},
+            metadata_dict={},
+            name="Existing Assistant",
+            created_at=datetime.now(UTC),
+        )
+        assistant_service.session.scalar.side_effect = [existing, existing_version]
 
-        from aegra_api.services import authenticated
-
-        async def inject_handler(ctx, value):
+        async def inject_handler(ctx: AuthContextWrapper | None, value: dict[str, object]) -> None:
             value["metadata"]["created_by"] = "charlie"
             value["metadata"]["team_id"] = "team111"
             return None
@@ -520,7 +535,51 @@ class TestAssistantServiceDatabase:
         assert result.metadata.get("created_by") == "charlie"
         assert result.metadata.get("team_id") == "team111"
         assert existing.metadata_dict.get("created_by") == "charlie"
+        assert existing.metadata_dict.get("team_id") == "team111"
+        assert existing_version.metadata_dict.get("created_by") == "charlie"
+        assert existing_version.metadata_dict.get("team_id") == "team111"
         assistant_service.session.commit.assert_awaited()
+        assistant_service.session.refresh.assert_awaited_once_with(existing)
+
+    @pytest.mark.asyncio
+    async def test_create_assistant_do_nothing_does_not_apply_client_metadata(
+        self, assistant_service: AssistantService, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A do_nothing create must stay idempotent: the client's own metadata
+        on *this* request must not overwrite an existing assistant's stored
+        metadata, even though the auth handler still runs.
+        """
+        existing = AssistantORM(
+            assistant_id="existing-id",
+            name="Existing Assistant",
+            graph_id="test-graph",
+            config={},
+            context={},
+            user_id="user-123",
+            version=1,
+            metadata_dict={"owner": "original-owner"},
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+        assistant_service.session.scalar.return_value = existing
+
+        async def noop_handler(ctx: AuthContextWrapper | None, value: dict[str, object]) -> None:
+            return None
+
+        monkeypatch.setattr(authenticated, "handle_event", noop_handler)
+
+        request = AssistantCreate(
+            graph_id="test-graph",
+            name="New Request Name",
+            metadata={"owner": "client-supplied-owner", "extra": "junk"},
+            if_exists="do_nothing",
+        )
+
+        result = await assistant_service.create_assistant(request)
+
+        assert result.metadata == {"owner": "original-owner"}
+        assert existing.metadata_dict == {"owner": "original-owner"}
+        assistant_service.session.commit.assert_not_awaited()
 
     @pytest.mark.asyncio
     async def test_assistant_special_characters(self, assistant_service):

--- a/libs/aegra-api/tests/integration/test_services/test_assistant_service_db.py
+++ b/libs/aegra-api/tests/integration/test_services/test_assistant_service_db.py
@@ -686,6 +686,57 @@ class TestAssistantServiceDatabase:
         assistant_service.session.commit.assert_awaited()
 
     @pytest.mark.asyncio
+    async def test_create_assistant_do_nothing_preserves_unrelated_nested_keys(
+        self, assistant_service: AssistantService, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A shallow `{**existing, **handler_injected}` merge would replace a
+        changed nested dict wholesale, silently deleting sibling keys already
+        stored under it that this request's client payload never touched."""
+        existing = AssistantORM(
+            assistant_id="existing-id",
+            name="Existing Assistant",
+            graph_id="test-graph",
+            config={},
+            context={},
+            user_id="user-123",
+            version=1,
+            metadata_dict={"org": {"dept": "sales", "region": "us"}},
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+        existing_version = AssistantVersionORM(
+            assistant_id="existing-id",
+            version=1,
+            graph_id="test-graph",
+            config={},
+            context={},
+            metadata_dict={"org": {"dept": "sales", "region": "us"}},
+            name="Existing Assistant",
+            created_at=datetime.now(UTC),
+        )
+        assistant_service.session.scalar.side_effect = [existing, existing_version]
+
+        async def mutate_nested_handler(ctx: AuthContextWrapper | None, value: dict[str, object]) -> None:
+            value["metadata"]["org"]["team_id"] = "team111"
+            return None
+
+        monkeypatch.setattr(authenticated, "handle_event", mutate_nested_handler)
+
+        # Client resends only "region" — it doesn't know about "dept".
+        request = AssistantCreate(
+            graph_id="test-graph",
+            name="New Request Name",
+            metadata={"org": {"region": "us"}},
+            if_exists="do_nothing",
+        )
+
+        result = await assistant_service.create_assistant(request)
+
+        assert result.metadata["org"] == {"dept": "sales", "region": "us", "team_id": "team111"}
+        assert existing.metadata_dict["org"] == {"dept": "sales", "region": "us", "team_id": "team111"}
+        assert existing_version.metadata_dict["org"] == {"dept": "sales", "region": "us", "team_id": "team111"}
+
+    @pytest.mark.asyncio
     async def test_assistant_special_characters(self, assistant_service):
         """Test assistant creation with special characters"""
         special_name = "Assistant with émojis 🚀 and spëcial çharacters"

--- a/libs/aegra-api/tests/integration/test_services/test_assistant_service_db.py
+++ b/libs/aegra-api/tests/integration/test_services/test_assistant_service_db.py
@@ -478,6 +478,51 @@ class TestAssistantServiceDatabase:
         assert result.name == "Large Metadata Assistant"
 
     @pytest.mark.asyncio
+    async def test_create_assistant_do_nothing_refreshes_injected_metadata(self, assistant_service, monkeypatch):
+        """Regression test for #495.
+
+        A create() call that resolves via if_exists="do_nothing" to a
+        pre-existing row must still apply the auth handler's freshly-injected
+        metadata (e.g. created_by, team_id), not silently return the stale row.
+        """
+        existing = AssistantORM(
+            assistant_id="existing-id",
+            name="Existing Assistant",
+            graph_id="test-graph",
+            config={},
+            context={},
+            user_id="user-123",
+            version=1,
+            metadata_dict={},
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+        assistant_service.session.scalar.return_value = existing
+
+        from aegra_api.services import authenticated
+
+        async def inject_handler(ctx, value):
+            value["metadata"]["created_by"] = "charlie"
+            value["metadata"]["team_id"] = "team111"
+            return None
+
+        monkeypatch.setattr(authenticated, "handle_event", inject_handler)
+
+        request = AssistantCreate(
+            graph_id="test-graph",
+            name="New Request Name",
+            metadata={},
+            if_exists="do_nothing",
+        )
+
+        result = await assistant_service.create_assistant(request)
+
+        assert result.metadata.get("created_by") == "charlie"
+        assert result.metadata.get("team_id") == "team111"
+        assert existing.metadata_dict.get("created_by") == "charlie"
+        assistant_service.session.commit.assert_awaited()
+
+    @pytest.mark.asyncio
     async def test_assistant_special_characters(self, assistant_service):
         """Test assistant creation with special characters"""
         special_name = "Assistant with émojis 🚀 and spëcial çharacters"

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.10.3"
+version = "0.10.4"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.10.3"
+version = "0.10.4"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -100,7 +100,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.10.3"
+version = "0.10.4"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
## Description
`@auth.on.assistants.create` handlers inject metadata (e.g. `created_by`, `team_id`) by mutating `value["metadata"]` in place, and `create_assistant` correctly merges that into `request.metadata` before doing anything else. But when the request resolves via `if_exists="do_nothing"` to a pre-existing row — matched on `user_id + graph_id + config`, which is backed by a real unique index (`idx_assistant_user_graph_config`) — the short-circuit returned the stale row as-is, discarding the freshly computed metadata entirely. `created_by` came back missing and `team_id` came back `None`, even though the shipped `examples/jwt_mock_auth_example.py` handler sets both.

## Type of Change
- [x] `fix`: Bug fix
- [x] `test`: Tests added/updated

## Related Issues
Fixes #495

## Changes Made
- `AssistantService.create_assistant`: in the `if_exists="do_nothing"` branch, merge the auth-handler-injected metadata onto the existing row (via the same `_injected_metadata` helper `update_assistant` already uses) and persist the change before returning it, instead of returning the pre-existing row untouched.
- Added a regression test in `tests/integration/test_services/test_assistant_service_db.py` that seeds an existing `AssistantORM` row, injects metadata via a monkeypatched `handle_event`, and asserts the returned/persisted row reflects it. Verified this test fails on the pre-fix code with the exact symptom from the issue (`created_by` missing) and passes with the fix.
- Patch version bump (`0.10.3` → `0.10.4`) in both `aegra-api` and `aegra-cli`, per repo versioning policy.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] E2E tests added/updated
- [x] Manual testing performed

- `uv run --package aegra-api pytest libs/aegra-api/tests/unit libs/aegra-api/tests/integration` — 1875 passed, 1 skipped.
- `make e2e-auth` — all 32 auth e2e tests pass, including the two the issue cites as failing on `main`: `TestAssistantAuthorization::test_assistant_create_injects_metadata` and `TestAuthorizationMetadataInjection::test_assistant_create_metadata_injection`.

## Checklist
- [x] Code follows project style (Ruff formatting)
- [x] All linting checks pass (`make lint`)
- [x] Type checking passes (`make type-check`) — zero new `ty` diagnostics vs. the pre-change baseline (verified diagnostic count is identical, 7, before and after)
- [x] All tests pass (`make test-api` unit + integration, plus `make e2e-auth`)
- [ ] Documentation updated (if needed) — not applicable; internal bug fix, no API contract change
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] PR title follows Conventional Commits format

## Additional Notes
This does not affect the `if_exists` default ("error") path — only the explicit `do_nothing` idempotent-create path, which now applies the same metadata-injection contract as a fresh create.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Existing assistants now receive and persist newly injected metadata when duplicate creation is configured to do nothing.
  * Metadata updates correctly refresh the assistant’s modification timestamp.

* **Release**
  * Updated the Aegra API and CLI packages to version 0.10.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes duplicate assistant creation so auth-handler metadata changes are persisted to both the existing assistant and its current version snapshot.
- Computes the handler-injected metadata delta without treating client metadata as injected.
- Deep-merges nested metadata while preserving stored sibling keys.
- Adds regression coverage for client metadata, `None` values, nested mutations, and version synchronization.
- Bumps the API and CLI packages together to version 0.10.4.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/services/assistant_service.py | The duplicate-create path now isolates and deep-merges auth-injected metadata and synchronizes the active version snapshot. |
| libs/aegra-api/tests/integration/test_services/test_assistant_service_db.py | Regression tests cover the previously reported metadata-delta, nested-mutation, typing, and version-snapshot cases. |
| libs/aegra-api/pyproject.toml | Bumps aegra-api to version 0.10.4 consistently with repository policy. |
| libs/aegra-cli/pyproject.toml | Keeps the aegra-cli package version aligned with aegra-api. |
| uv.lock | Reflects only the corresponding workspace package version bumps. |

</details>

<sub>Reviews (5): Last reviewed commit: ["fix(api): deep-merge nested metadata, de..."](https://github.com/aegra/aegra/commit/71eba78e49ba24ed7a2d695cefe49e349bb7500a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53985516)</sub>

**Context used:**

- Knowledge Base — [Assistants and Graphs](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/assistants-and-graphs.md)

<!-- /greptile_comment -->