### PR TITLE
fix(worker): sweep runs orphaned without a lease in local mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,6 +80,8 @@ REDIS_URL=redis://localhost:6379/0
 # LEASE_DURATION_SECONDS=30
 # HEARTBEAT_INTERVAL_SECONDS=10
 # REAPER_INTERVAL_SECONDS=15
+# ORPHAN_SWEEP_ENABLED=true
+# ORPHAN_SWEEP_MIN_AGE_SECONDS=300
 
 # --- Cron Scheduler ---
 # Enable the background cron scheduler that fires scheduled runs.

--- a/docs/guides/worker-architecture.mdx
+++ b/docs/guides/worker-architecture.mdx
@@ -225,6 +225,13 @@ sequenceDiagram
 
 The reaper runs on every instance (default every 15 seconds). This is safe — the atomic lease acquisition prevents duplicate execution.
 
+### Runs orphaned without a lease
+
+`LocalExecutor` never takes a lease, so a hard crash in local mode leaves a `running` row the reaper cannot match, on a thread stuck `busy`.
+Each instance therefore sweeps once at startup, in broker mode only, marking such rows `error` and reconciling their threads.
+Only rows idle longer than `ORPHAN_SWEEP_MIN_AGE_SECONDS` (default 300) are touched, and `ORPHAN_SWEEP_ENABLED=false` disables the sweep; both assume every replica agrees on `REDIS_BROKER_ENABLED`.
+The sweep fails these runs rather than re-enqueueing them, since an orphan may be old enough that replaying its side effects would surprise callers.
+
 ## Graceful shutdown
 
 On SIGTERM (rolling deploy, pod reschedule, node drain) the executor waits up to `WORKER_DRAIN_TIMEOUT` (default 30s) for in-flight runs to finish. Runs still executing when the window closes are **handed back to the queue**, not finalized: the run is reset to `pending` with its lease cleared and re-enqueued, so another instance resumes it from the last checkpoint — the same guarantee the crash path provides. Clients streaming the run stay connected and pick up events from the resuming worker.

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.10.4"
+version = "0.10.5"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-api/src/aegra_api/main.py
+++ b/libs/aegra-api/src/aegra_api/main.py
@@ -10,6 +10,7 @@ from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from fastapi.routing import APIRoute, APIRouter
+from sqlalchemy.exc import SQLAlchemyError
 
 from aegra_api import __version__
 from aegra_api.api.assistants import router as assistants_router
@@ -133,6 +134,11 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
 
     # Start lease reaper (recovers crashed worker runs, Redis mode only)
     if settings.redis.REDIS_BROKER_ENABLED:
+        # Lease-less orphans are invisible to the periodic reaper.
+        try:
+            await lease_reaper.sweep_leaseless_orphans()
+        except (SQLAlchemyError, OSError):
+            logger.exception("Orphan sweep failed; continuing startup")
         await lease_reaper.start()
 
     # Start cron scheduler (fires due cron jobs)

--- a/libs/aegra-api/src/aegra_api/observability/metrics.py
+++ b/libs/aegra-api/src/aegra_api/observability/metrics.py
@@ -18,7 +18,8 @@ REAPER_RECOVERED_RUNS = prometheus_client.Counter(
     "aegra_reaper_recovered_runs_total",
     "Runs recovered by the lease reaper, by outcome: crashed_retried "
     "(expired lease, re-enqueued), crashed_exhausted (max retries exceeded, "
-    "marked failed), stuck_pending (never claimed, re-enqueued). Counts only "
+    "marked error), stuck_pending (never claimed, re-enqueued), "
+    "local_orphan (no lease, swept at startup and marked error). Counts only "
     "confirmed Redis pushes and DB updates; recovery that falls back to the "
     "workers' Postgres poll during a Redis outage is not counted.",
     labelnames=["outcome"],
@@ -26,7 +27,7 @@ REAPER_RECOVERED_RUNS = prometheus_client.Counter(
 
 # Pre-create label children so every outcome series renders as 0 on /metrics
 # before the first recovery event (absent series break rate() alerts).
-for _outcome in ("crashed_retried", "crashed_exhausted", "stuck_pending"):
+for _outcome in ("crashed_retried", "crashed_exhausted", "stuck_pending", "local_orphan"):
     REAPER_RECOVERED_RUNS.labels(outcome=_outcome)
 
 

--- a/libs/aegra-api/src/aegra_api/services/lease_reaper.py
+++ b/libs/aegra-api/src/aegra_api/services/lease_reaper.py
@@ -4,6 +4,9 @@ Periodically scans the runs table for rows where
 ``status='running' AND lease_expires_at < now()``. It atomically either
 returns them to ``pending`` or marks their retry budget exhausted, then
 re-enqueues only retryable run IDs.
+
+Runs that never took a lease cannot match that predicate; a startup sweep
+reconciles those separately.
 """
 
 import asyncio
@@ -22,6 +25,11 @@ from aegra_api.services.run_status import set_thread_status_if_no_active_runs
 from aegra_api.settings import settings
 
 logger = structlog.getLogger(__name__)
+
+# Bound the startup sweep so a large backlog cannot open one huge transaction.
+_SWEEP_BATCH_SIZE = 500
+_SWEEP_MAX_BATCHES = 100
+_MAX_LOGGED_RUN_IDS = 20
 
 
 class LeaseReaper:
@@ -116,6 +124,93 @@ class LeaseReaper:
             stuck_pending = [row[0] for row in stuck_result.fetchall()]
 
         return crashed, stuck_pending
+
+    @staticmethod
+    async def sweep_leaseless_orphans() -> int:
+        """Fail stale ``running`` rows that never took a lease. Returns the count swept.
+
+        Assumes every replica agrees on ``REDIS_BROKER_ENABLED``; a replica still
+        running the local executor would have its active runs swept.
+        """
+        if not settings.worker.ORPHAN_SWEEP_ENABLED:
+            logger.info("Orphan sweep disabled, skipping")
+            return 0
+
+        total = 0
+        sample: list[str] = []
+
+        for _ in range(_SWEEP_MAX_BATCHES):
+            selected, swept = await LeaseReaper._sweep_one_batch()
+            if swept:
+                total += len(swept)
+                sample.extend(swept[: _MAX_LOGGED_RUN_IDS - len(sample)])
+                REAPER_RECOVERED_RUNS.labels(outcome="local_orphan").inc(len(swept))
+            if selected == 0:
+                break
+        else:
+            logger.warning("Orphan sweep hit its batch limit; the rest waits for the next startup")
+
+        if total:
+            logger.warning("Swept runs orphaned without a lease", count=total, run_ids=sample)
+
+        return total
+
+    @staticmethod
+    async def _sweep_one_batch() -> tuple[int, list[str]]:
+        """Sweep one batch in a single transaction. Returns (rows seen, run IDs swept)."""
+        now = datetime.now(UTC)
+        cutoff = now - timedelta(seconds=settings.worker.ORPHAN_SWEEP_MIN_AGE_SECONDS)
+        swept: list[str] = []
+        threads_by_user: dict[str, set[str]] = {}
+
+        maker = _get_session_maker()
+        async with maker() as session:
+            locked_result = await session.execute(
+                select(RunORM.run_id, RunORM.thread_id, RunORM.user_id)
+                .where(
+                    RunORM.status == "running",
+                    RunORM.claimed_by.is_(None),
+                    RunORM.lease_expires_at.is_(None),
+                    RunORM.updated_at < cutoff,
+                )
+                .limit(_SWEEP_BATCH_SIZE)
+                .with_for_update(skip_locked=True)
+            )
+            rows = locked_result.fetchall()
+
+            for run_id, thread_id, user_id in rows:
+                update_result = await session.execute(
+                    update(RunORM)
+                    .where(
+                        RunORM.run_id == run_id,
+                        RunORM.user_id == user_id,
+                        RunORM.status == "running",
+                        RunORM.claimed_by.is_(None),
+                        RunORM.lease_expires_at.is_(None),
+                    )
+                    .values(
+                        status="error",
+                        error_message="Run orphaned without a lease and could not be recovered",
+                        updated_at=now,
+                    )
+                    .returning(RunORM.run_id)
+                )
+                if update_result.scalar_one_or_none() is None:
+                    continue
+
+                swept.append(run_id)
+                threads_by_user.setdefault(user_id, set()).add(thread_id)
+
+            for user_id, thread_ids in threads_by_user.items():
+                await set_thread_status_if_no_active_runs(
+                    session,
+                    thread_ids,
+                    "error",
+                    user_id=user_id,
+                )
+            await session.commit()
+
+        return len(rows), swept
 
     @staticmethod
     async def _recover_crashed_runs(run_ids: list[str]) -> tuple[list[str], list[str]]:

--- a/libs/aegra-api/src/aegra_api/settings.py
+++ b/libs/aegra-api/src/aegra_api/settings.py
@@ -376,6 +376,11 @@ class WorkerSettings(EnvBase):
     STUCK_PENDING_THRESHOLD_SECONDS: int = 120
     POSTGRES_POLL_INTERVAL_SECONDS: int = 5
 
+    # Startup sweep for running rows the reaper cannot see: no lease, no owner.
+    # Assumes every replica agrees on REDIS_BROKER_ENABLED.
+    ORPHAN_SWEEP_ENABLED: bool = True
+    ORPHAN_SWEEP_MIN_AGE_SECONDS: int = Field(default=300, ge=1)
+
     @model_validator(mode="after")
     def _validate_lease_timing(self) -> "WorkerSettings":
         """Ensure the worker lease safely outlives missed heartbeat intervals."""

--- a/libs/aegra-api/tests/integration/test_lease_reaper_orphan_sweep_db.py
+++ b/libs/aegra-api/tests/integration/test_lease_reaper_orphan_sweep_db.py
@@ -1,0 +1,115 @@
+"""Real-PostgreSQL regression tests for the lease-less orphan sweep."""
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
+from uuid import uuid4
+
+import asyncpg
+import pytest
+from sqlalchemy import delete, select, text
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker, create_async_engine
+
+from aegra_api.core.orm import Run as RunORM
+from aegra_api.core.orm import Thread as ThreadORM
+from aegra_api.services.lease_reaper import LeaseReaper
+from aegra_api.settings import settings
+
+_USER_ID = "orphan-sweep-test-user"
+
+
+async def _skip_unless_schema_ready(engine: AsyncEngine) -> None:
+    """Skip when the test database is unreachable or unmigrated."""
+    runs_table = None
+    try:
+        async with engine.begin() as conn:
+            runs_table = await conn.scalar(text("SELECT to_regclass('public.runs')"))
+    except (SQLAlchemyError, asyncpg.PostgresError, OSError) as exc:
+        pytest.skip(f"PostgreSQL test database is unavailable: {exc}")
+    if runs_table is None:
+        pytest.skip("runs table is unavailable; run Alembic migrations before this DB regression test")
+
+
+async def _seed_leaseless_run(maker: async_sessionmaker, *, age: timedelta) -> tuple[str, str]:
+    """Insert a busy thread with a running, never-leased run of the given age."""
+    thread_id = f"orphan-thread-{uuid4()}"
+    run_id = f"orphan-run-{uuid4()}"
+    stamped = datetime.now(UTC) - age
+
+    async with maker() as session:
+        session.add(ThreadORM(thread_id=thread_id, status="busy", user_id=_USER_ID))
+        await session.flush()
+        session.add(
+            RunORM(
+                run_id=run_id,
+                thread_id=thread_id,
+                status="running",
+                user_id=_USER_ID,
+                claimed_by=None,
+                lease_expires_at=None,
+                updated_at=stamped,
+            )
+        )
+        await session.commit()
+    return thread_id, run_id
+
+
+async def _cleanup(maker: async_sessionmaker, thread_id: str) -> None:
+    async with maker() as session:
+        await session.execute(delete(RunORM).where(RunORM.thread_id == thread_id))
+        await session.execute(delete(ThreadORM).where(ThreadORM.thread_id == thread_id))
+        await session.commit()
+
+
+@asynccontextmanager
+async def _seeded_orphan(age: timedelta) -> AsyncIterator[tuple[async_sessionmaker, str, str]]:
+    """Seed a lease-less orphan of the given age; always clean up and dispose."""
+    engine = create_async_engine(settings.db.database_url)
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    thread_id: str | None = None
+    try:
+        await _skip_unless_schema_ready(engine)
+        thread_id, run_id = await _seed_leaseless_run(maker, age=age)
+        yield maker, thread_id, run_id
+    finally:
+        if thread_id is not None:
+            await _cleanup(maker, thread_id)
+        await engine.dispose()
+
+
+async def _statuses(maker: async_sessionmaker, thread_id: str, run_id: str) -> tuple[str, str]:
+    async with maker() as session:
+        run_status = await session.scalar(select(RunORM.status).where(RunORM.run_id == run_id))
+        thread_status = await session.scalar(select(ThreadORM.status).where(ThreadORM.thread_id == thread_id))
+    return run_status, thread_status
+
+
+@pytest.mark.asyncio
+async def test_sweep_fails_stale_leaseless_run_and_frees_its_thread() -> None:
+    """A running row with no lease is invisible to the reaper and must be swept."""
+    async with _seeded_orphan(timedelta(hours=1)) as (maker, thread_id, run_id):
+        with (
+            patch("aegra_api.services.lease_reaper._get_session_maker", return_value=maker),
+            patch.object(settings.worker, "ORPHAN_SWEEP_ENABLED", True),
+            patch.object(settings.worker, "ORPHAN_SWEEP_MIN_AGE_SECONDS", 300),
+        ):
+            swept = await LeaseReaper.sweep_leaseless_orphans()
+
+        assert swept >= 1
+        assert await _statuses(maker, thread_id, run_id) == ("error", "error")
+
+
+@pytest.mark.asyncio
+async def test_sweep_leaves_a_recently_started_leaseless_run_alone() -> None:
+    """A local run that only just started must not be mistaken for a crash."""
+    async with _seeded_orphan(timedelta(seconds=5)) as (maker, thread_id, run_id):
+        with (
+            patch("aegra_api.services.lease_reaper._get_session_maker", return_value=maker),
+            patch.object(settings.worker, "ORPHAN_SWEEP_ENABLED", True),
+            patch.object(settings.worker, "ORPHAN_SWEEP_MIN_AGE_SECONDS", 300),
+        ):
+            await LeaseReaper.sweep_leaseless_orphans()
+
+        assert await _statuses(maker, thread_id, run_id) == ("running", "busy")

--- a/libs/aegra-api/tests/unit/test_services/test_lease_reaper.py
+++ b/libs/aegra-api/tests/unit/test_services/test_lease_reaper.py
@@ -4,9 +4,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from redis import RedisError
+from sqlalchemy.dialects import postgresql
 
 from aegra_api.observability.metrics import REAPER_RECOVERED_RUNS
-from aegra_api.services.lease_reaper import LeaseReaper
+from aegra_api.services.lease_reaper import _SWEEP_MAX_BATCHES, LeaseReaper
 
 
 def _recovered_count(outcome: str) -> float:
@@ -400,3 +401,125 @@ class TestStartStop:
         # Should not raise
         await reaper.stop()
         assert reaper._task is None
+
+
+class TestSweepOneBatch:
+    @pytest.mark.asyncio
+    async def test_marks_orphan_error_and_reconciles_its_thread(self) -> None:
+        session = AsyncMock()
+        locked = MagicMock()
+        locked.fetchall.return_value = [("run-1", "thread-1", "user-1")]
+        updated = MagicMock()
+        updated.scalar_one_or_none.return_value = "run-1"
+        session.execute = AsyncMock(side_effect=[locked, updated])
+        session.commit = AsyncMock()
+        maker = _make_session_maker(session)
+
+        with (
+            patch("aegra_api.services.lease_reaper._get_session_maker", return_value=maker),
+            patch("aegra_api.services.lease_reaper.settings") as mock_settings,
+            patch(
+                "aegra_api.services.lease_reaper.set_thread_status_if_no_active_runs",
+                new_callable=AsyncMock,
+            ) as mock_set_thread,
+        ):
+            mock_settings.worker.ORPHAN_SWEEP_MIN_AGE_SECONDS = 300
+            seen, swept = await LeaseReaper._sweep_one_batch()
+
+        assert (seen, swept) == (1, ["run-1"])
+        mock_set_thread.assert_awaited_once_with(session, {"thread-1"}, "error", user_id="user-1")
+        session.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_selects_only_running_rows_that_never_held_a_lease(self) -> None:
+        session = AsyncMock()
+        locked = MagicMock()
+        locked.fetchall.return_value = []
+        session.execute = AsyncMock(return_value=locked)
+        session.commit = AsyncMock()
+        maker = _make_session_maker(session)
+
+        with (
+            patch("aegra_api.services.lease_reaper._get_session_maker", return_value=maker),
+            patch("aegra_api.services.lease_reaper.settings") as mock_settings,
+            patch(
+                "aegra_api.services.lease_reaper.set_thread_status_if_no_active_runs",
+                new_callable=AsyncMock,
+            ),
+        ):
+            mock_settings.worker.ORPHAN_SWEEP_MIN_AGE_SECONDS = 300
+            await LeaseReaper._sweep_one_batch()
+
+        statement = session.execute.await_args_list[0].args[0]
+        compiled = str(statement.compile(dialect=postgresql.dialect()))
+        assert "runs.claimed_by IS NULL" in compiled
+        assert "runs.lease_expires_at IS NULL" in compiled
+        assert "runs.updated_at <" in compiled
+        assert "FOR UPDATE SKIP LOCKED" in compiled
+
+    @pytest.mark.asyncio
+    async def test_counts_a_row_seen_but_not_swept_when_its_update_loses(self) -> None:
+        session = AsyncMock()
+        locked = MagicMock()
+        locked.fetchall.return_value = [("run-1", "thread-1", "user-1")]
+        updated = MagicMock()
+        updated.scalar_one_or_none.return_value = None
+        session.execute = AsyncMock(side_effect=[locked, updated])
+        session.commit = AsyncMock()
+        maker = _make_session_maker(session)
+
+        with (
+            patch("aegra_api.services.lease_reaper._get_session_maker", return_value=maker),
+            patch("aegra_api.services.lease_reaper.settings") as mock_settings,
+            patch(
+                "aegra_api.services.lease_reaper.set_thread_status_if_no_active_runs",
+                new_callable=AsyncMock,
+            ) as mock_set_thread,
+        ):
+            mock_settings.worker.ORPHAN_SWEEP_MIN_AGE_SECONDS = 300
+            seen, swept = await LeaseReaper._sweep_one_batch()
+
+        assert (seen, swept) == (1, [])
+        mock_set_thread.assert_not_awaited()
+
+
+class TestSweepLeaselessOrphans:
+    @pytest.mark.asyncio
+    async def test_keeps_batching_until_a_batch_sees_nothing(self) -> None:
+        batches = [(2, ["run-1", "run-2"]), (1, ["run-3"]), (0, [])]
+        before = _recovered_count("local_orphan")
+
+        with (
+            patch("aegra_api.services.lease_reaper.settings") as mock_settings,
+            patch.object(LeaseReaper, "_sweep_one_batch", new_callable=AsyncMock, side_effect=batches) as mock_batch,
+        ):
+            mock_settings.worker.ORPHAN_SWEEP_ENABLED = True
+            total = await LeaseReaper.sweep_leaseless_orphans()
+
+        assert total == 3
+        assert mock_batch.await_count == 3
+        assert _recovered_count("local_orphan") == before + 3
+
+    @pytest.mark.asyncio
+    async def test_stops_at_the_batch_limit_instead_of_looping_forever(self) -> None:
+        with (
+            patch("aegra_api.services.lease_reaper.settings") as mock_settings,
+            patch.object(LeaseReaper, "_sweep_one_batch", new_callable=AsyncMock, return_value=(1, [])) as mock_batch,
+        ):
+            mock_settings.worker.ORPHAN_SWEEP_ENABLED = True
+            total = await LeaseReaper.sweep_leaseless_orphans()
+
+        assert total == 0
+        assert mock_batch.await_count == _SWEEP_MAX_BATCHES
+
+    @pytest.mark.asyncio
+    async def test_does_not_touch_the_database_when_disabled(self) -> None:
+        with (
+            patch("aegra_api.services.lease_reaper.settings") as mock_settings,
+            patch.object(LeaseReaper, "_sweep_one_batch", new_callable=AsyncMock) as mock_batch,
+        ):
+            mock_settings.worker.ORPHAN_SWEEP_ENABLED = False
+            total = await LeaseReaper.sweep_leaseless_orphans()
+
+        assert total == 0
+        mock_batch.assert_not_awaited()

--- a/libs/aegra-api/tests/unit/test_settings.py
+++ b/libs/aegra-api/tests/unit/test_settings.py
@@ -588,6 +588,8 @@ class TestWorkerSettingsLeaseValidation:
             "BG_JOB_TIMEOUT_SECS",
             "BG_JOB_MAX_RETRIES",
             "POSTGRES_POLL_INTERVAL_SECONDS",
+            "ORPHAN_SWEEP_ENABLED",
+            "ORPHAN_SWEEP_MIN_AGE_SECONDS",
         ):
             monkeypatch.delenv(var, raising=False)
 
@@ -637,3 +639,20 @@ class TestCronSettingsValidation:
 
         with pytest.raises((ValueError, ValidationError), match="CRON_POLL_INTERVAL_SECONDS"):
             CronSettings(_env_file=None)
+
+
+class TestOrphanSweepSettings:
+    """The sweep's age threshold is its only guard against reaping a live run."""
+
+    def test_defaults_to_five_minutes_and_enabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ORPHAN_SWEEP_ENABLED", raising=False)
+        monkeypatch.delenv("ORPHAN_SWEEP_MIN_AGE_SECONDS", raising=False)
+        ws = WorkerSettings(_env_file=None)
+        assert ws.ORPHAN_SWEEP_ENABLED is True
+        assert ws.ORPHAN_SWEEP_MIN_AGE_SECONDS == 300
+
+    @pytest.mark.parametrize("value", ["0", "-1"])
+    def test_rejects_non_positive_age(self, monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+        monkeypatch.setenv("ORPHAN_SWEEP_MIN_AGE_SECONDS", value)
+        with pytest.raises(ValidationError, match="ORPHAN_SWEEP_MIN_AGE_SECONDS"):
+            WorkerSettings(_env_file=None)

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.10.4"
+version = "0.10.5"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-cli/src/aegra_cli/templates/env.example.template
+++ b/libs/aegra-cli/src/aegra_cli/templates/env.example.template
@@ -80,6 +80,8 @@ REDIS_URL=redis://localhost:6379/0
 # LEASE_DURATION_SECONDS=30
 # HEARTBEAT_INTERVAL_SECONDS=10
 # REAPER_INTERVAL_SECONDS=15
+# ORPHAN_SWEEP_ENABLED=true
+# ORPHAN_SWEEP_MIN_AGE_SECONDS=300
 
 # --- Cron Scheduler ---
 # Enable the background cron scheduler that fires scheduled runs.

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.10.4"
+version = "0.10.5"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -100,7 +100,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.10.4"
+version = "0.10.5"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
`LocalExecutor` never takes a lease, so a hard crash leaves the run `running` with `claimed_by` and `lease_expires_at` both `NULL` — a row no reaper predicate can ever match, on a thread that stays `busy` and rejects resumes, and enabling the Redis broker does not clean those rows up. This adds a one-shot startup sweep (broker mode only, before the periodic reaper) that marks stale lease-less runs `error` and reconciles their threads in the same transaction, guarded by `ORPHAN_SWEEP_MIN_AGE_SECONDS` so a run still executing on a local-mode replica is not mistaken for a crash.

Fixes #476

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic startup recovery for stale, abandoned local runs.
  * Recovered runs are marked as errors and their associated threads are released.
  * Added settings to enable or disable recovery and configure the minimum run age.

* **Bug Fixes**
  * Improved handling of abandoned local runs after service restarts.
  * Added monitoring visibility for locally recovered runs.

* **Chores**
  * Updated the API and CLI release versions to 0.10.4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a broker-mode startup sweep that marks stale lease-less local runs as errors and reconciles their threads.
- Adds bounded, transactional orphan recovery and a recovery metric.
- Adds configuration, environment templates, operator documentation, and regression tests.
- Updates API and CLI package versions to 0.10.5.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because temporary row-lock contention can still leave lease-less runs and their threads orphaned indefinitely.

The startup loop treats a zero-row `SKIP LOCKED` result as proof that no eligible work remains, although it can also mean every eligible row is temporarily locked; because the sweep is one-shot and the periodic reaper cannot match lease-less rows, those runs can remain running indefinitely.

**Files Needing Attention:** libs/aegra-api/src/aegra_api/services/lease_reaper.py

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/services/lease_reaper.py | Adds transactional startup recovery, but the prior `SKIP LOCKED` zero-result termination issue remains. |
| libs/aegra-api/src/aegra_api/main.py | Runs the one-shot sweep before starting the periodic reaper and allows startup to continue after expected database or OS failures. |
| libs/aegra-api/src/aegra_api/settings.py | Adds an enabled flag and a positive minimum-age setting for orphan recovery. |
| docs/guides/worker-architecture.mdx | Documents the startup sweep, broker-mode constraint, terminal behavior, and configuration. |
| libs/aegra-api/tests/integration/test_lease_reaper_orphan_sweep_db.py | Verifies stale orphans are failed and recent lease-less runs remain untouched against PostgreSQL. |
| libs/aegra-api/tests/unit/test_services/test_lease_reaper.py | Covers selection predicates, thread reconciliation, batching, metrics, limits, and disabled behavior. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Broker-mode startup] --> B{Orphan sweep enabled?}
  B -- No --> F[Start periodic lease reaper]
  B -- Yes --> C[Select stale lease-less running rows<br/>FOR UPDATE SKIP LOCKED]
  C --> D[Mark selected runs error]
  D --> E[Reconcile affected thread statuses]
  E --> G{Selected rows?}
  G -- Yes --> C
  G -- No --> F
```
</details>

<sub>Reviews (6): Last reviewed commit: ["fix(worker): sweep runs orphaned without..."](https://github.com/aegra/aegra/commit/d337bae20ef9c8a8fb0ff8e041730a0b46ddd85a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54400221)</sub>

**Context used:**

- Knowledge Base — [Broker and worker coordination](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/broker-and-worker-coordination.md)
- Knowledge Base — [Run execution lifecycle](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/run-execution.md)

<!-- /greptile_comment -->