### PR TITLE
fix(api): check in stream/events pool connections on SSE cancel

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Aegra",
     "description": "Production-ready Agent Protocol server",
-    "version": "0.10.3"
+    "version": "0.10.4"
   },
   "paths": {
     "/info": {

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.10.3"
+version = "0.10.4"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-api/src/aegra_api/api/event_streaming.py
+++ b/libs/aegra-api/src/aegra_api/api/event_streaming.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 from collections.abc import AsyncGenerator
 
+import anyio
 import structlog
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import JSONResponse
@@ -57,18 +58,26 @@ def _thread_run_lister(thread_id: str, user: User) -> RunLister:
     broker events expired instead of tailing them forever; graph_name feeds the
     run's root lifecycle events. Each tick uses a short-lived session so a
     connection is not held for the whole SSE lifetime (see #423).
+
+    The checkout is shielded from sse-starlette's ``cancel_on_finish`` anyio
+    scope: that cancel punches through ``asyncio.shield``, so an unshielded
+    ``async with`` is GC-terminated and leaks the pooled asyncpg connection
+    (#530). The SELECT is a single indexed poll, so delaying cancel until it
+    finishes is cheaper than losing the connection. The caller awaits
+    ``asyncio.sleep`` between ticks, which is the unshielded cancel checkpoint.
     """
 
     async def list_run_ids() -> list[tuple[str, str | None, str | None]]:
         maker = _get_session_maker()
-        async with maker() as session:
-            rows = await session.execute(
-                select(RunORM.run_id, RunORM.status, AssistantORM.graph_id)
-                .outerjoin(AssistantORM, RunORM.assistant_id == AssistantORM.assistant_id)
-                .where(RunORM.thread_id == thread_id, RunORM.user_id == user.identity)
-                .order_by(RunORM.created_at.asc())
-            )
-            return [(run_id, status, graph_id) for run_id, status, graph_id in rows.all()]
+        with anyio.CancelScope(shield=True):
+            async with maker() as session:
+                rows = await session.execute(
+                    select(RunORM.run_id, RunORM.status, AssistantORM.graph_id)
+                    .outerjoin(AssistantORM, RunORM.assistant_id == AssistantORM.assistant_id)
+                    .where(RunORM.thread_id == thread_id, RunORM.user_id == user.identity)
+                    .order_by(RunORM.created_at.asc())
+                )
+                return [(run_id, status, graph_id) for run_id, status, graph_id in rows.all()]
 
     return list_run_ids
 

--- a/libs/aegra-api/src/aegra_api/api/event_streaming.py
+++ b/libs/aegra-api/src/aegra_api/api/event_streaming.py
@@ -58,17 +58,11 @@ def _thread_run_lister(thread_id: str, user: User) -> RunLister:
     broker events expired instead of tailing them forever; graph_name feeds the
     run's root lifecycle events. Each tick uses a short-lived session so a
     connection is not held for the whole SSE lifetime (see #423).
-
-    The checkout is shielded from sse-starlette's ``cancel_on_finish`` anyio
-    scope: that cancel punches through ``asyncio.shield``, so an unshielded
-    ``async with`` is GC-terminated and leaks the pooled asyncpg connection
-    (#530). The SELECT is a single indexed poll, so delaying cancel until it
-    finishes is cheaper than losing the connection. The caller awaits
-    ``asyncio.sleep`` between ticks, which is the unshielded cancel checkpoint.
     """
 
     async def list_run_ids() -> list[tuple[str, str | None, str | None]]:
         maker = _get_session_maker()
+        # sse-starlette's anyio cancel punches through asyncio.shield (#530).
         with anyio.CancelScope(shield=True):
             async with maker() as session:
                 rows = await session.execute(

--- a/libs/aegra-api/tests/integration/test_api/test_event_streaming.py
+++ b/libs/aegra-api/tests/integration/test_api/test_event_streaming.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
+import threading
 import uuid
 from collections.abc import Iterator
 from functools import partial
@@ -237,31 +238,26 @@ class TestStreamRoute:
         }
 
     async def test_lister_session_close_survives_sse_cancel(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Disconnect during a lister poll must still run session ``__aexit__``.
-
-        sse_starlette cancels the generator via an anyio scope (not
-        ``asyncio.Task.cancel``), which is the production leak in #530.
-        """
-        closed = asyncio.Event()
-        aexit_cancelled = False
-        aexits = 0
+        """Disconnect during a lister poll must still run session ``__aexit__``."""
+        poll_started = threading.Event()
+        closed = threading.Event()
+        state = {"aexit_cancelled": False, "aexits": 0}
 
         class _SlowSession(_Session):
             async def execute(self, _stmt: Any) -> Any:
+                poll_started.set()
                 await asyncio.sleep(0.4)
                 return await super().execute(_stmt)
 
             async def __aexit__(self, *_exc: Any) -> None:
-                nonlocal aexit_cancelled, aexits
                 try:
                     await asyncio.sleep(0)
                 except asyncio.CancelledError:
-                    aexit_cancelled = True
+                    state["aexit_cancelled"] = True
                     raise
-                aexits += 1
-                # First close is the pre-SSE ownership check; the second is the
-                # in-stream lister poll that cancel_on_finish used to interrupt.
-                if aexits >= 2:
+                state["aexits"] += 1
+                # Ownership check closes first; the second close is the in-stream poll.
+                if state["aexits"] >= 2:
                     closed.set()
 
         monkeypatch.setattr(
@@ -271,31 +267,40 @@ class TestStreamRoute:
         )
         app = _make_app(monkeypatch)
         monkeypatch.setattr(es_module, "_get_session_maker", lambda: lambda: _SlowSession(owner=_USER))
-        server = uvicorn.Server(uvicorn.Config(app, host="127.0.0.1", port=0, log_level="error"))
-        serve = asyncio.create_task(server.serve())
+        # Separate loop: uvicorn.serve() cancels every task on its running loop.
+        server = uvicorn.Server(uvicorn.Config(app, host="127.0.0.1", port=0, log_level="error", lifespan="off"))
+        loop = asyncio.new_event_loop()
+        thread = threading.Thread(target=loop.run_forever, daemon=True)
+        thread.start()
+        serve = asyncio.run_coroutine_threadsafe(server.serve(), loop)
         try:
             for _ in range(50):
-                if server.started:
+                if server.started and server.servers:
                     break
                 await asyncio.sleep(0.02)
+            else:
+                raise RuntimeError("uvicorn did not bind a port")
             port = server.servers[0].sockets[0].getsockname()[1]
-            async with httpx.AsyncClient(timeout=None) as client, client.stream(
-                "POST",
-                f"http://127.0.0.1:{port}/threads/t1/stream/events",
-                json={"channels": ["messages"]},
-            ) as resp:
+            async with (
+                httpx.AsyncClient(timeout=None) as client,
+                client.stream(
+                    "POST",
+                    f"http://127.0.0.1:{port}/threads/t1/stream/events",
+                    json={"channels": ["messages"]},
+                ) as resp,
+            ):
                 assert resp.status_code == 200
-                await asyncio.sleep(0.1)
+                if not await asyncio.to_thread(poll_started.wait, 1.5):
+                    raise TimeoutError("lister poll did not start")
                 await resp.aclose()
-            await asyncio.wait_for(closed.wait(), timeout=1.5)
+            if not await asyncio.to_thread(closed.wait, 1.5):
+                raise TimeoutError("lister session was not closed")
         finally:
             server.should_exit = True
-            server.force_exit = True
-            try:
-                await asyncio.wait_for(serve, timeout=3)
-            except TimeoutError:
-                serve.cancel()
-                with contextlib.suppress(asyncio.CancelledError):
-                    await serve
+            with contextlib.suppress(TimeoutError):
+                serve.result(timeout=3)
+            loop.call_soon_threadsafe(loop.stop)
+            thread.join(timeout=3)
+            loop.close()
 
-        assert not aexit_cancelled
+        assert not state["aexit_cancelled"]

--- a/libs/aegra-api/tests/integration/test_api/test_event_streaming.py
+++ b/libs/aegra-api/tests/integration/test_api/test_event_streaming.py
@@ -3,13 +3,16 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import uuid
 from collections.abc import Iterator
 from functools import partial
 from typing import Any
 
+import httpx
 import pytest
+import uvicorn
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -168,6 +171,11 @@ class TestStreamRoute:
             await broker.put(f"{run_id}_event_4", ("end", {"status": "success"}))
 
         asyncio.run(seed())
+        monkeypatch.setattr(
+            es_module,
+            "ThreadEventSession",
+            partial(ThreadEventSession, idle_grace_seconds=0.01),
+        )
         client = TestClient(_make_app(monkeypatch, run_ids=[run_id]))
 
         with client.stream("POST", "/threads/t1/stream/events", json={"channels": ["messages", "lifecycle"]}) as resp:
@@ -227,3 +235,67 @@ class TestStreamRoute:
             "value": interrupt_value,
             "payload": interrupt_value,
         }
+
+    async def test_lister_session_close_survives_sse_cancel(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Disconnect during a lister poll must still run session ``__aexit__``.
+
+        sse_starlette cancels the generator via an anyio scope (not
+        ``asyncio.Task.cancel``), which is the production leak in #530.
+        """
+        closed = asyncio.Event()
+        aexit_cancelled = False
+        aexits = 0
+
+        class _SlowSession(_Session):
+            async def execute(self, _stmt: Any) -> Any:
+                await asyncio.sleep(0.4)
+                return await super().execute(_stmt)
+
+            async def __aexit__(self, *_exc: Any) -> None:
+                nonlocal aexit_cancelled, aexits
+                try:
+                    await asyncio.sleep(0)
+                except asyncio.CancelledError:
+                    aexit_cancelled = True
+                    raise
+                aexits += 1
+                # First close is the pre-SSE ownership check; the second is the
+                # in-stream lister poll that cancel_on_finish used to interrupt.
+                if aexits >= 2:
+                    closed.set()
+
+        monkeypatch.setattr(
+            es_module,
+            "ThreadEventSession",
+            partial(ThreadEventSession, idle_grace_seconds=5),
+        )
+        app = _make_app(monkeypatch)
+        monkeypatch.setattr(es_module, "_get_session_maker", lambda: lambda: _SlowSession(owner=_USER))
+        server = uvicorn.Server(uvicorn.Config(app, host="127.0.0.1", port=0, log_level="error"))
+        serve = asyncio.create_task(server.serve())
+        try:
+            for _ in range(50):
+                if server.started:
+                    break
+                await asyncio.sleep(0.02)
+            port = server.servers[0].sockets[0].getsockname()[1]
+            async with httpx.AsyncClient(timeout=None) as client, client.stream(
+                "POST",
+                f"http://127.0.0.1:{port}/threads/t1/stream/events",
+                json={"channels": ["messages"]},
+            ) as resp:
+                assert resp.status_code == 200
+                await asyncio.sleep(0.1)
+                await resp.aclose()
+            await asyncio.wait_for(closed.wait(), timeout=1.5)
+        finally:
+            server.should_exit = True
+            server.force_exit = True
+            try:
+                await asyncio.wait_for(serve, timeout=3)
+            except TimeoutError:
+                serve.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await serve
+
+        assert not aexit_cancelled

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.10.3"
+version = "0.10.4"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.10.3"
+version = "0.10.4"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -100,7 +100,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.10.3"
+version = "0.10.4"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
## Description

Fixes #530.

`POST /threads/{thread_id}/stream/events` checks out a short-lived SQLAlchemy session on every run-lister poll (250ms). When the client disconnects, `sse_starlette.EventSourceResponse.cancel_on_finish` cancels the generator with an **anyio** cancel scope.

That cancel punches through SQLAlchemy 2.0.51's `asyncio.shield(_terminate_graceful_close)`, so the pooled asyncpg connection is not checked in. The pool logs `Exception terminating connection` and GC later warns about the same `AdaptedConnection`.

#428 / #423 already dropped `Depends(get_session)` so the stream does not pin a session for its whole lifetime. This is the residual race on the per-tick lister session. Still present on 0.10.3 / `main`.

## Type of Change

- [x] `fix`: Bug fix

## Related Issues

Fixes #530.

## Changes Made

- Wrap the lister's `async with maker()` in `anyio.CancelScope(shield=True)` so query + `__aexit__` finish and the connection returns to `AsyncAdaptedQueuePool`.
- Leave the unshielded checkpoint at the caller's `asyncio.sleep` between polls, so a disconnect is not delayed by the next tick.
- Integration test: real `EventSourceResponse` over uvicorn, disconnect during a slow lister poll, assert `__aexit__` still runs. `asyncio.Task.cancel` would be a false green — `asyncio.shield` already loses to anyio, which is why this goes through `cancel_on_finish`.

No API / schema / OpenAPI change.

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing performed

Standalone A/B against local Postgres 18 + asyncpg, same shape as the #530 repro (`pg_sleep(1)`, disconnect at 200ms):

| | `Exception terminating connection` | GC non-checked-in warning |
|---|---|---|
| `main` (unshielded) | 1 | 0 (ERROR traceback is `cancel_on_finish`) |
| this PR (`CancelScope(shield=True)` + checkpoint) | 0 | 0 |

`libs/aegra-api/tests/integration/test_api/test_event_streaming.py`: **11 passed**.

## Checklist

- [x] Code follows project style (Ruff formatting)
- [x] All linting checks pass (`make lint`)
- [x] Type checking passes (`make type-check`)
- [x] All tests pass (`make test`)
- [x] Documentation updated (if needed)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] PR title follows Conventional Commits format

## Additional Notes

Shielding the **entire** `async with` (not only `__aexit__`) is required: SQLAlchemy's terminate also runs on the cancelled execute path, before `__aexit__`. Shielding only close still leaked. Shielding without an unshielded checkpoint after the block hangs the generator in a `while True` of shielded polls — that does not apply here because `_thread_run_lister` returns after one SELECT and `ThreadEventSession.stream` sleeps 250ms unshielded between ticks.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when clients disconnect during live event-stream updates.
  * Prevented in-progress run listing from being interrupted prematurely, allowing sessions to close cleanly.
* **Tests**
  * Added integration coverage for disconnects occurring during slow event-stream polling.
* **Chores**
  * Updated the API and CLI release version to 0.10.4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This follow-up addresses the prior review findings while preserving the SSE cancellation fix.
- Bumps `aegra-api`, `aegra-cli`, lockfile, and OpenAPI metadata to version 0.10.4.
- Replaces the cancellation-history docstring with a concise invariant-focused comment.
- Isolates Uvicorn on a separate event loop and reports readiness timeout explicitly instead of indexing an absent server.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/api/event_streaming.py | Keeps the shielded short-lived session lifecycle and shortens the explanatory cancellation comment. |
| libs/aegra-api/tests/integration/test_api/test_event_streaming.py | Runs Uvicorn on an isolated loop and handles failure to bind without the previously reported `IndexError`. |
| libs/aegra-api/pyproject.toml | Applies the required patch release bump to aegra-api. |
| libs/aegra-cli/pyproject.toml | Keeps the CLI package version aligned with aegra-api. |
| uv.lock | Synchronizes workspace package metadata with version 0.10.4. |
| docs/openapi.json | Updates generated API version metadata to 0.10.4. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(api): isolate SSE cancel test and pa..."](https://github.com/aegra/aegra/commit/6a914f5854cc8a08130b7dcb84bfd9825a73f680) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54443772)</sub>

<!-- /greptile_comment -->