### PR TITLE
fix(api): honor cancel even when Redis pub/sub drops

### DIFF
--- a/docs/guides/streaming.mdx
+++ b/docs/guides/streaming.mdx
@@ -224,7 +224,7 @@ await client.runs.cancel(
 
 Cancellation is asynchronous while a live worker owns the run.
 The cancel response may therefore still show `pending` or `running`; poll, join, or stream the run until it reaches a terminal status.
-Use the REST endpoint with `wait=1` when the caller needs the request to wait briefly for the worker to settle.
+Use `wait=1` to block the request until the worker settles (about 25 seconds by default: two heartbeats plus slack). The response may still be non-terminal if that bound expires.
 
 ## SSE reconnection
 

--- a/docs/guides/worker-architecture.mdx
+++ b/docs/guides/worker-architecture.mdx
@@ -232,10 +232,11 @@ The API first tries an ownership-safe database update that succeeds only when th
 That path interrupts the run, clears its lease, and marks the thread idle in one transaction when no other run is active.
 The API still broadcasts a best-effort cancellation after this transaction because an expired worker may be delayed rather than dead.
 It emits the terminal stream event itself so connected clients always receive a definitive end event.
-When the run has a live owner, the API leaves the database state unchanged and uses Redis pub/sub to ask that worker to cancel its task and finalize the run.
+When the run has a live owner, the API leaves the database state unchanged, records a durable Redis cancel intent, and uses Redis pub/sub to ask that worker to cancel its task and finalize the run.
+The owning worker also checks that intent on its lease heartbeat, so a missed pub/sub message is still recovered.
 Requests for runs that are already terminal are no-ops, so a late cancellation cannot overwrite a successful or failed result.
 Worker finalization is also conditional on the run remaining active, which prevents a delayed worker from overwriting a terminal state committed by the API.
-The response contains the currently persisted state; set `wait=1` to wait for a live worker to finalize the run before returning.
+The response contains the currently persisted state; set `wait=1` to wait for a live worker to finalize the run before returning (about 25 seconds by default).
 
 ```mermaid
 sequenceDiagram

--- a/docs/guides/worker-architecture.mdx
+++ b/docs/guides/worker-architecture.mdx
@@ -255,8 +255,10 @@ sequenceDiagram
         A->>R: PUBLISH end event
     else live owner
         PG-->>A: no row updated
+        A->>R: SET aegra:run:{run_id}:cancel TTL 1h
         A->>R: PUBLISH aegra:run:cancel
         R->>B: Cancel message received
+        Note over B: heartbeat GET intent if pub/sub missed
         B->>B: task.cancel()
         B->>PG: Finalize run and thread
         B->>R: PUBLISH end event
@@ -288,6 +290,7 @@ sequenceDiagram
 | `aegra:run:cache:{run_id}` | SSE replay buffer | Worker (RPUSH) | API (LRANGE) |
 | `aegra:run:counter:{run_id}` | Event sequence counter | Worker (INCR) | API (GET) |
 | `aegra:run:cancel` | Cancel commands | API (PUBLISH) | Worker (SUBSCRIBE) |
+| `aegra:run:{run_id}:cancel` | Durable cancel/interrupt intent (TTL 1h) | API (SET) | Worker heartbeat (GET) |
 | `aegra:run:done:{run_id}` | Completion signal (TTL 1h) | Worker (SET) | API (EXISTS) |
 
 ## Configuration

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Aegra",
     "description": "Production-ready Agent Protocol server",
-    "version": "0.10.3"
+    "version": "0.10.4"
   },
   "paths": {
     "/info": {
@@ -2265,7 +2265,7 @@
           "Thread Runs"
         ],
         "summary": "Cancel Run Endpoint",
-        "description": "Cancel or interrupt a running execution.\n\nUse `action=cancel` to hard-cancel the run immediately, or\n`action=interrupt` to cooperatively interrupt (the graph can handle the\ninterrupt and save partial state). Set `wait=1` to wait up to 10 seconds\nfor the background task to settle before returning the updated run. The\nresponse may still report `pending` or `running` if the timeout expires.\nWithout `wait=1`, a live-owned run is cancelled asynchronously, so the\nresponse may still report `pending` or `running`.",
+        "description": "Cancel or interrupt a running execution.\n\nUse `action=cancel` to hard-cancel the run immediately, or\n`action=interrupt` to cooperatively interrupt (the graph can handle the\ninterrupt and save partial state). Set `wait=1` to wait up to 25 seconds\nby default (2 worker heartbeats + 5s) for the background task to settle\nbefore returning the updated run. The response may still report `pending`\nor `running` if the bound expires. Without `wait=1`, a live-owned run is\ncancelled asynchronously, so the response may still report `pending` or\n`running`.",
         "operationId": "cancel_run_endpoint_threads__thread_id__runs__run_id__cancel_post",
         "parameters": [
           {
@@ -2294,11 +2294,11 @@
               "type": "integer",
               "maximum": 1,
               "minimum": 0,
-              "description": "Set to 1 to wait up to 10 seconds for the run task to settle before returning.",
+              "description": "Set to 1 to wait for the run task to settle before returning. Default bound is 25 seconds (2 heartbeats + 5s); the response may still report pending or running if the bound expires.",
               "default": 0,
               "title": "Wait"
             },
-            "description": "Set to 1 to wait up to 10 seconds for the run task to settle before returning."
+            "description": "Set to 1 to wait for the run task to settle before returning. Default bound is 25 seconds (2 heartbeats + 5s); the response may still report pending or running if the bound expires."
           },
           {
             "name": "action",

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.10.3"
+version = "0.10.4"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-api/src/aegra_api/api/runs.py
+++ b/libs/aegra-api/src/aegra_api/api/runs.py
@@ -18,7 +18,7 @@ from aegra_api.core.auth_deps import auth_dependency, get_current_user
 from aegra_api.core.auth_handlers import build_auth_context, handle_event
 from aegra_api.core.orm import Run as RunORM
 from aegra_api.core.orm import Thread as ThreadORM
-from aegra_api.core.orm import _get_session_maker, get_session
+from aegra_api.core.orm import _get_session_maker, get_session, get_session_maker
 from aegra_api.core.sse import create_end_event, get_sse_headers, make_sse_response, sse_to_bytes
 from aegra_api.models import Run, RunCreate, RunStatus, User
 from aegra_api.models.enums import RunCancellationAction
@@ -26,7 +26,12 @@ from aegra_api.models.errors import CONFLICT, NOT_FOUND, SSE_RESPONSE
 from aegra_api.services.broker import broker_manager
 from aegra_api.services.run_preparation import _prepare_run
 from aegra_api.services.run_status import interrupt_unowned_run
-from aegra_api.services.run_waiters import TERMINAL_STATES, encode_output, heartbeat_wait_body
+from aegra_api.services.run_waiters import (
+    TERMINAL_STATES,
+    encode_output,
+    heartbeat_wait_body,
+    wait_for_terminal_run,
+)
 from aegra_api.services.streaming_service import streaming_service
 from aegra_api.settings import settings
 from aegra_api.utils.status_compat import validate_run_status
@@ -482,51 +487,59 @@ async def cancel_run_endpoint(
         0,
         ge=0,
         le=1,
-        description="Set to 1 to wait up to 10 seconds for the run task to settle before returning.",
+        description=(
+            "Set to 1 to wait for the run task to settle before returning. "
+            "Default bound is 25 seconds (2 heartbeats + 5s); the response may "
+            "still report pending or running if the bound expires."
+        ),
     ),
     action: RunCancellationAction = Query(
         "cancel",
         description="Cancellation strategy: 'cancel' for hard cancel, 'interrupt' for cooperative interrupt.",
     ),
     user: User = Depends(get_current_user),
-    session: AsyncSession = Depends(get_session),
 ) -> Run:
     """Cancel or interrupt a running execution.
 
     Use `action=cancel` to hard-cancel the run immediately, or
     `action=interrupt` to cooperatively interrupt (the graph can handle the
-    interrupt and save partial state). Set `wait=1` to wait up to 10 seconds
-    for the background task to settle before returning the updated run. The
-    response may still report `pending` or `running` if the timeout expires.
-    Without `wait=1`, a live-owned run is cancelled asynchronously, so the
-    response may still report `pending` or `running`.
+    interrupt and save partial state). Set `wait=1` to wait up to 25 seconds
+    by default (2 worker heartbeats + 5s) for the background task to settle
+    before returning the updated run. The response may still report `pending`
+    or `running` if the bound expires. Without `wait=1`, a live-owned run is
+    cancelled asynchronously, so the response may still report `pending` or
+    `running`.
     """
+    maker = get_session_maker()
     logger.info(f"[cancel_run] fetch run run_id={run_id} thread_id={thread_id} user={user.identity}")
-    run_orm = await session.scalar(
-        select(RunORM).where(
-            RunORM.run_id == run_id,
-            RunORM.thread_id == thread_id,
-            RunORM.user_id == user.identity,
+    async with maker() as session:
+        run_orm = await session.scalar(
+            select(RunORM).where(
+                RunORM.run_id == run_id,
+                RunORM.thread_id == thread_id,
+                RunORM.user_id == user.identity,
+            )
         )
-    )
-    if not run_orm:
-        raise HTTPException(404, f"Run '{run_id}' not found")
+        if not run_orm:
+            raise HTTPException(404, f"Run '{run_id}' not found")
 
-    logger.info(f"[cancel_run] request {action} run_id={run_id} user={user.identity} thread_id={thread_id}")
-    await _request_run_interruption(session, run_orm, action)
+        logger.info(f"[cancel_run] request {action} run_id={run_id} user={user.identity} thread_id={thread_id}")
+        await _request_run_interruption(session, run_orm, action)
 
-    # Optionally wait for the run to settle
     if wait:
-        # Poll DB until the run reaches a terminal state (or 10s timeout).
-        for _ in range(20):
-            await asyncio.sleep(0.5)
-            session.expire_all()  # sync method, clears cache
-            fresh = await session.scalar(select(RunORM).where(RunORM.run_id == run_id))
-            if fresh and fresh.status in TERMINAL_STATES:
-                break
+        await wait_for_terminal_run(run_id)
 
-    await session.refresh(run_orm)
-    return Run.model_validate(run_orm)
+    async with maker() as session:
+        fresh = await session.scalar(
+            select(RunORM).where(
+                RunORM.run_id == run_id,
+                RunORM.thread_id == thread_id,
+                RunORM.user_id == user.identity,
+            )
+        )
+        if not fresh:
+            raise HTTPException(404, f"Run '{run_id}' not found")
+        return Run.model_validate(fresh)
 
 
 @router.delete(

--- a/libs/aegra-api/src/aegra_api/api/runs.py
+++ b/libs/aegra-api/src/aegra_api/api/runs.py
@@ -483,6 +483,7 @@ async def stream_run(
 async def cancel_run_endpoint(
     thread_id: str,
     run_id: str,
+    *,
     wait: int = Query(
         0,
         ge=0,
@@ -527,7 +528,7 @@ async def cancel_run_endpoint(
         await _request_run_interruption(session, run_orm, action)
 
     if wait:
-        await wait_for_terminal_run(run_id)
+        await wait_for_terminal_run(run_id, user_id=user.identity)
 
     async with maker() as session:
         fresh = await session.scalar(

--- a/libs/aegra-api/src/aegra_api/core/active_runs.py
+++ b/libs/aegra-api/src/aegra_api/core/active_runs.py
@@ -13,10 +13,10 @@ explicit_run_cancellations: set[str] = set()
 
 
 def request_local_cancellation(run_id: str) -> bool:
-    """Mark explicit cancel and cancel the owning task if this process has it."""
-    explicit_run_cancellations.add(run_id)
+    """Cancel the owning task if this process has it. Skip non-owners."""
     task = active_runs.get(run_id)
     if task is None or task.done():
         return False
+    explicit_run_cancellations.add(run_id)
     task.cancel()
     return True

--- a/libs/aegra-api/src/aegra_api/core/active_runs.py
+++ b/libs/aegra-api/src/aegra_api/core/active_runs.py
@@ -10,3 +10,13 @@ active_runs: dict[str, asyncio.Task[None]] = {}
 
 # Explicit API cancellations are marked so worker shutdown remains recoverable.
 explicit_run_cancellations: set[str] = set()
+
+
+def request_local_cancellation(run_id: str) -> bool:
+    """Mark explicit cancel and cancel the owning task if this process has it."""
+    explicit_run_cancellations.add(run_id)
+    task = active_runs.get(run_id)
+    if task is None or task.done():
+        return False
+    task.cancel()
+    return True

--- a/libs/aegra-api/src/aegra_api/services/redis_broker.py
+++ b/libs/aegra-api/src/aegra_api/services/redis_broker.py
@@ -19,7 +19,7 @@ from typing import Any
 import structlog
 from redis import RedisError
 
-from aegra_api.core.active_runs import active_runs, explicit_run_cancellations
+from aegra_api.core.active_runs import request_local_cancellation
 from aegra_api.core.redis_manager import redis_manager
 from aegra_api.core.serializers import GeneralSerializer
 from aegra_api.models.enums import RunCancellationAction
@@ -48,6 +48,8 @@ _BACKOFF_FACTOR = 2.0
 # block forever, but it should still retry a transient blip rather than drop the
 # event — a dropped event is a permanently lost SSE token.
 _PUT_MAX_ATTEMPTS = 3
+# Survives a missed pub/sub so the owning worker can honor cancel on heartbeat.
+_CANCEL_INTENT_TTL_SECONDS = 3600
 
 
 def _serialize_payload(payload: Any) -> str:
@@ -65,6 +67,31 @@ def _deserialize_payload(raw: Any) -> Any:
     if isinstance(raw, list) and len(raw) >= 1 and isinstance(raw[0], str):
         return tuple(raw)
     return raw
+
+
+def cancel_intent_key(run_id: str) -> str:
+    """Per-run durable cancel key. Untagged, matching existing per-run keys."""
+    return f"{settings.redis.REDIS_CHANNEL_PREFIX}{run_id}:cancel"
+
+
+async def persist_cancel_intent(run_id: str, action: RunCancellationAction) -> None:
+    """Record cancel/interrupt so a missed PUBLISH is still recoverable."""
+    try:
+        client = redis_manager.get_client()
+        await client.set(cancel_intent_key(run_id), action, ex=_CANCEL_INTENT_TTL_SECONDS)
+    except RedisError:
+        logger.warning("Failed to persist cancel intent", run_id=run_id)
+
+
+async def cancel_intent_exists(run_id: str) -> bool:
+    """True when a durable cancel/interrupt intent is set for this run."""
+    try:
+        client = redis_manager.get_client()
+        value = await client.get(cancel_intent_key(run_id))
+    except RedisError:
+        logger.warning("Failed to read cancel intent", run_id=run_id)
+        return False
+    return bool(value)
 
 
 def _backoff_delay(attempt: int) -> float:
@@ -383,7 +410,8 @@ class RedisBrokerManager(BaseBrokerManager):
         *,
         emit_end_event: bool = True,
     ) -> None:
-        """Broadcast a cancel command via Redis pub/sub."""
+        """Persist cancel intent, publish, then always cancel a local owner."""
+        await persist_cancel_intent(run_id, action)
         message = json.dumps(
             {
                 "run_id": run_id,
@@ -397,9 +425,7 @@ class RedisBrokerManager(BaseBrokerManager):
             logger.info(f"Published {action} command for run {run_id}")
         except RedisError as e:
             logger.error(f"Failed to publish {action} for run {run_id}: {e}")
-            # Fall back to local execution - if the task is on this instance,
-            # we can still cancel it even if Redis publish fails.
-            await self._execute_cancel(run_id, emit_end_event=emit_end_event)
+        await self._execute_cancel(run_id, emit_end_event=emit_end_event)
 
     async def get_event_sequence(self, run_id: str) -> int:
         """Read the current event sequence counter from Redis (O(1) GET)."""
@@ -479,13 +505,10 @@ class RedisBrokerManager(BaseBrokerManager):
 
     async def _execute_cancel(self, run_id: str, *, emit_end_event: bool = True) -> None:
         """Cancel a locally-owned task and signal the broker."""
-        task = active_runs.get(run_id)
-        if task is None or task.done():
+        if not request_local_cancellation(run_id):
             return
 
         logger.info(f"Cancelling run {run_id} (local task found)")
-        explicit_run_cancellations.add(run_id)
-        task.cancel()
 
         broker = self.get_or_create_broker(run_id)
         if emit_end_event and not broker.is_finished():

--- a/libs/aegra-api/src/aegra_api/services/redis_broker.py
+++ b/libs/aegra-api/src/aegra_api/services/redis_broker.py
@@ -83,15 +83,23 @@ async def persist_cancel_intent(run_id: str, action: RunCancellationAction) -> N
         logger.warning("Failed to persist cancel intent", run_id=run_id)
 
 
-async def cancel_intent_exists(run_id: str) -> bool:
-    """True when a durable cancel/interrupt intent is set for this run."""
+async def read_cancel_intent(run_id: str) -> RunCancellationAction | None:
+    """Return the stored cancel/interrupt action, or None if unset."""
     try:
         client = redis_manager.get_client()
         value = await client.get(cancel_intent_key(run_id))
     except RedisError:
         logger.warning("Failed to read cancel intent", run_id=run_id)
-        return False
-    return bool(value)
+        return None
+    if value is None:
+        return None
+    action = value.decode() if isinstance(value, (bytes, bytearray)) else str(value)
+    if action == "cancel":
+        return "cancel"
+    if action == "interrupt":
+        return "interrupt"
+    logger.warning("Unknown cancel intent action", run_id=run_id, action=action)
+    return None
 
 
 def _backoff_delay(attempt: int) -> float:

--- a/libs/aegra-api/src/aegra_api/services/run_waiters.py
+++ b/libs/aegra-api/src/aegra_api/services/run_waiters.py
@@ -8,6 +8,7 @@ yields the final JSON result when the run completes.
 import asyncio
 import contextlib
 import json
+import time
 from collections.abc import AsyncIterator
 from typing import Any
 
@@ -23,6 +24,38 @@ logger = structlog.getLogger(__name__)
 
 # Terminal run states — used by join/wait to skip waiting
 TERMINAL_STATES = {"success", "error", "interrupted"}
+CANCEL_WAIT_POLL_SECONDS = 0.5
+CANCEL_WAIT_SLACK_SECONDS = 5.0
+
+
+def cancel_wait_timeout_seconds() -> float:
+    """Bound for cancel?wait=1: two heartbeats plus slack."""
+    return 2 * settings.worker.HEARTBEAT_INTERVAL_SECONDS + CANCEL_WAIT_SLACK_SECONDS
+
+
+async def wait_for_terminal_run(
+    run_id: str,
+    *,
+    timeout_seconds: float | None = None,
+) -> RunORM | None:
+    """Poll the run row until it is terminal or the wait bound elapses.
+
+    Opens a short-lived session per poll so the cancel request does not hold
+    a connection for the full wait.
+    """
+    maker = _get_session_maker()
+    deadline = time.monotonic() + (timeout_seconds if timeout_seconds is not None else cancel_wait_timeout_seconds())
+    latest: RunORM | None = None
+    while True:
+        async with maker() as session:
+            latest = await session.scalar(select(RunORM).where(RunORM.run_id == run_id))
+            if latest is not None:
+                session.expunge(latest)
+                if latest.status in TERMINAL_STATES:
+                    return latest
+        if time.monotonic() >= deadline:
+            return latest
+        await asyncio.sleep(CANCEL_WAIT_POLL_SECONDS)
 
 
 async def read_run_output(

--- a/libs/aegra-api/src/aegra_api/services/run_waiters.py
+++ b/libs/aegra-api/src/aegra_api/services/run_waiters.py
@@ -36,6 +36,7 @@ def cancel_wait_timeout_seconds() -> float:
 async def wait_for_terminal_run(
     run_id: str,
     *,
+    user_id: str,
     timeout_seconds: float | None = None,
 ) -> RunORM | None:
     """Poll the run row until it is terminal or the wait bound elapses.
@@ -48,7 +49,12 @@ async def wait_for_terminal_run(
     latest: RunORM | None = None
     while True:
         async with maker() as session:
-            latest = await session.scalar(select(RunORM).where(RunORM.run_id == run_id))
+            latest = await session.scalar(
+                select(RunORM).where(
+                    RunORM.run_id == run_id,
+                    RunORM.user_id == user_id,
+                )
+            )
             if latest is not None:
                 session.expunge(latest)
                 if latest.status in TERMINAL_STATES:

--- a/libs/aegra-api/src/aegra_api/services/worker_executor.py
+++ b/libs/aegra-api/src/aegra_api/services/worker_executor.py
@@ -29,7 +29,7 @@ from aegra_api.core.redis_manager import redis_manager
 from aegra_api.models.run_job import RunJob
 from aegra_api.observability.span_enrichment import merge_run_metadata, set_trace_context
 from aegra_api.services.base_executor import BaseExecutor
-from aegra_api.services.redis_broker import cancel_intent_exists
+from aegra_api.services.redis_broker import read_cancel_intent
 from aegra_api.services.run_executor import _lease_loss_cancellations, _timeout_cancellations, execute_run
 from aegra_api.services.run_status import finalize_run
 from aegra_api.settings import settings
@@ -484,12 +484,15 @@ async def _heartbeat_loop(
 
     while True:
         try:
-            if await cancel_intent_exists(run_id):
+            intent = await read_cancel_intent(run_id)
+            if intent is not None:
                 logger.info(
                     "Honoring durable cancel intent",
                     run_id=run_id,
                     worker=worker_name,
+                    action=intent,
                 )
+                # Pub/sub already hard-cancels both cancel and interrupt.
                 request_local_cancellation(run_id)
         except RedisError:
             logger.warning("Cancel-intent check failed", run_id=run_id, worker=worker_name)

--- a/libs/aegra-api/src/aegra_api/services/worker_executor.py
+++ b/libs/aegra-api/src/aegra_api/services/worker_executor.py
@@ -22,13 +22,14 @@ from redis import RedisError
 from redis import TimeoutError as RedisTimeoutError
 from sqlalchemy import select, update
 
-from aegra_api.core.active_runs import active_runs, explicit_run_cancellations
+from aegra_api.core.active_runs import active_runs, explicit_run_cancellations, request_local_cancellation
 from aegra_api.core.orm import Run as RunORM
 from aegra_api.core.orm import _get_session_maker
 from aegra_api.core.redis_manager import redis_manager
 from aegra_api.models.run_job import RunJob
 from aegra_api.observability.span_enrichment import merge_run_metadata, set_trace_context
 from aegra_api.services.base_executor import BaseExecutor
+from aegra_api.services.redis_broker import cancel_intent_exists
 from aegra_api.services.run_executor import _lease_loss_cancellations, _timeout_cancellations, execute_run
 from aegra_api.services.run_status import finalize_run
 from aegra_api.settings import settings
@@ -473,7 +474,8 @@ async def _heartbeat_loop(
 ) -> None:
     """Extend lease periodically while the job is running.
 
-    If the lease is lost (another worker claimed the run), cancels
+    Honors a durable cancel intent without stopping lease renewal — the
+    owning task's cleanup releases the lease. Lease loss still cancels
     ``job_task`` to prevent double execution.
     """
     interval = settings.worker.HEARTBEAT_INTERVAL_SECONDS
@@ -481,6 +483,17 @@ async def _heartbeat_loop(
     maker = _get_session_maker()
 
     while True:
+        try:
+            if await cancel_intent_exists(run_id):
+                logger.info(
+                    "Honoring durable cancel intent",
+                    run_id=run_id,
+                    worker=worker_name,
+                )
+                request_local_cancellation(run_id)
+        except RedisError:
+            logger.warning("Cancel-intent check failed", run_id=run_id, worker=worker_name)
+
         await asyncio.sleep(interval)
         try:
             new_expiry = datetime.now(UTC) + timedelta(seconds=duration)

--- a/libs/aegra-api/tests/integration/test_api/test_runs_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_runs_crud.py
@@ -295,6 +295,12 @@ class TestUpdateRun:
 class TestCancelRun:
     """Test POST /threads/{thread_id}/runs/{run_id}/cancel"""
 
+    def _session_maker(self, session: DummySessionBase) -> MagicMock:
+        ctx = AsyncMock()
+        ctx.__aenter__ = AsyncMock(return_value=session)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+        return MagicMock(return_value=ctx)
+
     def test_cancel_run_not_found(self):
         """Test canceling a non-existent run"""
         app = create_test_app(include_runs=True, include_threads=False)
@@ -303,10 +309,11 @@ class TestCancelRun:
             async def scalar(self, _stmt):
                 return None
 
-        override_session_dependency(app, BasicSession)
+        maker = self._session_maker(Session())
         client = make_client(app)
 
-        resp = client.post("/threads/test-thread-123/runs/nonexistent/cancel")
+        with patch("aegra_api.api.runs.get_session_maker", return_value=maker):
+            resp = client.post("/threads/test-thread-123/runs/nonexistent/cancel")
 
         assert resp.status_code == 404
 
@@ -326,10 +333,11 @@ class TestCancelRun:
             async def commit(self):
                 pass
 
-        override_session_dependency(app, Session)
+        maker = self._session_maker(Session())
         client = make_client(app)
 
         with (
+            patch("aegra_api.api.runs.get_session_maker", return_value=maker),
             patch("aegra_api.api.runs.streaming_service") as mock_streaming,
             patch(
                 "aegra_api.api.runs.interrupt_unowned_run",

--- a/libs/aegra-api/tests/integration/test_api/test_runs_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_runs_crud.py
@@ -295,18 +295,18 @@ class TestUpdateRun:
 class TestCancelRun:
     """Test POST /threads/{thread_id}/runs/{run_id}/cancel"""
 
-    def _session_maker(self, session: DummySessionBase) -> MagicMock:
+    def _session_maker(self: "TestCancelRun", session: DummySessionBase) -> MagicMock:
         ctx = AsyncMock()
         ctx.__aenter__ = AsyncMock(return_value=session)
         ctx.__aexit__ = AsyncMock(return_value=False)
         return MagicMock(return_value=ctx)
 
-    def test_cancel_run_not_found(self):
+    def test_cancel_run_not_found(self) -> None:
         """Test canceling a non-existent run"""
         app = create_test_app(include_runs=True, include_threads=False)
 
         class Session(DummySessionBase):
-            async def scalar(self, _stmt):
+            async def scalar(self, _stmt: object) -> DummyRun | None:
                 return None
 
         maker = self._session_maker(Session())
@@ -317,21 +317,21 @@ class TestCancelRun:
 
         assert resp.status_code == 404
 
-    def test_cancel_run_success(self):
+    def test_cancel_run_success(self) -> None:
         """Test successfully canceling a run"""
         app = create_test_app(include_runs=True, include_threads=False)
 
         run = _run_row(status="running")
 
         class Session(DummySessionBase):
-            async def scalar(self, _stmt):
+            async def scalar(self, _stmt: object) -> DummyRun:
                 return run
 
-            async def execute(self, _stmt):
-                pass
+            async def execute(self, _stmt: object) -> None:
+                return None
 
-            async def commit(self):
-                pass
+            async def commit(self) -> None:
+                return None
 
         maker = self._session_maker(Session())
         client = make_client(app)

--- a/libs/aegra-api/tests/unit/test_core/test_active_runs.py
+++ b/libs/aegra-api/tests/unit/test_core/test_active_runs.py
@@ -20,7 +20,7 @@ def test_request_local_cancellation_cancels_live_task() -> None:
     assert run_id in cancellations
 
 
-def test_request_local_cancellation_marks_intent_without_local_task() -> None:
+def test_request_local_cancellation_skips_missing_task() -> None:
     run_id = "run-123"
 
     with (
@@ -29,7 +29,7 @@ def test_request_local_cancellation_marks_intent_without_local_task() -> None:
     ):
         assert request_local_cancellation(run_id) is False
 
-    assert run_id in cancellations
+    assert run_id not in cancellations
 
 
 def test_request_local_cancellation_skips_completed_task() -> None:
@@ -44,4 +44,4 @@ def test_request_local_cancellation_skips_completed_task() -> None:
         assert request_local_cancellation(run_id) is False
 
     mock_task.cancel.assert_not_called()
-    assert run_id in cancellations
+    assert run_id not in cancellations

--- a/libs/aegra-api/tests/unit/test_core/test_active_runs.py
+++ b/libs/aegra-api/tests/unit/test_core/test_active_runs.py
@@ -1,0 +1,47 @@
+"""Tests for the process-local run cancellation registry."""
+
+from unittest.mock import MagicMock, patch
+
+from aegra_api.core.active_runs import request_local_cancellation
+
+
+def test_request_local_cancellation_cancels_live_task() -> None:
+    mock_task = MagicMock()
+    mock_task.done.return_value = False
+    run_id = "run-123"
+
+    with (
+        patch.dict("aegra_api.core.active_runs.active_runs", {run_id: mock_task}, clear=True),
+        patch("aegra_api.core.active_runs.explicit_run_cancellations", set()) as cancellations,
+    ):
+        assert request_local_cancellation(run_id) is True
+
+    mock_task.cancel.assert_called_once()
+    assert run_id in cancellations
+
+
+def test_request_local_cancellation_marks_intent_without_local_task() -> None:
+    run_id = "run-123"
+
+    with (
+        patch.dict("aegra_api.core.active_runs.active_runs", {}, clear=True),
+        patch("aegra_api.core.active_runs.explicit_run_cancellations", set()) as cancellations,
+    ):
+        assert request_local_cancellation(run_id) is False
+
+    assert run_id in cancellations
+
+
+def test_request_local_cancellation_skips_completed_task() -> None:
+    mock_task = MagicMock()
+    mock_task.done.return_value = True
+    run_id = "run-123"
+
+    with (
+        patch.dict("aegra_api.core.active_runs.active_runs", {run_id: mock_task}, clear=True),
+        patch("aegra_api.core.active_runs.explicit_run_cancellations", set()) as cancellations,
+    ):
+        assert request_local_cancellation(run_id) is False
+
+    mock_task.cancel.assert_not_called()
+    assert run_id in cancellations

--- a/libs/aegra-api/tests/unit/test_services/test_cancel_wait.py
+++ b/libs/aegra-api/tests/unit/test_services/test_cancel_wait.py
@@ -1,0 +1,58 @@
+"""Tests for cancel?wait=1 terminal polling."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aegra_api.services.run_waiters import cancel_wait_timeout_seconds, wait_for_terminal_run
+
+
+def test_cancel_wait_timeout_derives_from_heartbeat() -> None:
+    with patch("aegra_api.services.run_waiters.settings") as mock_settings:
+        mock_settings.worker.HEARTBEAT_INTERVAL_SECONDS = 10
+        assert cancel_wait_timeout_seconds() == 25.0
+
+
+@pytest.mark.asyncio
+async def test_wait_for_terminal_run_returns_on_interrupted() -> None:
+    run = MagicMock()
+    run.status = "interrupted"
+    session = AsyncMock()
+    session.scalar = AsyncMock(return_value=run)
+    session.expunge = MagicMock()
+    maker = MagicMock()
+    ctx = AsyncMock()
+    ctx.__aenter__ = AsyncMock(return_value=session)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    maker.return_value = ctx
+
+    with patch("aegra_api.services.run_waiters._get_session_maker", return_value=maker):
+        result = await wait_for_terminal_run("run-1", timeout_seconds=5)
+
+    assert result is run
+    session.expunge.assert_called_once_with(run)
+
+
+@pytest.mark.asyncio
+async def test_wait_for_terminal_run_times_out_still_running() -> None:
+    run = MagicMock()
+    run.status = "running"
+    session = AsyncMock()
+    session.scalar = AsyncMock(return_value=run)
+    session.expunge = MagicMock()
+    maker = MagicMock()
+    ctx = AsyncMock()
+    ctx.__aenter__ = AsyncMock(return_value=session)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    maker.return_value = ctx
+
+    with (
+        patch("aegra_api.services.run_waiters._get_session_maker", return_value=maker),
+        patch("aegra_api.services.run_waiters.asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
+        patch("aegra_api.services.run_waiters.time") as mock_time,
+    ):
+        mock_time.monotonic.side_effect = [0.0, 6.0]
+        result = await wait_for_terminal_run("run-1", timeout_seconds=5)
+
+    assert result is run
+    mock_sleep.assert_not_awaited()

--- a/libs/aegra-api/tests/unit/test_services/test_cancel_wait.py
+++ b/libs/aegra-api/tests/unit/test_services/test_cancel_wait.py
@@ -27,7 +27,7 @@ async def test_wait_for_terminal_run_returns_on_interrupted() -> None:
     maker.return_value = ctx
 
     with patch("aegra_api.services.run_waiters._get_session_maker", return_value=maker):
-        result = await wait_for_terminal_run("run-1", timeout_seconds=5)
+        result = await wait_for_terminal_run("run-1", user_id="user-1", timeout_seconds=5)
 
     assert result is run
     session.expunge.assert_called_once_with(run)
@@ -52,7 +52,7 @@ async def test_wait_for_terminal_run_times_out_still_running() -> None:
         patch("aegra_api.services.run_waiters.time") as mock_time,
     ):
         mock_time.monotonic.side_effect = [0.0, 6.0]
-        result = await wait_for_terminal_run("run-1", timeout_seconds=5)
+        result = await wait_for_terminal_run("run-1", user_id="user-1", timeout_seconds=5)
 
     assert result is run
     mock_sleep.assert_not_awaited()

--- a/libs/aegra-api/tests/unit/test_services/test_redis_broker.py
+++ b/libs/aegra-api/tests/unit/test_services/test_redis_broker.py
@@ -13,6 +13,7 @@ from aegra_api.services.redis_broker import (
     RedisRunBroker,
     _deserialize_payload,
     _serialize_payload,
+    read_cancel_intent,
 )
 
 
@@ -56,6 +57,33 @@ class TestSerializationHelpers:
         result = _deserialize_payload(["end", {"status": "success"}])
         assert result == ("end", {"status": "success"})
         assert isinstance(result, tuple)
+
+
+class TestReadCancelIntent:
+    @pytest.mark.asyncio
+    async def test_returns_stored_action(self) -> None:
+        mock_client = MagicMock()
+        mock_client.get = AsyncMock(return_value=b"interrupt")
+
+        with patch("aegra_api.services.redis_broker.redis_manager") as mock_rm:
+            mock_rm.get_client.return_value = mock_client
+            assert await read_cancel_intent("run-123") == "interrupt"
+
+        mock_client.get.assert_awaited_once_with("aegra:run:run-123:cancel")
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_missing_or_redis_fails(self) -> None:
+        mock_client = MagicMock()
+        mock_client.get = AsyncMock(return_value=None)
+
+        with patch("aegra_api.services.redis_broker.redis_manager") as mock_rm:
+            mock_rm.get_client.return_value = mock_client
+            assert await read_cancel_intent("run-123") is None
+
+        mock_client.get = AsyncMock(side_effect=RedisConnectionError("Redis down"))
+        with patch("aegra_api.services.redis_broker.redis_manager") as mock_rm:
+            mock_rm.get_client.return_value = mock_client
+            assert await read_cancel_intent("run-123") is None
 
 
 class TestRedisRunBroker:
@@ -826,7 +854,7 @@ class TestRedisBrokerManager:
         ):
             await manager._execute_cancel("run-123")
 
-        assert cancellations == {"run-123"}
+        assert cancellations == set()
 
     @pytest.mark.asyncio
     async def test_start_and_stop(self) -> None:

--- a/libs/aegra-api/tests/unit/test_services/test_redis_broker.py
+++ b/libs/aegra-api/tests/unit/test_services/test_redis_broker.py
@@ -679,13 +679,22 @@ class TestRedisBrokerManager:
         """Test that request_cancel publishes cancel command to Redis"""
         manager = self._make_manager()
         mock_client = MagicMock()
+        mock_client.set = AsyncMock()
         mock_client.publish = AsyncMock()
 
-        with patch("aegra_api.services.redis_broker.redis_manager") as mock_rm:
+        with (
+            patch("aegra_api.services.redis_broker.redis_manager") as mock_rm,
+            patch.object(manager, "_execute_cancel", new_callable=AsyncMock),
+        ):
             mock_rm.get_client.return_value = mock_client
 
             await manager.request_cancel("run-123", "cancel")
 
+            mock_client.set.assert_awaited_once_with(
+                "aegra:run:run-123:cancel",
+                "cancel",
+                ex=3600,
+            )
             mock_client.publish.assert_awaited_once()
             channel, message = mock_client.publish.call_args[0]
             assert channel == "aegra:run:cancel"
@@ -693,10 +702,65 @@ class TestRedisBrokerManager:
             assert payload == {"run_id": "run-123", "action": "cancel", "emit_end_event": True}
 
     @pytest.mark.asyncio
+    async def test_request_cancel_persists_interrupt_action(self) -> None:
+        manager = self._make_manager()
+        mock_client = MagicMock()
+        mock_client.set = AsyncMock()
+        mock_client.publish = AsyncMock()
+
+        with (
+            patch("aegra_api.services.redis_broker.redis_manager") as mock_rm,
+            patch.object(manager, "_execute_cancel", new_callable=AsyncMock) as mock_exec,
+        ):
+            mock_rm.get_client.return_value = mock_client
+            await manager.request_cancel("run-123", "interrupt")
+
+        mock_client.set.assert_awaited_once_with(
+            "aegra:run:run-123:cancel",
+            "interrupt",
+            ex=3600,
+        )
+        mock_exec.assert_awaited_once_with("run-123", emit_end_event=True)
+
+    @pytest.mark.asyncio
+    async def test_request_cancel_cancels_locally_when_publish_succeeds(self) -> None:
+        manager = self._make_manager()
+        mock_client = MagicMock()
+        mock_client.set = AsyncMock()
+        mock_client.publish = AsyncMock()
+
+        with (
+            patch("aegra_api.services.redis_broker.redis_manager") as mock_rm,
+            patch.object(manager, "_execute_cancel", new_callable=AsyncMock) as mock_exec,
+        ):
+            mock_rm.get_client.return_value = mock_client
+            await manager.request_cancel("run-123", "cancel")
+
+        mock_exec.assert_awaited_once_with("run-123", emit_end_event=True)
+
+    @pytest.mark.asyncio
+    async def test_request_cancel_still_publishes_when_intent_set_fails(self) -> None:
+        manager = self._make_manager()
+        mock_client = MagicMock()
+        mock_client.set = AsyncMock(side_effect=RedisConnectionError("Redis down"))
+        mock_client.publish = AsyncMock()
+
+        with (
+            patch("aegra_api.services.redis_broker.redis_manager") as mock_rm,
+            patch.object(manager, "_execute_cancel", new_callable=AsyncMock) as mock_exec,
+        ):
+            mock_rm.get_client.return_value = mock_client
+            await manager.request_cancel("run-123", "cancel")
+
+        mock_client.publish.assert_awaited_once()
+        mock_exec.assert_awaited_once_with("run-123", emit_end_event=True)
+
+    @pytest.mark.asyncio
     async def test_request_cancel_falls_back_on_redis_error(self) -> None:
         """Test that request_cancel falls back to local execution on Redis error"""
         manager = self._make_manager()
         mock_client = MagicMock()
+        mock_client.set = AsyncMock()
         mock_client.publish = AsyncMock(side_effect=RedisConnectionError("Redis down"))
 
         with (
@@ -722,7 +786,7 @@ class TestRedisBrokerManager:
 
         with (
             patch.dict("aegra_api.core.active_runs.active_runs", {"run-123": mock_task}, clear=True),
-            patch("aegra_api.services.redis_broker.explicit_run_cancellations", set()) as cancellations,
+            patch("aegra_api.core.active_runs.explicit_run_cancellations", set()) as cancellations,
             patch.object(manager, "get_or_create_broker", return_value=mock_broker),
             patch.object(manager, "allocate_event_id", new_callable=AsyncMock, return_value="run-123_event_6"),
         ):
@@ -742,7 +806,7 @@ class TestRedisBrokerManager:
 
         with (
             patch.dict("aegra_api.core.active_runs.active_runs", {"run-123": mock_task}, clear=True),
-            patch("aegra_api.services.redis_broker.explicit_run_cancellations", set()) as cancellations,
+            patch("aegra_api.core.active_runs.explicit_run_cancellations", set()) as cancellations,
             patch.object(manager, "get_or_create_broker", return_value=mock_broker),
         ):
             await manager._execute_cancel("run-123", emit_end_event=False)
@@ -756,9 +820,13 @@ class TestRedisBrokerManager:
         """Test that _execute_cancel does nothing when task not found locally"""
         manager = self._make_manager()
 
-        with patch.dict("aegra_api.core.active_runs.active_runs", {}, clear=True):
+        with (
+            patch.dict("aegra_api.core.active_runs.active_runs", {}, clear=True),
+            patch("aegra_api.core.active_runs.explicit_run_cancellations", set()) as cancellations,
+        ):
             await manager._execute_cancel("run-123")
-            # Should not raise
+
+        assert cancellations == {"run-123"}
 
     @pytest.mark.asyncio
     async def test_start_and_stop(self) -> None:

--- a/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
+++ b/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
@@ -215,6 +215,7 @@ class TestHeartbeatLoop:
             patch(f"{MODULE}._get_session_maker", return_value=maker),
             patch(f"{MODULE}.settings") as mock_settings,
             patch(f"{MODULE}.asyncio.sleep", side_effect=counting_sleep),
+            patch(f"{MODULE}.cancel_intent_exists", new_callable=AsyncMock, return_value=False),
         ):
             mock_settings.worker.HEARTBEAT_INTERVAL_SECONDS = 1
             mock_settings.worker.LEASE_DURATION_SECONDS = 30
@@ -244,6 +245,7 @@ class TestHeartbeatLoop:
             patch(f"{MODULE}._get_session_maker", return_value=maker),
             patch(f"{MODULE}.settings") as mock_settings,
             patch(f"{MODULE}.asyncio.sleep", side_effect=counting_sleep),
+            patch(f"{MODULE}.cancel_intent_exists", new_callable=AsyncMock, return_value=False),
         ):
             mock_settings.worker.HEARTBEAT_INTERVAL_SECONDS = 1
             mock_settings.worker.LEASE_DURATION_SECONDS = 30
@@ -253,6 +255,74 @@ class TestHeartbeatLoop:
 
         # Loop continued despite DB errors (2 iterations before cancel on 3rd sleep)
         assert session.execute.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_honors_cancel_intent_without_stopping_heartbeat(self) -> None:
+        session = AsyncMock()
+        session.execute = AsyncMock()
+        session.commit = AsyncMock()
+        maker = _make_session_maker(session)
+        mock_task = MagicMock()
+        mock_task.done.return_value = False
+        run_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+        call_count = 0
+
+        async def counting_sleep(delay: float) -> None:
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 2:
+                raise asyncio.CancelledError
+
+        with (
+            patch(f"{MODULE}._get_session_maker", return_value=maker),
+            patch(f"{MODULE}.settings") as mock_settings,
+            patch(f"{MODULE}.asyncio.sleep", side_effect=counting_sleep),
+            patch(f"{MODULE}.cancel_intent_exists", new_callable=AsyncMock, return_value=True),
+            patch.dict("aegra_api.core.active_runs.active_runs", {run_id: mock_task}, clear=True),
+            patch("aegra_api.core.active_runs.explicit_run_cancellations", set()) as cancellations,
+        ):
+            mock_settings.worker.HEARTBEAT_INTERVAL_SECONDS = 1
+            mock_settings.worker.LEASE_DURATION_SECONDS = 30
+            with pytest.raises(asyncio.CancelledError):
+                await _heartbeat_loop(run_id, "worker-0")
+
+        mock_task.cancel.assert_called()
+        assert run_id in cancellations
+        assert session.execute.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_intent_redis_error_does_not_skip_lease_renewal(self) -> None:
+        session = AsyncMock()
+        session.execute = AsyncMock()
+        session.commit = AsyncMock()
+        maker = _make_session_maker(session)
+
+        call_count = 0
+
+        async def counting_sleep(delay: float) -> None:
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 2:
+                raise asyncio.CancelledError
+
+        with (
+            patch(f"{MODULE}._get_session_maker", return_value=maker),
+            patch(f"{MODULE}.settings") as mock_settings,
+            patch(f"{MODULE}.asyncio.sleep", side_effect=counting_sleep),
+            patch(
+                f"{MODULE}.cancel_intent_exists",
+                new_callable=AsyncMock,
+                side_effect=RedisConnectionError("Redis down"),
+            ),
+        ):
+            mock_settings.worker.HEARTBEAT_INTERVAL_SECONDS = 1
+            mock_settings.worker.LEASE_DURATION_SECONDS = 30
+            with pytest.raises(asyncio.CancelledError):
+                await _heartbeat_loop("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", "worker-0")
+
+        assert session.execute.await_count == 1
+        assert session.commit.await_count == 1
 
 
 # ------------------------------------------------------------------

--- a/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
+++ b/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
@@ -215,7 +215,7 @@ class TestHeartbeatLoop:
             patch(f"{MODULE}._get_session_maker", return_value=maker),
             patch(f"{MODULE}.settings") as mock_settings,
             patch(f"{MODULE}.asyncio.sleep", side_effect=counting_sleep),
-            patch(f"{MODULE}.cancel_intent_exists", new_callable=AsyncMock, return_value=False),
+            patch(f"{MODULE}.read_cancel_intent", new_callable=AsyncMock, return_value=None),
         ):
             mock_settings.worker.HEARTBEAT_INTERVAL_SECONDS = 1
             mock_settings.worker.LEASE_DURATION_SECONDS = 30
@@ -245,7 +245,7 @@ class TestHeartbeatLoop:
             patch(f"{MODULE}._get_session_maker", return_value=maker),
             patch(f"{MODULE}.settings") as mock_settings,
             patch(f"{MODULE}.asyncio.sleep", side_effect=counting_sleep),
-            patch(f"{MODULE}.cancel_intent_exists", new_callable=AsyncMock, return_value=False),
+            patch(f"{MODULE}.read_cancel_intent", new_callable=AsyncMock, return_value=None),
         ):
             mock_settings.worker.HEARTBEAT_INTERVAL_SECONDS = 1
             mock_settings.worker.LEASE_DURATION_SECONDS = 30
@@ -257,7 +257,8 @@ class TestHeartbeatLoop:
         assert session.execute.await_count == 2
 
     @pytest.mark.asyncio
-    async def test_honors_cancel_intent_without_stopping_heartbeat(self) -> None:
+    @pytest.mark.parametrize("intent", ["cancel", "interrupt"])
+    async def test_honors_cancel_intent_without_stopping_heartbeat(self, intent: str) -> None:
         session = AsyncMock()
         session.execute = AsyncMock()
         session.commit = AsyncMock()
@@ -278,7 +279,7 @@ class TestHeartbeatLoop:
             patch(f"{MODULE}._get_session_maker", return_value=maker),
             patch(f"{MODULE}.settings") as mock_settings,
             patch(f"{MODULE}.asyncio.sleep", side_effect=counting_sleep),
-            patch(f"{MODULE}.cancel_intent_exists", new_callable=AsyncMock, return_value=True),
+            patch(f"{MODULE}.read_cancel_intent", new_callable=AsyncMock, return_value=intent),
             patch.dict("aegra_api.core.active_runs.active_runs", {run_id: mock_task}, clear=True),
             patch("aegra_api.core.active_runs.explicit_run_cancellations", set()) as cancellations,
         ):
@@ -311,7 +312,7 @@ class TestHeartbeatLoop:
             patch(f"{MODULE}.settings") as mock_settings,
             patch(f"{MODULE}.asyncio.sleep", side_effect=counting_sleep),
             patch(
-                f"{MODULE}.cancel_intent_exists",
+                f"{MODULE}.read_cancel_intent",
                 new_callable=AsyncMock,
                 side_effect=RedisConnectionError("Redis down"),
             ),

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.10.3"
+version = "0.10.4"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.10.3"
+version = "0.10.4"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -100,7 +100,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.10.3"
+version = "0.10.4"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
## Description

Fixes #528.

`POST /threads/{thread_id}/runs/{run_id}/cancel?wait=1` published a Redis pub/sub command and then waited 10 seconds. `_execute_cancel` (the call that actually `task.cancel()`s the worker) ran only when `PUBLISH` *raised*. A successful publish with nobody listening was treated as success. The owning worker's heartbeat never looked for a cancel, so a dropped message leaked the job slot until the process died.

`wait=1` now waits up to 25 seconds by default (two heartbeats + 5s) and still documents that a timeout can return `running`. The real fix is delivery: persist a durable intent, always cancel a local owner, and honor that intent on the lease heartbeat.

## Type of Change

- [x] `fix`: Bug fix

## Related Issues

Fixes #528.

## Changes Made

- `SET {prefix}{run_id}:cancel` (action + 1h TTL) before `PUBLISH`. `SET`, `PUBLISH`, and local cancel are independent — a failed SET does not skip the rest.
- Always `_execute_cancel` locally after publish (no-op on a process that does not own the run).
- Shared `request_local_cancellation` marks `explicit_run_cancellations` and cancels `active_runs[run_id]` so `_cleanup_cancelled_execution` still finalizes the DB row. Heartbeat does **not** cancel `job_task` directly.
- `_heartbeat_loop` checks the intent before the first sleep and once per interval. Redis GET failures do not skip Postgres lease renewal. After requesting cancel, the heartbeat keeps renewing until the owner task's cleanup releases the lease.
- `wait=1` uses short-lived sessions (no request-scoped connection held for the wait). Bound is `2 * HEARTBEAT_INTERVAL_SECONDS + 5`.
- Patch bump `0.10.3` → `0.10.4`. No API contract change beyond the documented wait bound.

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] E2E tests added/updated
- [x] Manual testing performed

**Unit:** persist-then-publish-then-local-cancel; SET failure still publishes; heartbeat honors intent without dropping the lease; Redis GET error still renews the lease; `wait=1` timeout derives from heartbeat.

**E2E:** existing `test_cancel_run_e2e.py` — 3 passed, 1 skipped against WorkerExecutor docker compose.

**Manual (docker compose, `stress_test`, `wait=1`):**

```
kill_pubsub=False HTTP 200 in 1.2s cancel=interrupted get=interrupted
kill_pubsub=True  HTTP 200 in 1.6s cancel=interrupted get=interrupted
```

The second case is the production path: `PUBLISH` succeeds with no subscriber; the durable key plus heartbeat still stops the worker.

## Checklist

- [x] Code follows project style (Ruff formatting)
- [x] All linting checks pass (`make lint`)
- [x] Type checking passes (`make type-check`)
- [x] Documentation updated (if needed)
- [x] Commit messages follow Conventional Commits
- [x] PR title follows Conventional Commits format

## Additional Notes

Does not change `wait=0`. Does not add a Postgres column. New Redis key is untagged, matching existing per-run keys.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved run cancellation reliability across worker instances, including recovery when cancellation notifications are missed.
  * Added safer local cancellation handling for active runs without affecting completed runs.

* **Enhancements**
  * `wait=1` now waits up to approximately 25 seconds for cancellation to settle, then returns the latest available state.
  * Updated cancellation guidance, API documentation, and package versions to 0.10.4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes cancellation resilient to missed Redis pub/sub messages by persisting cancellation intent and checking it during worker heartbeats. It also moves `wait=1` polling to short-lived database sessions and derives its timeout from the heartbeat interval.

- Persists cancellation intent in Redis before publishing the command.
- Cancels locally owned tasks after every publish attempt.
- Checks durable cancellation intent during lease heartbeats without stopping lease renewal.
- Extends and documents the bounded cancellation wait.
- Prevents non-owning processes from accumulating explicit-cancellation markers.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/core/active_runs.py | Local cancellation now records an explicit marker only when a live task is actually owned and cancelled, resolving the previously reported orphan-marker issue. |
| libs/aegra-api/src/aegra_api/services/redis_broker.py | Cancellation requests persist a durable intent, publish independently, and always attempt local cancellation. |
| libs/aegra-api/src/aegra_api/services/worker_executor.py | Worker heartbeats check durable cancellation intent while continuing lease renewal until normal task cleanup. |
| libs/aegra-api/src/aegra_api/api/runs.py | The cancellation endpoint now uses short-lived sessions around its bounded terminal-state wait. |
| libs/aegra-api/tests/integration/test_api/test_runs_crud.py | Changed cancellation test helpers now satisfy the repository’s full type-annotation requirement. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant API
    participant Redis
    participant Worker
    participant DB
    API->>Redis: SET durable cancel intent
    API->>Redis: PUBLISH cancel command
    API->>Worker: Request local cancellation
    alt Pub/sub reaches owner
        Redis-->>Worker: Cancel command
    else Pub/sub is missed
        Worker->>Redis: GET cancel intent on heartbeat
        Redis-->>Worker: cancel or interrupt
    end
    Worker->>Worker: Cancel owning task
    Worker->>DB: Finalize run and release lease
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(api): tighten durable cancel recover..."](https://github.com/aegra/aegra/commit/c29e38085bcb7dda722d2e0c001a7aa6366481bd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54435278)</sub>

**Context used:**

- Knowledge Base — [Execution Engine: Broker, Executors, Leases, and Cleanup](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/execution-engine.md)

<!-- /greptile_comment -->