### PR TITLE
fix(api): add bulk run cancel endpoint

### DIFF
--- a/docs/feature-support.mdx
+++ b/docs/feature-support.mdx
@@ -51,6 +51,7 @@ description: "What Aegra supports today, what's coming soon, and what's not yet 
 | Concurrent execution | Supported | Up to `N_JOBS_PER_WORKER` (default 10) concurrent runs per worker. |
 | Lease-based crash recovery | Supported | Automatic re-execution of runs from crashed workers via checkpoint resumption. |
 | Cross-instance cancel | Supported | Cancel propagates via Redis pub/sub to any instance. |
+| Bulk run cancellation | Supported | `client.runs.cancel_many()` maps to `POST /runs/cancel` with thread, run ID, or status selectors. |
 | Job timeout | Supported | Configurable max execution time (default 1 hour). |
 | Postgres fallback | Supported | Workers fall back to DB polling when Redis is unavailable. |
 | Multi-instance SSE | Supported | SSE streams work across instances via Redis broker. |

--- a/docs/guides/authentication.mdx
+++ b/docs/guides/authentication.mdx
@@ -166,7 +166,7 @@ as their parent, so one rule covers a whole family of endpoints:
 | Handler | Also covers |
 |---------|-------------|
 | `@auth.on.threads.read` | `GET /threads/{id}`, `/state`, `/state/{checkpoint_id}`, `/history`, `GET` a run, its `/join` and `/stream` |
-| `@auth.on.threads.update` | `PATCH /threads/{id}`, `POST /threads/{id}/state`, `PATCH` a run, `POST .../runs/{id}/cancel` |
+| `@auth.on.threads.update` | `PATCH /threads/{id}`, `POST /threads/{id}/state`, `PATCH` a run, `POST .../runs/{id}/cancel`, `POST /runs/cancel` |
 | `@auth.on.threads.delete` | `DELETE /threads/{id}`, `DELETE` a run |
 | `@auth.on.threads.create_run` | `POST /threads/{id}/runs`, `/runs/stream`, `/runs/wait`, `/threads/{id}/commands`, and the stateless `POST /runs`, `/runs/stream`, `/runs/wait` |
 | `@auth.on.threads.search` | `GET /threads`, `POST /threads/search`, `GET /threads/{id}/runs` |

--- a/docs/guides/streaming.mdx
+++ b/docs/guides/streaming.mdx
@@ -220,6 +220,13 @@ await client.runs.cancel(
     run_id=run["run_id"],
     action="interrupt",
 )
+
+# Cancel several runs selected by thread, run IDs, or status
+await client.runs.cancel_many(
+    thread_id=thread_id,
+    run_ids=[run["run_id"]],
+    action="interrupt",
+)
 ```
 
 Cancellation is asynchronous while a live worker owns the run.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Aegra",
     "description": "Production-ready Agent Protocol server",
-    "version": "0.10.3"
+    "version": "0.10.4"
   },
   "paths": {
     "/info": {
@@ -148,7 +148,7 @@
           "Assistants"
         ],
         "summary": "Create Assistant",
-        "description": "Create a new assistant.\n\nAn assistant is a configured instance of a graph. Provide a `graph_id`\nreferencing a graph defined in your `aegra.json`. If `assistant_id` is\nomitted, one is auto-generated. Set `if_exists` to `\"do_nothing\"` for\nidempotent creation.",
+        "description": "Create a new assistant.\n\nAn assistant is a configured instance of a graph. Provide a `graph_id`\nreferencing a graph defined in your `aegra.json`. If `assistant_id` is\nomitted, one is auto-generated. Set `if_exists` to `\"do_nothing\"` for\nidempotent creation; otherwise a taken `assistant_id` or an identical\ngraph/config pair answers 409.",
         "operationId": "create_assistant_assistants_post",
         "requestBody": {
           "content": {
@@ -167,6 +167,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Assistant"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Resource state conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentProtocolError"
                 }
               }
             }
@@ -2334,6 +2344,70 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/AgentProtocolError"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/runs/cancel": {
+      "post": {
+        "tags": [
+          "Thread Runs"
+        ],
+        "summary": "Cancel Runs Endpoint",
+        "description": "Cancel or interrupt multiple runs selected by thread, run IDs, or status.\n\nThis endpoint matches the LangGraph SDK ``runs.cancel_many()`` request\nshape. Selectors are scoped to the authenticated user, so unauthorized runs\nare simply excluded from the matching set. Runs that are already terminal\nare safe no-ops.",
+        "operationId": "cancel_runs_endpoint_runs_cancel_post",
+        "parameters": [
+          {
+            "name": "action",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "enum": [
+                "cancel",
+                "interrupt"
+              ],
+              "type": "string",
+              "description": "Cancellation strategy: 'cancel' for hard cancel, 'interrupt' for cooperative interrupt.",
+              "default": "interrupt",
+              "title": "Action"
+            },
+            "description": "Cancellation strategy: 'cancel' for hard cancel, 'interrupt' for cooperative interrupt."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RunCancelMany"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Run"
+                  },
+                  "title": "Response Cancel Runs Endpoint Runs Cancel Post"
                 }
               }
             }
@@ -4625,6 +4699,57 @@
         ],
         "title": "Run",
         "description": "Run entity model\n\nStatus values: pending, running, error, success, timeout, interrupted"
+      },
+      "RunCancelMany": {
+        "properties": {
+          "thread_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Thread Id",
+            "description": "Thread containing runs to cancel."
+          },
+          "run_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Run Ids",
+            "description": "Specific run IDs to cancel."
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "pending",
+                  "running",
+                  "all"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status",
+            "description": "Run status selector. Use 'all' to target every matching non-terminal run."
+          }
+        },
+        "type": "object",
+        "title": "RunCancelMany",
+        "description": "Request model for cancelling multiple runs."
       },
       "RunCreate": {
         "properties": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2357,7 +2357,7 @@
           "Thread Runs"
         ],
         "summary": "Cancel Runs Endpoint",
-        "description": "Cancel or interrupt multiple runs selected by thread, run IDs, or status.\n\nThis endpoint matches the LangGraph SDK ``runs.cancel_many()`` request\nshape. Selectors are scoped to the authenticated user, so unauthorized runs\nare simply excluded from the matching set. Runs that are already terminal\nare safe no-ops.",
+        "description": "Cancel or interrupt multiple runs selected by thread, run IDs, or status.\n\nThis endpoint matches the LangGraph SDK ``runs.cancel_many()`` request\nshape. Selectors are scoped to the authenticated user, so unauthorized runs\nare simply excluded from the matching set. SDK ``rollback`` maps to Aegra's\nhard cancel behavior. Runs that are already terminal are safe no-ops.",
         "operationId": "cancel_runs_endpoint_runs_cancel_post",
         "parameters": [
           {
@@ -2370,11 +2370,11 @@
                 "rollback"
               ],
               "type": "string",
-              "description": "Cancellation strategy: 'interrupt' or SDK-compatible 'rollback'.",
+              "description": "Cancellation strategy: 'interrupt' for cooperative interrupt or 'rollback' for hard cancel.",
               "default": "interrupt",
               "title": "Action"
             },
-            "description": "Cancellation strategy: 'interrupt' or SDK-compatible 'rollback'."
+            "description": "Cancellation strategy: 'interrupt' for cooperative interrupt or 'rollback' for hard cancel."
           }
         ],
         "requestBody": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -148,7 +148,7 @@
           "Assistants"
         ],
         "summary": "Create Assistant",
-        "description": "Create a new assistant.\n\nAn assistant is a configured instance of a graph. Provide a `graph_id`\nreferencing a graph defined in your `aegra.json`. If `assistant_id` is\nomitted, one is auto-generated. Set `if_exists` to `\"do_nothing\"` for\nidempotent creation; otherwise a taken `assistant_id` or an identical\ngraph/config pair answers 409.",
+        "description": "Create a new assistant.\n\nAn assistant is a configured instance of a graph. Provide a `graph_id`\nreferencing a graph defined in your `aegra.json`. If `assistant_id` is\nomitted, one is auto-generated. Set `if_exists` to `\"do_nothing\"` for\nidempotent creation.",
         "operationId": "create_assistant_assistants_post",
         "requestBody": {
           "content": {
@@ -167,16 +167,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Assistant"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "Resource state conflict",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AgentProtocolError"
                 }
               }
             }
@@ -2376,15 +2366,15 @@
             "required": false,
             "schema": {
               "enum": [
-                "cancel",
-                "interrupt"
+                "interrupt",
+                "rollback"
               ],
               "type": "string",
-              "description": "Cancellation strategy: 'cancel' for hard cancel, 'interrupt' for cooperative interrupt.",
+              "description": "Cancellation strategy: 'interrupt' or SDK-compatible 'rollback'.",
               "default": "interrupt",
               "title": "Action"
             },
-            "description": "Cancellation strategy: 'cancel' for hard cancel, 'interrupt' for cooperative interrupt."
+            "description": "Cancellation strategy: 'interrupt' or SDK-compatible 'rollback'."
           }
         ],
         "requestBody": {
@@ -4701,6 +4691,43 @@
         "description": "Run entity model\n\nStatus values: pending, running, error, success, timeout, interrupted"
       },
       "RunCancelMany": {
+        "anyOf": [
+          {
+            "properties": {
+              "thread_id": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "thread_id"
+            ]
+          },
+          {
+            "properties": {
+              "run_ids": {
+                "minItems": 1
+              }
+            },
+            "required": [
+              "run_ids"
+            ]
+          },
+          {
+            "properties": {
+              "status": {
+                "type": "string",
+                "enum": [
+                  "pending",
+                  "running",
+                  "all"
+                ]
+              }
+            },
+            "required": [
+              "status"
+            ]
+          }
+        ],
         "properties": {
           "thread_id": {
             "anyOf": [
@@ -4720,7 +4747,8 @@
                 "items": {
                   "type": "string"
                 },
-                "type": "array"
+                "type": "array",
+                "minItems": 1
               },
               {
                 "type": "null"

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -4705,6 +4705,7 @@
           {
             "properties": {
               "run_ids": {
+                "type": "array",
                 "minItems": 1
               }
             },

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.10.3"
+version = "0.10.4"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-api/src/aegra_api/api/runs.py
+++ b/libs/aegra-api/src/aegra_api/api/runs.py
@@ -534,7 +534,7 @@ async def cancel_runs_endpoint(
     request: RunCancelMany,
     action: BulkRunCancellationAction = Query(
         "interrupt",
-        description="Cancellation strategy: 'interrupt' or SDK-compatible 'rollback'.",
+        description="Cancellation strategy: 'interrupt' for cooperative interrupt or 'rollback' for hard cancel.",
     ),
     user: User = Depends(get_current_user),
     session: AsyncSession = Depends(get_session),
@@ -543,8 +543,8 @@ async def cancel_runs_endpoint(
 
     This endpoint matches the LangGraph SDK ``runs.cancel_many()`` request
     shape. Selectors are scoped to the authenticated user, so unauthorized runs
-    are simply excluded from the matching set. Runs that are already terminal
-    are safe no-ops.
+    are simply excluded from the matching set. SDK ``rollback`` maps to Aegra's
+    hard cancel behavior. Runs that are already terminal are safe no-ops.
     """
     filters = [RunORM.user_id == user.identity]
     if request.thread_id is not None:
@@ -558,9 +558,9 @@ async def cancel_runs_endpoint(
     run_orms = list(result.all())
 
     logger.info(f"[cancel_runs] request {action} matched={len(run_orms)}")
-    interruption_action: RunCancellationAction = "interrupt"
+    cancellation_action: RunCancellationAction = "interrupt" if action == "interrupt" else "cancel"
     for run_orm in run_orms:
-        await _request_run_interruption(session, run_orm, interruption_action)
+        await _request_run_interruption(session, run_orm, cancellation_action)
 
     for run_orm in run_orms:
         await session.refresh(run_orm)

--- a/libs/aegra-api/src/aegra_api/api/runs.py
+++ b/libs/aegra-api/src/aegra_api/api/runs.py
@@ -20,7 +20,7 @@ from aegra_api.core.orm import Run as RunORM
 from aegra_api.core.orm import Thread as ThreadORM
 from aegra_api.core.orm import _get_session_maker, get_session
 from aegra_api.core.sse import create_end_event, get_sse_headers, make_sse_response, sse_to_bytes
-from aegra_api.models import Run, RunCreate, RunStatus, User
+from aegra_api.models import Run, RunCancelMany, RunCreate, RunStatus, User
 from aegra_api.models.enums import RunCancellationAction
 from aegra_api.models.errors import CONFLICT, NOT_FOUND, SSE_RESPONSE
 from aegra_api.services.broker import broker_manager
@@ -527,6 +527,46 @@ async def cancel_run_endpoint(
 
     await session.refresh(run_orm)
     return Run.model_validate(run_orm)
+
+
+@router.post("/runs/cancel", response_model=list[Run])
+async def cancel_runs_endpoint(
+    request: RunCancelMany,
+    action: RunCancellationAction = Query(
+        "interrupt",
+        description="Cancellation strategy: 'cancel' for hard cancel, 'interrupt' for cooperative interrupt.",
+    ),
+    user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+) -> list[Run]:
+    """Cancel or interrupt multiple runs selected by thread, run IDs, or status.
+
+    This endpoint matches the LangGraph SDK ``runs.cancel_many()`` request
+    shape. Selectors are scoped to the authenticated user, so unauthorized runs
+    are simply excluded from the matching set. Runs that are already terminal
+    are safe no-ops.
+    """
+    filters = [RunORM.user_id == user.identity]
+    if request.thread_id is not None:
+        filters.append(RunORM.thread_id == request.thread_id)
+    if request.run_ids:
+        filters.append(RunORM.run_id.in_(request.run_ids))
+    if request.status is not None and request.status != "all":
+        filters.append(RunORM.status == validate_run_status(request.status))
+
+    result = await session.scalars(select(RunORM).where(*filters))
+    run_orms = list(result.all())
+
+    logger.info(
+        f"[cancel_runs] request {action} matched={len(run_orms)} "
+        f"user={user.identity} thread_id={request.thread_id} status={request.status}"
+    )
+    for run_orm in run_orms:
+        await _request_run_interruption(session, run_orm, action)
+
+    for run_orm in run_orms:
+        await session.refresh(run_orm)
+    return [Run.model_validate(run_orm) for run_orm in run_orms]
 
 
 @router.delete(

--- a/libs/aegra-api/src/aegra_api/api/runs.py
+++ b/libs/aegra-api/src/aegra_api/api/runs.py
@@ -21,7 +21,7 @@ from aegra_api.core.orm import Thread as ThreadORM
 from aegra_api.core.orm import _get_session_maker, get_session
 from aegra_api.core.sse import create_end_event, get_sse_headers, make_sse_response, sse_to_bytes
 from aegra_api.models import Run, RunCancelMany, RunCreate, RunStatus, User
-from aegra_api.models.enums import RunCancellationAction
+from aegra_api.models.enums import BulkRunCancellationAction, RunCancellationAction
 from aegra_api.models.errors import CONFLICT, NOT_FOUND, SSE_RESPONSE
 from aegra_api.services.broker import broker_manager
 from aegra_api.services.run_preparation import _prepare_run
@@ -532,9 +532,9 @@ async def cancel_run_endpoint(
 @router.post("/runs/cancel", response_model=list[Run])
 async def cancel_runs_endpoint(
     request: RunCancelMany,
-    action: RunCancellationAction = Query(
+    action: BulkRunCancellationAction = Query(
         "interrupt",
-        description="Cancellation strategy: 'cancel' for hard cancel, 'interrupt' for cooperative interrupt.",
+        description="Cancellation strategy: 'interrupt' or SDK-compatible 'rollback'.",
     ),
     user: User = Depends(get_current_user),
     session: AsyncSession = Depends(get_session),
@@ -557,12 +557,10 @@ async def cancel_runs_endpoint(
     result = await session.scalars(select(RunORM).where(*filters))
     run_orms = list(result.all())
 
-    logger.info(
-        f"[cancel_runs] request {action} matched={len(run_orms)} "
-        f"user={user.identity} thread_id={request.thread_id} status={request.status}"
-    )
+    logger.info(f"[cancel_runs] request {action} matched={len(run_orms)}")
+    interruption_action: RunCancellationAction = "interrupt"
     for run_orm in run_orms:
-        await _request_run_interruption(session, run_orm, action)
+        await _request_run_interruption(session, run_orm, interruption_action)
 
     for run_orm in run_orms:
         await session.refresh(run_orm)

--- a/libs/aegra-api/src/aegra_api/core/auth_registry.py
+++ b/libs/aegra-api/src/aegra_api/core/auth_registry.py
@@ -68,6 +68,7 @@ ROUTE_AUTH_MAP: Final[dict[tuple[str, str], tuple[str, str]]] = {
     ("POST", "/runs"): ("threads", "create_run"),
     ("POST", "/runs/stream"): ("threads", "create_run"),
     ("POST", "/runs/wait"): ("threads", "create_run"),
+    ("POST", "/runs/cancel"): ("threads", "update"),
     # --- crons --------------------------------------------------------------
     ("POST", "/runs/crons"): ("crons", "create"),
     ("POST", "/threads/{thread_id}/runs/crons"): ("crons", "create"),

--- a/libs/aegra-api/src/aegra_api/models/__init__.py
+++ b/libs/aegra-api/src/aegra_api/models/__init__.py
@@ -17,7 +17,7 @@ from aegra_api.models.crons import (
     CronUpdate,
 )
 from aegra_api.models.errors import AgentProtocolError, get_error_type
-from aegra_api.models.runs import Run, RunCreate, RunStatus
+from aegra_api.models.runs import Run, RunCancelMany, RunCreate, RunStatus
 from aegra_api.models.store import (
     StoreDeleteRequest,
     StoreGetResponse,
@@ -65,6 +65,7 @@ __all__ = [
     "ThreadHistoryRequest",
     # Runs
     "Run",
+    "RunCancelMany",
     "RunCreate",
     "RunStatus",
     # Crons

--- a/libs/aegra-api/src/aegra_api/models/enums.py
+++ b/libs/aegra-api/src/aegra_api/models/enums.py
@@ -29,3 +29,5 @@ MultitaskStrategy = Literal[
 ]
 
 RunCancellationAction = Literal["cancel", "interrupt"]
+
+BulkRunCancellationAction = Literal["interrupt", "rollback"]

--- a/libs/aegra-api/src/aegra_api/models/runs.py
+++ b/libs/aegra-api/src/aegra_api/models/runs.py
@@ -148,7 +148,7 @@ class RunCancelMany(BaseModel):
         json_schema_extra={
             "anyOf": [
                 {"required": ["thread_id"], "properties": {"thread_id": {"type": "string"}}},
-                {"required": ["run_ids"], "properties": {"run_ids": {"minItems": 1}}},
+                {"required": ["run_ids"], "properties": {"run_ids": {"type": "array", "minItems": 1}}},
                 {
                     "required": ["status"],
                     "properties": {"status": {"type": "string", "enum": ["pending", "running", "all"]}},

--- a/libs/aegra-api/src/aegra_api/models/runs.py
+++ b/libs/aegra-api/src/aegra_api/models/runs.py
@@ -144,8 +144,21 @@ class RunCreate(BaseModel):
 class RunCancelMany(BaseModel):
     """Request model for cancelling multiple runs."""
 
+    model_config = ConfigDict(
+        json_schema_extra={
+            "anyOf": [
+                {"required": ["thread_id"], "properties": {"thread_id": {"type": "string"}}},
+                {"required": ["run_ids"], "properties": {"run_ids": {"minItems": 1}}},
+                {
+                    "required": ["status"],
+                    "properties": {"status": {"type": "string", "enum": ["pending", "running", "all"]}},
+                },
+            ]
+        }
+    )
+
     thread_id: str | None = Field(None, description="Thread containing runs to cancel.")
-    run_ids: list[str] | None = Field(None, description="Specific run IDs to cancel.")
+    run_ids: list[str] | None = Field(None, min_length=1, description="Specific run IDs to cancel.")
     status: Literal["pending", "running", "all"] | None = Field(
         None,
         description="Run status selector. Use 'all' to target every matching non-terminal run.",

--- a/libs/aegra-api/src/aegra_api/models/runs.py
+++ b/libs/aegra-api/src/aegra_api/models/runs.py
@@ -141,6 +141,24 @@ class RunCreate(BaseModel):
         return self
 
 
+class RunCancelMany(BaseModel):
+    """Request model for cancelling multiple runs."""
+
+    thread_id: str | None = Field(None, description="Thread containing runs to cancel.")
+    run_ids: list[str] | None = Field(None, description="Specific run IDs to cancel.")
+    status: Literal["pending", "running", "all"] | None = Field(
+        None,
+        description="Run status selector. Use 'all' to target every matching non-terminal run.",
+    )
+
+    @model_validator(mode="after")
+    def validate_has_selector(self) -> Self:
+        """Require at least one selector so an empty request is never broad by accident."""
+        if self.thread_id is None and not self.run_ids and self.status is None:
+            raise ValueError("Must specify at least one of 'thread_id', 'run_ids', or 'status'")
+        return self
+
+
 class Run(BaseModel):
     """Run entity model
 

--- a/libs/aegra-api/tests/e2e/test_runs/test_runs.py
+++ b/libs/aegra-api/tests/e2e/test_runs/test_runs.py
@@ -165,7 +165,7 @@ async def test_runs_cancel_e2e():
 
 @pytest.mark.e2e
 @pytest.mark.asyncio
-async def test_runs_cancel_many_sdk_e2e():
+async def test_runs_cancel_many_sdk_e2e() -> None:
     """The LangGraph SDK cancel_many helper must not 404 against Aegra."""
     client = get_e2e_client()
 

--- a/libs/aegra-api/tests/e2e/test_runs/test_runs.py
+++ b/libs/aegra-api/tests/e2e/test_runs/test_runs.py
@@ -165,6 +165,34 @@ async def test_runs_cancel_e2e():
 
 @pytest.mark.e2e
 @pytest.mark.asyncio
+async def test_runs_cancel_many_sdk_e2e():
+    """The LangGraph SDK cancel_many helper must not 404 against Aegra."""
+    client = get_e2e_client()
+
+    assistant = await client.assistants.create(
+        graph_id="agent",
+        config={"tags": ["chat", "runs-cancel-many"]},
+        if_exists="do_nothing",
+    )
+    thread = await client.threads.create()
+    thread_id = thread["thread_id"]
+
+    run = await client.runs.create(
+        thread_id=thread_id,
+        assistant_id=assistant["assistant_id"],
+        input={"messages": [{"role": "user", "content": "Say one short sentence."}]},
+    )
+    check_and_skip_if_geo_blocked(run)
+
+    await client.runs.cancel_many(thread_id=thread_id, run_ids=[run["run_id"]], action="interrupt")
+
+    got = await client.runs.get(thread_id, run["run_id"])
+    elog("Runs.cancel_many", got)
+    assert got["run_id"] == run["run_id"]
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
 async def test_runs_wait_stateful_e2e():
     """
     Test the stateful wait endpoint (POST /threads/{thread_id}/runs/wait).

--- a/libs/aegra-api/tests/integration/test_api/test_runs_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_runs_crud.py
@@ -433,8 +433,8 @@ class TestCancelRun:
 
         assert resp.status_code == 422
 
-    def test_cancel_many_accepts_sdk_rollback_action(self: "TestCancelRun") -> None:
-        """Test the SDK rollback action is accepted for bulk cancellation."""
+    def test_cancel_many_maps_sdk_rollback_to_hard_cancel(self: "TestCancelRun") -> None:
+        """Test the SDK rollback action uses hard cancellation."""
         app = create_test_app(include_runs=True, include_threads=False)
 
         run = _run_row(run_id="run-rollback", status="running")
@@ -458,13 +458,15 @@ class TestCancelRun:
                 return_value=True,
             ),
         ):
+            mock_streaming.cancel_run = AsyncMock()
             mock_streaming.interrupt_run = AsyncMock()
             mock_streaming.signal_run_cancelled = AsyncMock()
 
             resp = client.post("/runs/cancel?action=rollback", json={"status": "running"})
 
             assert resp.status_code == 200
-            mock_streaming.interrupt_run.assert_awaited_once_with("run-rollback", emit_end_event=False)
+            mock_streaming.cancel_run.assert_awaited_once_with("run-rollback", emit_end_event=False)
+            mock_streaming.interrupt_run.assert_not_awaited()
 
     def test_cancel_many_rejects_unsupported_action(self: "TestCancelRun") -> None:
         """Test unsupported actions fail explicitly."""

--- a/libs/aegra-api/tests/integration/test_api/test_runs_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_runs_crud.py
@@ -1,5 +1,6 @@
 """Integration tests for runs CRUD operations"""
 
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from tests.fixtures.clients import create_test_app, make_client
@@ -346,7 +347,7 @@ class TestCancelRun:
             mock_streaming.cancel_run.assert_awaited_once_with("test-run-123", emit_end_event=False)
             mock_streaming.signal_run_cancelled.assert_awaited_once_with("test-run-123")
 
-    def test_cancel_many_matches_sdk_payload(self):
+    def test_cancel_many_matches_sdk_payload(self) -> None:
         """Test bulk cancel accepts the langgraph-sdk cancel_many payload."""
         app = create_test_app(include_runs=True, include_threads=False)
 
@@ -356,9 +357,9 @@ class TestCancelRun:
         ]
 
         class Session(DummySessionBase):
-            async def scalars(self, _stmt):
+            async def scalars(self, _stmt: Any) -> Any:
                 class Result:
-                    def all(self):
+                    def all(self) -> list[Any]:
                         return runs
 
                 return Result()
@@ -389,16 +390,16 @@ class TestCancelRun:
             mock_streaming.interrupt_run.assert_any_await("run-2", emit_end_event=False)
             assert mock_streaming.signal_run_cancelled.await_count == 2
 
-    def test_cancel_many_status_all_is_safe_for_terminal_runs(self):
+    def test_cancel_many_status_all_is_safe_for_terminal_runs(self) -> None:
         """Test bulk cancel accepts status=all and leaves terminal runs untouched."""
         app = create_test_app(include_runs=True, include_threads=False)
 
         terminal_run = _run_row(run_id="run-success", status="success")
 
         class Session(DummySessionBase):
-            async def scalars(self, _stmt):
+            async def scalars(self, _stmt: Any) -> Any:
                 class Result:
-                    def all(self):
+                    def all(self) -> list[Any]:
                         return [terminal_run]
 
                 return Result()
@@ -421,7 +422,7 @@ class TestCancelRun:
             mock_streaming.cancel_run.assert_not_awaited()
             mock_streaming.interrupt_run.assert_not_awaited()
 
-    def test_cancel_many_requires_a_selector(self):
+    def test_cancel_many_requires_a_selector(self) -> None:
         """Test an empty bulk cancel request is rejected."""
         app = create_test_app(include_runs=True, include_threads=False)
 
@@ -432,14 +433,47 @@ class TestCancelRun:
 
         assert resp.status_code == 422
 
-    def test_cancel_many_rejects_unsupported_action(self):
-        """Test unsupported SDK actions fail explicitly."""
+    def test_cancel_many_accepts_sdk_rollback_action(self) -> None:
+        """Test the SDK rollback action is accepted for bulk cancellation."""
+        app = create_test_app(include_runs=True, include_threads=False)
+
+        run = _run_row(run_id="run-rollback", status="running")
+
+        class Session(DummySessionBase):
+            async def scalars(self, _stmt: Any) -> Any:
+                class Result:
+                    def all(self) -> list[Any]:
+                        return [run]
+
+                return Result()
+
+        override_session_dependency(app, Session)
+        client = make_client(app)
+
+        with (
+            patch("aegra_api.api.runs.streaming_service") as mock_streaming,
+            patch(
+                "aegra_api.api.runs.interrupt_unowned_run",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+        ):
+            mock_streaming.interrupt_run = AsyncMock()
+            mock_streaming.signal_run_cancelled = AsyncMock()
+
+            resp = client.post("/runs/cancel?action=rollback", json={"status": "running"})
+
+            assert resp.status_code == 200
+            mock_streaming.interrupt_run.assert_awaited_once_with("run-rollback", emit_end_event=False)
+
+    def test_cancel_many_rejects_unsupported_action(self) -> None:
+        """Test unsupported actions fail explicitly."""
         app = create_test_app(include_runs=True, include_threads=False)
 
         override_session_dependency(app, BasicSession)
         client = make_client(app)
 
-        resp = client.post("/runs/cancel?action=rollback", json={"status": "running"})
+        resp = client.post("/runs/cancel?action=cancel", json={"status": "running"})
 
         assert resp.status_code == 422
 

--- a/libs/aegra-api/tests/integration/test_api/test_runs_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_runs_crud.py
@@ -346,6 +346,103 @@ class TestCancelRun:
             mock_streaming.cancel_run.assert_awaited_once_with("test-run-123", emit_end_event=False)
             mock_streaming.signal_run_cancelled.assert_awaited_once_with("test-run-123")
 
+    def test_cancel_many_matches_sdk_payload(self):
+        """Test bulk cancel accepts the langgraph-sdk cancel_many payload."""
+        app = create_test_app(include_runs=True, include_threads=False)
+
+        runs = [
+            _run_row(run_id="run-1", thread_id="thread-1", status="running"),
+            _run_row(run_id="run-2", thread_id="thread-1", status="pending"),
+        ]
+
+        class Session(DummySessionBase):
+            async def scalars(self, _stmt):
+                class Result:
+                    def all(self):
+                        return runs
+
+                return Result()
+
+        override_session_dependency(app, Session)
+        client = make_client(app)
+
+        with (
+            patch("aegra_api.api.runs.streaming_service") as mock_streaming,
+            patch(
+                "aegra_api.api.runs.interrupt_unowned_run",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+        ):
+            mock_streaming.interrupt_run = AsyncMock()
+            mock_streaming.signal_run_cancelled = AsyncMock()
+
+            resp = client.post(
+                "/runs/cancel?action=interrupt",
+                json={"thread_id": "thread-1", "run_ids": ["run-1", "run-2"]},
+            )
+
+            assert resp.status_code == 200
+            assert [run["run_id"] for run in resp.json()] == ["run-1", "run-2"]
+            assert mock_streaming.interrupt_run.await_count == 2
+            mock_streaming.interrupt_run.assert_any_await("run-1", emit_end_event=False)
+            mock_streaming.interrupt_run.assert_any_await("run-2", emit_end_event=False)
+            assert mock_streaming.signal_run_cancelled.await_count == 2
+
+    def test_cancel_many_status_all_is_safe_for_terminal_runs(self):
+        """Test bulk cancel accepts status=all and leaves terminal runs untouched."""
+        app = create_test_app(include_runs=True, include_threads=False)
+
+        terminal_run = _run_row(run_id="run-success", status="success")
+
+        class Session(DummySessionBase):
+            async def scalars(self, _stmt):
+                class Result:
+                    def all(self):
+                        return [terminal_run]
+
+                return Result()
+
+        override_session_dependency(app, Session)
+        client = make_client(app)
+
+        with (
+            patch("aegra_api.api.runs.streaming_service") as mock_streaming,
+            patch("aegra_api.api.runs.interrupt_unowned_run", new_callable=AsyncMock) as mock_interrupt_unowned,
+        ):
+            mock_streaming.cancel_run = AsyncMock()
+            mock_streaming.interrupt_run = AsyncMock()
+
+            resp = client.post("/runs/cancel", json={"status": "all"})
+
+            assert resp.status_code == 200
+            assert resp.json()[0]["status"] == "success"
+            mock_interrupt_unowned.assert_not_awaited()
+            mock_streaming.cancel_run.assert_not_awaited()
+            mock_streaming.interrupt_run.assert_not_awaited()
+
+    def test_cancel_many_requires_a_selector(self):
+        """Test an empty bulk cancel request is rejected."""
+        app = create_test_app(include_runs=True, include_threads=False)
+
+        override_session_dependency(app, BasicSession)
+        client = make_client(app)
+
+        resp = client.post("/runs/cancel", json={})
+
+        assert resp.status_code == 422
+
+    def test_cancel_many_rejects_unsupported_action(self):
+        """Test unsupported SDK actions fail explicitly."""
+        app = create_test_app(include_runs=True, include_threads=False)
+
+        override_session_dependency(app, BasicSession)
+        client = make_client(app)
+
+        resp = client.post("/runs/cancel?action=rollback", json={"status": "running"})
+
+        assert resp.status_code == 422
+
 
 class TestDeleteRun:
     """Test DELETE /threads/{thread_id}/runs/{run_id}"""

--- a/libs/aegra-api/tests/integration/test_api/test_runs_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_runs_crud.py
@@ -347,7 +347,7 @@ class TestCancelRun:
             mock_streaming.cancel_run.assert_awaited_once_with("test-run-123", emit_end_event=False)
             mock_streaming.signal_run_cancelled.assert_awaited_once_with("test-run-123")
 
-    def test_cancel_many_matches_sdk_payload(self) -> None:
+    def test_cancel_many_matches_sdk_payload(self: "TestCancelRun") -> None:
         """Test bulk cancel accepts the langgraph-sdk cancel_many payload."""
         app = create_test_app(include_runs=True, include_threads=False)
 
@@ -390,7 +390,7 @@ class TestCancelRun:
             mock_streaming.interrupt_run.assert_any_await("run-2", emit_end_event=False)
             assert mock_streaming.signal_run_cancelled.await_count == 2
 
-    def test_cancel_many_status_all_is_safe_for_terminal_runs(self) -> None:
+    def test_cancel_many_status_all_is_safe_for_terminal_runs(self: "TestCancelRun") -> None:
         """Test bulk cancel accepts status=all and leaves terminal runs untouched."""
         app = create_test_app(include_runs=True, include_threads=False)
 
@@ -422,7 +422,7 @@ class TestCancelRun:
             mock_streaming.cancel_run.assert_not_awaited()
             mock_streaming.interrupt_run.assert_not_awaited()
 
-    def test_cancel_many_requires_a_selector(self) -> None:
+    def test_cancel_many_requires_a_selector(self: "TestCancelRun") -> None:
         """Test an empty bulk cancel request is rejected."""
         app = create_test_app(include_runs=True, include_threads=False)
 
@@ -433,7 +433,7 @@ class TestCancelRun:
 
         assert resp.status_code == 422
 
-    def test_cancel_many_accepts_sdk_rollback_action(self) -> None:
+    def test_cancel_many_accepts_sdk_rollback_action(self: "TestCancelRun") -> None:
         """Test the SDK rollback action is accepted for bulk cancellation."""
         app = create_test_app(include_runs=True, include_threads=False)
 
@@ -466,7 +466,7 @@ class TestCancelRun:
             assert resp.status_code == 200
             mock_streaming.interrupt_run.assert_awaited_once_with("run-rollback", emit_end_event=False)
 
-    def test_cancel_many_rejects_unsupported_action(self) -> None:
+    def test_cancel_many_rejects_unsupported_action(self: "TestCancelRun") -> None:
         """Test unsupported actions fail explicitly."""
         app = create_test_app(include_runs=True, include_threads=False)
 

--- a/libs/aegra-api/tests/unit/test_core/test_auth_registry.py
+++ b/libs/aegra-api/tests/unit/test_core/test_auth_registry.py
@@ -210,6 +210,7 @@ _SPEC_TUPLES: dict[tuple[str, str], tuple[str, str]] = {
     ("POST", "/runs"): ("threads", "create_run"),
     ("POST", "/runs/stream"): ("threads", "create_run"),
     ("POST", "/runs/wait"): ("threads", "create_run"),
+    ("POST", "/runs/cancel"): ("threads", "update"),
     # crons
     ("POST", "/runs/crons"): ("crons", "create"),
     ("POST", "/threads/{thread_id}/runs/crons"): ("crons", "create"),

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.10.3"
+version = "0.10.4"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.10.3"
+version = "0.10.4"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -100,7 +100,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.10.3"
+version = "0.10.4"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
## Summary

  Fixes #537.

  Adds the missing `POST /runs/cancel` endpoint used by `langgraph-sdk` `client.runs.cancel_many(...)`.

  ## Changes

  - Added `RunCancelMany` request model.
  - Added `POST /runs/cancel` route.
  - Supports selectors:
    - `thread_id`
    - `run_ids`
    - `status`
  - Defaults bulk cancel action to `interrupt`, matching SDK behavior.
  - Reuses existing run interruption/cancellation logic.
  - Keeps terminal runs safe as no-ops.
  - Filters by authenticated `user_id` to preserve ownership isolation.
  - Adds auth registry mapping for `threads.update`.
  - Updates OpenAPI, docs, and package versions to `0.10.4`.
  - Adds integration and SDK E2E coverage.

  ## Testing

  - `ruff check`
  - `git diff --check`
  - `pytest libs/aegra-api/tests/unit/test_core/test_auth_registry.py libs/aegra-api/tests/integration/test_api/
  test_runs_crud.py -q`

  Result:

  ```text
  48 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bulk run cancellation with cooperative interruption or hard cancellation.
  * Select runs by thread, run IDs, or status; at least one selector is required.
  * Added thread pruning to delete expired threads or retain their latest checkpoint.
  * Added per-thread TTL configuration.
  * Increased assistant and thread search limits to 1,000.
* **Documentation**
  * Added usage examples, API reference details, endpoint information, and selector guidance.
  * Documented cancellation actions, thread pruning, TTL settings, and assistant creation conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds the SDK-compatible bulk run cancellation endpoint with authenticated run selection and cooperative or hard cancellation.
- Adds selectors for thread, run IDs, and run status.
- Maps the SDK’s `rollback` action to the existing hard-cancel behavior.
- Registers the endpoint under `threads.update` authorization.
- Adds integration and E2E coverage, documentation, OpenAPI updates, and synchronized package versions.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/api/runs.py | Adds the authenticated bulk-cancel route and correctly maps `interrupt` and SDK `rollback` actions to existing cancellation behavior. |
| libs/aegra-api/src/aegra_api/models/runs.py | Adds a validated bulk-cancellation request model requiring at least one non-empty selector. |
| libs/aegra-api/src/aegra_api/models/enums.py | Defines the SDK-compatible bulk cancellation action vocabulary. |
| libs/aegra-api/src/aegra_api/core/auth_registry.py | Maps bulk cancellation to the existing `threads.update` authorization handler. |
| libs/aegra-api/tests/integration/test_api/test_runs_crud.py | Covers selector validation, ownership scoping, terminal-run behavior, action validation, and rollback-to-hard-cancel mapping. |

</details>

<sub>Reviews (5): Last reviewed commit: ["merge: sync bulk cancel fix with main"](https://github.com/aegra/aegra/commit/fc78bfeba5e9e7d579c43baa635ee067bce0ceed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55250784)</sub>

<!-- /greptile_comment -->