### PR TITLE
fix(api): expose graph id in run config

### DIFF
--- a/docs/guides/authentication.mdx
+++ b/docs/guides/authentication.mdx
@@ -345,6 +345,7 @@ Convenience shortcuts are also available directly on `config["configurable"]`:
 
 - `config["configurable"]["user_id"]` -- the user's identity
 - `config["configurable"]["user_display_name"]` -- the user's display name
+- `config["configurable"]["graph_id"]` -- the graph key from `aegra.json` for the running assistant
 
 ## Provider examples
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Aegra",
     "description": "Production-ready Agent Protocol server",
-    "version": "0.10.3"
+    "version": "0.10.4"
   },
   "paths": {
     "/info": {

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.10.3"
+version = "0.10.4"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-api/src/aegra_api/services/langgraph_service.py
+++ b/libs/aegra-api/src/aegra_api/services/langgraph_service.py
@@ -703,6 +703,7 @@ def create_run_config(
     thread_id: str,
     user: User | BaseUser | None,
     *,
+    graph_id: str | None = None,
     additional_config: dict[str, Any] | None = None,
     checkpoint: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
@@ -746,6 +747,9 @@ def create_run_config(
     if checkpoint and isinstance(checkpoint, dict):
         safe = strip_pinned_config_keys(checkpoint)
         cfg["configurable"].update({k: v for k, v in safe.items() if v is not None})
+
+    if graph_id is not None:
+        cfg["configurable"].setdefault("graph_id", graph_id)
 
     # Finally inject user context via existing helper
     return inject_user_context(user, cfg)

--- a/libs/aegra-api/src/aegra_api/services/run_executor.py
+++ b/libs/aegra-api/src/aegra_api/services/run_executor.py
@@ -256,6 +256,7 @@ def _build_run_config(job: RunJob) -> dict[str, Any]:
         job.identity.run_id,
         job.identity.thread_id,
         job.user,
+        graph_id=job.identity.graph_id,
         additional_config=job.execution.config,
         checkpoint=job.execution.checkpoint,
     )

--- a/libs/aegra-api/tests/unit/test_services/test_langgraph_service.py
+++ b/libs/aegra-api/tests/unit/test_services/test_langgraph_service.py
@@ -663,6 +663,39 @@ class TestLangGraphServiceConfigs:
 
         assert result["configurable"]["checkpoint_key"] == "checkpoint_value"
 
+    def test_create_run_config_sets_graph_id_when_absent(self) -> None:
+        mock_user = Mock()
+        mock_user.identity = "user-123"
+        mock_user.display_name = "Test User"
+
+        with patch(
+            "aegra_api.services.langgraph_service.get_tracing_callbacks",
+            return_value=[],
+        ):
+            result = create_run_config("run-789", "thread-456", mock_user, graph_id="agent")
+
+        assert result["configurable"]["graph_id"] == "agent"
+
+    def test_create_run_config_preserves_client_graph_id(self) -> None:
+        mock_user = Mock()
+        mock_user.identity = "user-123"
+        mock_user.display_name = "Test User"
+        additional_config = {"configurable": {"graph_id": "client-agent"}}
+
+        with patch(
+            "aegra_api.services.langgraph_service.get_tracing_callbacks",
+            return_value=[],
+        ):
+            result = create_run_config(
+                "run-789",
+                "thread-456",
+                mock_user,
+                graph_id="server-agent",
+                additional_config=additional_config,
+            )
+
+        assert result["configurable"]["graph_id"] == "client-agent"
+
     def test_create_run_config_ignores_client_thread_id_override(self):
         """A client-supplied configurable.thread_id must not redirect execution.
 

--- a/libs/aegra-api/tests/unit/test_services/test_run_executor.py
+++ b/libs/aegra-api/tests/unit/test_services/test_run_executor.py
@@ -9,6 +9,7 @@ from aegra_api.models.auth import User
 from aegra_api.models.run_job import RunExecution, RunIdentity, RunJob
 from aegra_api.services import run_executor as run_executor_module
 from aegra_api.services.run_executor import (
+    _build_run_config,
     _GraphResult,
     _lease_loss_cancellations,
     _signal_end_event,
@@ -76,6 +77,16 @@ class TestExecuteRunSuccess:
         assert mock_finalize.await_args.kwargs["status"] == "success"
 
         mock_signal_end.assert_awaited_once_with("run-1", "success")
+
+
+class TestBuildRunConfig:
+    def test_injects_job_graph_id_into_configurable(self) -> None:
+        job = _make_job()
+
+        with patch("aegra_api.services.langgraph_service.get_tracing_callbacks", return_value=[]):
+            config = _build_run_config(job)
+
+        assert config["configurable"]["graph_id"] == "graph-1"
 
 
 class TestExecuteRunCancelledError:

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.10.3"
+version = "0.10.4"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.10.3"
+version = "0.10.4"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -100,7 +100,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.10.3"
+version = "0.10.4"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
Fixes #525

  ## Summary
  - Add `graph_id` to `create_run_config`
  - Pass `job.identity.graph_id` from the run executor into LangGraph config
  - Expose the value as `config.configurable.graph_id`
  - Preserve client-provided `configurable.graph_id` when already present

  ## Tests
  - `.\.venv\Scripts\pytest.exe libs\aegra-api\tests\unit\test_services\test_langgraph_service.py libs\aegra-
  api\tests\unit\test_services\test_run_executor.py -q --confcutdir=libs\aegra-api\tests\unit`
  - `.\.venv\Scripts\ruff.exe check ...`
  - `.\.venv\Scripts\ruff.exe format --check ...`
  - `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * LangGraph runs now automatically include the job’s graph identifier while preserving client-provided values.
  * Added thread pruning, per-thread TTL settings, and pagination support for up to 1,000 results.
  * Assistant creation now reports resource conflicts with a dedicated response.

* **Bug Fixes**
  * Shutdown cancellations now skip finalization and related completion signals.

* **Documentation**
  * Clarified how to configure the graph identifier for an assistant.
  * Updated API documentation and service versions to 0.10.6.

* **Tests**
  * Added coverage for graph identifier handling and shutdown cancellation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR exposes the active graph identifier through LangGraph run configuration and preserves an explicitly supplied configurable value.
- Passes the job’s graph ID into run configuration construction.
- Documents `configurable.graph_id` and adds unit coverage for injection and precedence.
- Updates API, CLI, lockfile, and OpenAPI versions to 0.10.6.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains, and the previously reported documentation and release-versioning issue is resolved.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/services/langgraph_service.py | Adds optional graph ID injection while preserving existing configurable values. |
| libs/aegra-api/src/aegra_api/services/run_executor.py | Supplies the executing job’s graph ID when constructing LangGraph run configuration. |
| docs/guides/authentication.mdx | Documents graph ID availability in the configurable run context. |
| libs/aegra-api/pyproject.toml | Bumps the API package version to 0.10.6. |
| libs/aegra-cli/pyproject.toml | Keeps the CLI package version aligned at 0.10.6. |

</details>

<sub>Reviews (3): Last reviewed commit: ["merge: resolve graph id config conflicts"](https://github.com/aegra/aegra/commit/33e3a31490892b2343e35d36af0b4999253db4ca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55092434)</sub>

<!-- /greptile_comment -->