### PR TITLE
fix(api): normalize subgraph task checkpoints

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Aegra",
     "description": "Production-ready Agent Protocol server",
-    "version": "0.10.0"
+    "version": "0.10.3"
   },
   "paths": {
     "/info": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Aegra",
     "description": "Production-ready Agent Protocol server",
-    "version": "0.10.3"
+    "version": "0.10.4"
   },
   "paths": {
     "/info": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Aegra",
     "description": "Production-ready Agent Protocol server",
-    "version": "0.10.3"
+    "version": "0.10.0"
   },
   "paths": {
     "/info": {
@@ -148,7 +148,7 @@
           "Assistants"
         ],
         "summary": "Create Assistant",
-        "description": "Create a new assistant.\n\nAn assistant is a configured instance of a graph. Provide a `graph_id`\nreferencing a graph defined in your `aegra.json`. If `assistant_id` is\nomitted, one is auto-generated. Set `if_exists` to `\"do_nothing\"` for\nidempotent creation.",
+        "description": "Create a new assistant.\n\nAn assistant is a configured instance of a graph. Provide a `graph_id`\nreferencing a graph defined in your `aegra.json`. If `assistant_id` is\nomitted, one is auto-generated. Set `if_exists` to `\"do_nothing\"` for\nidempotent creation; otherwise a taken `assistant_id` or an identical\ngraph/config pair answers 409.",
         "operationId": "create_assistant_assistants_post",
         "requestBody": {
           "content": {
@@ -167,6 +167,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Assistant"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Resource state conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentProtocolError"
                 }
               }
             }
@@ -5250,6 +5260,11 @@
             ],
             "title": "Checkpoint Ns",
             "default": ""
+          },
+          "checkpoint_map": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Checkpoint Map"
           }
         },
         "type": "object",

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.10.3"
+version = "0.10.4"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-api/src/aegra_api/api/threads.py
+++ b/libs/aegra-api/src/aegra_api/api/threads.py
@@ -773,7 +773,11 @@ async def get_thread_history_post(
                     state_snapshots.append(snapshot)
 
         # Convert outside the async with so the graph context is closed first
-        thread_states = thread_state_service.convert_snapshots_to_thread_states(state_snapshots, thread_id)
+        thread_states = thread_state_service.convert_snapshots_to_thread_states(
+            state_snapshots,
+            thread_id,
+            subgraphs=subgraphs,
+        )
 
         return thread_states
 

--- a/libs/aegra-api/src/aegra_api/core/serializers/langgraph.py
+++ b/libs/aegra-api/src/aegra_api/core/serializers/langgraph.py
@@ -31,8 +31,8 @@ class LangGraphSerializer(Serializer):
                     "name": getattr(task, "name", ""),
                     "error": getattr(task, "error", None),
                     "interrupts": [],
-                    "checkpoint": None,
-                    "state": getattr(task, "state", None),
+                    "checkpoint": self._checkpoint_from_config(getattr(task, "state", None)),
+                    "state": self._state_from_task_state(getattr(task, "state", None)),
                     "result": getattr(task, "result", None),
                 }
 
@@ -55,6 +55,34 @@ class LangGraphSerializer(Serializer):
             if isinstance(e, SerializationError):
                 raise
             raise SerializationError(f"Failed to serialize task: {str(e)}", task.__class__.__name__, e) from e
+
+    def _checkpoint_from_config(self, state: Any) -> dict[str, Any] | None:
+        if not self._is_checkpoint_config(state):
+            return None
+
+        configurable = state.get("configurable", {})
+        return {
+            "thread_id": configurable.get("thread_id"),
+            "checkpoint_ns": configurable.get("checkpoint_ns", ""),
+            "checkpoint_id": configurable.get("checkpoint_id"),
+            "checkpoint_map": configurable.get("checkpoint_map") or {},
+        }
+
+    def _state_from_task_state(self, state: Any) -> Any:
+        if self._is_checkpoint_config(state):
+            return None
+
+        return state
+
+    def _is_checkpoint_config(self, state: Any) -> bool:
+        if not isinstance(state, dict):
+            return False
+
+        configurable = state.get("configurable")
+        if not isinstance(configurable, dict):
+            return False
+
+        return any(key in configurable for key in ("thread_id", "checkpoint_ns", "checkpoint_id", "checkpoint_map"))
 
     def serialize_interrupt(self, interrupt: Any) -> dict[str, Any]:
         """Serialize a LangGraph interrupt"""

--- a/libs/aegra-api/src/aegra_api/models/threads.py
+++ b/libs/aegra-api/src/aegra_api/models/threads.py
@@ -109,6 +109,7 @@ class ThreadCheckpoint(BaseModel):
     checkpoint_id: str | None = None
     thread_id: str | None = None
     checkpoint_ns: str | None = ""
+    checkpoint_map: dict[str, Any] = Field(default_factory=dict)
 
 
 class ThreadCheckpointPostRequest(BaseModel):

--- a/libs/aegra-api/src/aegra_api/services/thread_state_service.py
+++ b/libs/aegra-api/src/aegra_api/services/thread_state_service.py
@@ -75,13 +75,19 @@ class ThreadStateService:
             )
             raise
 
-    def convert_snapshots_to_thread_states(self, snapshots: list[Any], thread_id: str) -> list[ThreadState]:
+    def convert_snapshots_to_thread_states(
+        self,
+        snapshots: list[Any],
+        thread_id: str,
+        *,
+        subgraphs: bool = False,
+    ) -> list[ThreadState]:
         """Convert multiple snapshots to ThreadState objects"""
         thread_states = []
 
         for i, snapshot in enumerate(snapshots):
             try:
-                thread_state = self.convert_snapshot_to_thread_state(snapshot, thread_id)
+                thread_state = self.convert_snapshot_to_thread_state(snapshot, thread_id, subgraphs=subgraphs)
                 thread_states.append(thread_state)
             except Exception as e:
                 logger.error(f"Failed to convert snapshot in batch: {e} (thread_id={thread_id}, snapshot_index={i})")

--- a/libs/aegra-api/src/aegra_api/services/thread_state_service.py
+++ b/libs/aegra-api/src/aegra_api/services/thread_state_service.py
@@ -111,11 +111,13 @@ class ThreadStateService:
         configurable = config.get("configurable", {})
         checkpoint_id = configurable.get("checkpoint_id")
         checkpoint_ns = configurable.get("checkpoint_ns", "")
+        checkpoint_map = configurable.get("checkpoint_map") or {}
 
         return ThreadCheckpoint(
             checkpoint_id=checkpoint_id,
             thread_id=thread_id,
             checkpoint_ns=checkpoint_ns,
+            checkpoint_map=checkpoint_map,
         )
 
     def _extract_checkpoint_id(self, config: Any) -> str | None:

--- a/libs/aegra-api/tests/integration/test_api/test_threads_history.py
+++ b/libs/aegra-api/tests/integration/test_api/test_threads_history.py
@@ -1,4 +1,6 @@
 import json
+from collections.abc import AsyncIterator
+from typing import Any
 
 import pytest
 from fastapi.testclient import TestClient
@@ -10,7 +12,7 @@ from aegra_api.core.orm import (
 # Reuse shared test helpers
 from tests.fixtures.clients import create_test_app, make_client
 from tests.fixtures.database import DummySessionBase, override_get_session_dep
-from tests.fixtures.langgraph import FakeAgent, make_snapshot, patch_langgraph_service
+from tests.fixtures.langgraph import FakeAgent, FakeSnapshot, make_snapshot, make_task, patch_langgraph_service
 from tests.fixtures.test_helpers import DummyThread
 
 
@@ -161,6 +163,36 @@ def test_post_history_with_checkpoint_ns(client: TestClient, mock_langgraph):
     assert len(states) == 2
     for s in states:
         assert s["checkpoint"]["checkpoint_ns"] == "nsA"
+
+
+def test_post_history_subgraphs_serializes_expanded_task_state(client: TestClient) -> None:
+    thread_id = _ensure_thread(client)
+    child_snapshot = make_snapshot(
+        {"foo": "bar"},
+        {"configurable": {"thread_id": thread_id, "checkpoint_id": "checkpoint-child", "checkpoint_ns": "child"}},
+    )
+    parent_snapshot = make_snapshot(
+        {},
+        {"configurable": {"thread_id": thread_id, "checkpoint_id": "checkpoint-parent", "checkpoint_ns": ""}},
+        tasks=(make_task(state=child_snapshot, interrupts=()),),
+    )
+
+    class SubgraphHistoryAgent(FakeAgent):
+        def __init__(self) -> None:
+            super().__init__([parent_snapshot])
+
+        async def aget_state_history(self, _config: dict[str, Any], **_kwargs: Any) -> AsyncIterator[FakeSnapshot]:
+            for snapshot in self._snapshots:
+                yield snapshot
+
+    with patch_langgraph_service(agent=SubgraphHistoryAgent()):
+        resp = client.post(f"/threads/{thread_id}/history", json={"subgraphs": True})
+
+    assert resp.status_code == 200, resp.text
+    task = resp.json()[0]["tasks"][0]
+    assert task["checkpoint"] is None
+    assert task["state"]["values"] == {"foo": "bar"}
+    assert task["state"]["checkpoint"]["checkpoint_id"] == "checkpoint-child"
 
 
 def test_get_history_basic(client: TestClient, mock_langgraph):

--- a/libs/aegra-api/tests/unit/test_services/test_thread_state_service.py
+++ b/libs/aegra-api/tests/unit/test_services/test_thread_state_service.py
@@ -163,6 +163,25 @@ def test_convert_snapshot_to_thread_state_preserves_checkpoint_map() -> None:
     assert result.checkpoint.checkpoint_map == {"child": "checkpoint-child"}
 
 
+def test_convert_snapshots_to_thread_states_forwards_subgraphs() -> None:
+    service = ThreadStateService()
+    child_snapshot = make_snapshot(
+        {"foo": "bar"},
+        {"configurable": {"checkpoint_id": "checkpoint-child", "checkpoint_ns": "child"}},
+    )
+    snapshot = make_snapshot(
+        {},
+        {"configurable": {"checkpoint_id": "checkpoint-parent", "checkpoint_ns": ""}},
+        tasks=(make_task(state=child_snapshot, interrupts=()),),
+    )
+
+    result = service.convert_snapshots_to_thread_states([snapshot], "thread-123", subgraphs=True)
+
+    nested_state = result[0].tasks[0]["state"]
+    assert nested_state.values == {"foo": "bar"}
+    assert nested_state.checkpoint.checkpoint_id == "checkpoint-child"
+
+
 def test_convert_snapshots_to_thread_states_skips_failures():
     service = ThreadStateService()
 

--- a/libs/aegra-api/tests/unit/test_services/test_thread_state_service.py
+++ b/libs/aegra-api/tests/unit/test_services/test_thread_state_service.py
@@ -49,6 +49,37 @@ def test_convert_snapshot_to_thread_state_basic():
     assert result.interrupts == [{"value": "Provide value:", "id": TEST_INTERRUPT_ID}]
 
 
+def test_convert_snapshot_to_thread_state_moves_task_config_to_checkpoint() -> None:
+    service = ThreadStateService()
+    task = make_task(
+        state={
+            "configurable": {
+                "thread_id": "thread-123",
+                "checkpoint_ns": "gather-intent-agent:123",
+                "checkpoint_id": "checkpoint-subgraph",
+                "checkpoint_map": {"": "checkpoint-parent"},
+            }
+        },
+        interrupts=(),
+    )
+    snapshot = make_snapshot(
+        {},
+        {"configurable": {"checkpoint_id": "checkpoint-1", "checkpoint_ns": ""}},
+        tasks=(task,),
+    )
+
+    result = service.convert_snapshot_to_thread_state(snapshot, "thread-123", subgraphs=False)
+
+    task_result = result.tasks[0]
+    assert task_result["state"] is None
+    assert task_result["checkpoint"] == {
+        "thread_id": "thread-123",
+        "checkpoint_ns": "gather-intent-agent:123",
+        "checkpoint_id": "checkpoint-subgraph",
+        "checkpoint_map": {"": "checkpoint-parent"},
+    }
+
+
 def test_convert_snapshot_to_thread_state_subgraphs_recurses():
     service = ThreadStateService()
 
@@ -112,6 +143,24 @@ def test_convert_snapshot_to_thread_state_subgraphs_recurses():
     assert nested_state.parent_checkpoint is not None
     assert nested_state.parent_checkpoint.checkpoint_id == "checkpoint-parent"
     assert nested_state.interrupts == [{"value": "Provide value:", "id": "child-interrupt"}]
+
+
+def test_convert_snapshot_to_thread_state_preserves_checkpoint_map() -> None:
+    service = ThreadStateService()
+    snapshot = make_snapshot(
+        {},
+        {
+            "configurable": {
+                "checkpoint_id": "checkpoint-1",
+                "checkpoint_ns": "",
+                "checkpoint_map": {"child": "checkpoint-child"},
+            }
+        },
+    )
+
+    result = service.convert_snapshot_to_thread_state(snapshot, "thread-123")
+
+    assert result.checkpoint.checkpoint_map == {"child": "checkpoint-child"}
 
 
 def test_convert_snapshots_to_thread_states_skips_failures():

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.10.3"
+version = "0.10.4"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Fixes #532

  ## Summary
  - Move unexpanded subgraph checkpoint config from `tasks[].state` into `tasks[].checkpoint`
  - Return `tasks[].state = null` when task state is a RunnableConfig checkpoint pointer
  - Preserve `thread_id`, `checkpoint_ns`, `checkpoint_id`, and `checkpoint_map`
  - Update the OpenAPI schema for checkpoint responses

  ## Tests
  - `.\.venv\Scripts\pytest.exe libs\aegra-api\tests\unit\test_services\test_thread_state_service.py
  libs\aegra-api\tests\unit\test_core\test_serializers\test_general.py -q --confcutdir=libs\aegra-
  api\tests\unit`
  - `.\.venv\Scripts\ruff.exe check ...`
  - `.\.venv\Scripts\ruff.exe format --check ...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Thread checkpoints now support optional checkpoint maps for preserving additional metadata.
  * Thread history requests can include nested subgraph state.
  * Task configuration and checkpoint metadata are represented more consistently in thread state.

* **Bug Fixes**
  * Improved snapshot conversion to preserve checkpoint maps and task configuration correctly.

* **Documentation**
  * Updated the OpenAPI specification to document checkpoint maps and the latest API version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR normalizes checkpoint pointers in serialized subgraph tasks and preserves checkpoint metadata throughout thread-history responses.
- Moves unexpanded task checkpoint configuration from `tasks[].state` to `tasks[].checkpoint`.
- Recursively converts expanded subgraph states when requested.
- Adds `checkpoint_map` to response models and the OpenAPI specification.
- Synchronizes the API, CLI, lockfile, and OpenAPI versions at `0.10.6`.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the previously reported OpenAPI version mismatch is fixed because the specification and both package manifests now use version 0.10.6.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/core/serializers/langgraph.py | Distinguishes checkpoint-pointer configurations from expanded task state and serializes the pointer into the checkpoint field. |
| libs/aegra-api/src/aegra_api/services/thread_state_service.py | Propagates the subgraphs option during batch conversion and preserves checkpoint maps in checkpoint responses. |
| libs/aegra-api/src/aegra_api/api/threads.py | Passes the requested subgraph-expansion mode into thread-history snapshot conversion. |
| libs/aegra-api/src/aegra_api/models/threads.py | Extends the checkpoint response model with a default-empty checkpoint map. |
| docs/openapi.json | Documents checkpoint maps and now reports version 0.10.6 consistently with both packages. |
| libs/aegra-api/tests/unit/test_services/test_thread_state_service.py | Adds regression coverage for checkpoint normalization, checkpoint maps, and expanded subgraph conversion. |
| libs/aegra-api/tests/integration/test_api/test_threads_history.py | Adds HTTP-level coverage for expanded task state in subgraph history responses. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[LangGraph task state] --> B{RunnableConfig checkpoint pointer?}
    B -->|Yes| C[Set task state to null]
    C --> D[Expose pointer as task checkpoint]
    B -->|No, expanded snapshot| E{Subgraphs requested?}
    E -->|Yes| F[Recursively convert nested snapshot]
    E -->|No| G[Preserve serialized task state]
    D --> H[Thread history response]
    F --> H
    G --> H
```
</details>

<sub>Reviews (4): Last reviewed commit: ["merge: sync thread checkpoint fix with m..."](https://github.com/aegra/aegra/commit/1dcc3c2ec897707b3ea5a23f1d8e88611b243471) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55067158)</sub>

<!-- /greptile_comment -->