### PR TITLE
fix(api): release db session before thread-history iteration

### DIFF
--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.10.3"
+version = "0.10.4"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-api/src/aegra_api/api/threads.py
+++ b/libs/aegra-api/src/aegra_api/api/threads.py
@@ -696,8 +696,7 @@ async def get_thread_history_post(
 ) -> list[ThreadState]:
     """Get the checkpoint history for a thread (POST variant).
 
-    Returns a list of past states ordered from newest to oldest. Use `limit`
-    to control how many states are returned and `before` to paginate.
+    Returns states newest to oldest; `limit` bounds the count, `before` paginates.
     """
     try:
         limit = request.limit or 10
@@ -710,9 +709,8 @@ async def get_thread_history_post(
         subgraphs = bool(request.subgraphs) if request.subgraphs is not None else False
         checkpoint_ns = request.checkpoint_ns
 
-        # Session scoped to this lookup only: aget_state_history below can run
-        # long, and holding a pooled connection open across it is what leaked
-        # connections on aborted requests (aegra#517, same shape as #423/#428).
+        # Scoped to this lookup only: holding it open across aget_state_history
+        # below leaked connections on aborted requests (aegra#517).
         maker = _get_session_maker()
         async with maker() as session:
             stmt = select(ThreadORM).where(ThreadORM.thread_id == thread_id, ThreadORM.user_id == user.identity)

--- a/libs/aegra-api/src/aegra_api/api/threads.py
+++ b/libs/aegra-api/src/aegra_api/api/threads.py
@@ -21,7 +21,7 @@ from aegra_api.core.auth_handlers import build_auth_context, handle_event
 from aegra_api.core.database import db_manager
 from aegra_api.core.orm import Run as RunORM
 from aegra_api.core.orm import Thread as ThreadORM
-from aegra_api.core.orm import get_session
+from aegra_api.core.orm import _get_session_maker, get_session
 from aegra_api.models import (
     Thread,
     ThreadCheckpoint,
@@ -693,7 +693,6 @@ async def get_thread_history_post(
     thread_id: str,
     request: ThreadHistoryRequest,
     user: User = Depends(get_current_user),
-    session: AsyncSession = Depends(get_session),
 ) -> list[ThreadState]:
     """Get the checkpoint history for a thread (POST variant).
 
@@ -711,8 +710,13 @@ async def get_thread_history_post(
         subgraphs = bool(request.subgraphs) if request.subgraphs is not None else False
         checkpoint_ns = request.checkpoint_ns
 
-        stmt = select(ThreadORM).where(ThreadORM.thread_id == thread_id, ThreadORM.user_id == user.identity)
-        thread = await session.scalar(stmt)
+        # Session scoped to this lookup only: aget_state_history below can run
+        # long, and holding a pooled connection open across it is what leaked
+        # connections on aborted requests (aegra#517, same shape as #423/#428).
+        maker = _get_session_maker()
+        async with maker() as session:
+            stmt = select(ThreadORM).where(ThreadORM.thread_id == thread_id, ThreadORM.user_id == user.identity)
+            thread = await session.scalar(stmt)
         if not thread:
             raise HTTPException(404, f"Thread '{thread_id}' not found")
 
@@ -796,7 +800,6 @@ async def get_thread_history_get(
     checkpoint_ns: str | None = Query(None, description="Checkpoint namespace"),
     metadata: str | None = Query(None, description="JSON-encoded metadata filter"),
     user: User = Depends(get_current_user),
-    session: AsyncSession = Depends(get_session),
 ) -> list[ThreadState]:
     """Get the checkpoint history for a thread.
 
@@ -819,7 +822,7 @@ async def get_thread_history_get(
         subgraphs=subgraphs,
         checkpoint_ns=checkpoint_ns,
     )
-    return await get_thread_history_post(thread_id, req, user, session)
+    return await get_thread_history_post(thread_id, req, user)
 
 
 @router.delete(

--- a/libs/aegra-api/tests/integration/test_api/test_threads_history.py
+++ b/libs/aegra-api/tests/integration/test_api/test_threads_history.py
@@ -1,4 +1,5 @@
 import json
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi.testclient import TestClient
@@ -12,6 +13,27 @@ from tests.fixtures.clients import create_test_app, make_client
 from tests.fixtures.database import DummySessionBase, override_get_session_dep
 from tests.fixtures.langgraph import FakeAgent, make_snapshot, patch_langgraph_service
 from tests.fixtures.test_helpers import DummyThread
+
+
+def _make_session_maker(session_instance: DummySessionBase, on_exit=None) -> MagicMock:
+    """Return a callable mimicking ``async_sessionmaker``.
+
+    Calling the returned object produces an async context manager that yields
+    *session_instance*, matching the ``async with maker() as session:`` pattern
+    ``get_thread_history_post`` uses (see ``aegra_api.api.runs`` for the same idiom).
+    ``on_exit``, if given, is invoked when the context manager exits (i.e. the
+    pooled connection would be released back to the pool).
+    """
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=session_instance)
+
+    async def _aexit(*_args):
+        if on_exit is not None:
+            on_exit()
+        return False
+
+    ctx.__aexit__ = AsyncMock(side_effect=_aexit)
+    return MagicMock(return_value=ctx)
 
 
 def _thread_row():
@@ -46,7 +68,7 @@ def _thread_row():
 
 
 @pytest.fixture()
-def client() -> TestClient:
+def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
     # Build app with threads router only
     app = create_test_app(include_runs=False, include_threads=True)
 
@@ -55,8 +77,16 @@ def client() -> TestClient:
         async def scalar(self, _stmt):
             return _thread_row()
 
-    # Override the ORM get_session dependency
+    # POST /threads (used by _ensure_thread below) still uses Depends(get_session).
     app.dependency_overrides[core_get_session] = override_get_session_dep(Session)
+
+    # get_thread_history_post/get manage their own session via
+    # _get_session_maker() (not Depends), scoped to the thread lookup only —
+    # patch that instead of overriding the get_session dependency.
+    monkeypatch.setattr(
+        "aegra_api.api.threads._get_session_maker",
+        lambda: _make_session_maker(Session()),
+    )
 
     return make_client(app)
 
@@ -290,3 +320,62 @@ class TestBeforeParameterFormats:
 
         assert len(captured) == 1
         assert captured[0] is None
+
+
+# ------------------------------------------------------------------
+# Regression: the thread-lookup session must be released back to the pool
+# before the (potentially long-running / abortable) aget_state_history
+# iteration starts, not held open across it. See: aegra#517.
+# ------------------------------------------------------------------
+
+
+def test_post_history_session_released_before_state_history_iterates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The DB session used for the thread lookup must be closed before
+    ``aget_state_history`` is iterated, so an abort mid-iteration can't strand
+    a checked-out connection.
+
+    Fails before the fix: the session dependency stayed open for the whole
+    handler, so ``session_closed`` was still empty when the first snapshot
+    was pulled.
+    """
+    app = create_test_app(include_runs=False, include_threads=True)
+
+    class Session(DummySessionBase):
+        async def scalar(self, _stmt):
+            return _thread_row()
+
+    app.dependency_overrides[core_get_session] = override_get_session_dep(Session)
+
+    session_closed: list[bool] = []
+    monkeypatch.setattr(
+        "aegra_api.api.threads._get_session_maker",
+        lambda: _make_session_maker(Session(), on_exit=lambda: session_closed.append(True)),
+    )
+
+    class AssertingAgent(FakeAgent):
+        """Blows up if the thread-lookup session is still open when history streaming starts."""
+
+        def __init__(self) -> None:
+            super().__init__(
+                snapshots=[
+                    make_snapshot({"messages": ["hello"]}, {"configurable": {"checkpoint_id": "cp_1"}}),
+                ]
+            )
+
+        async def aget_state_history(self, config, **kwargs):
+            if not session_closed:
+                raise AssertionError("thread-lookup session still open when aget_state_history started")
+            async for s in super().aget_state_history(config, **kwargs):
+                yield s
+
+    client = make_client(app)
+    thread_id = _ensure_thread(client)
+
+    with patch_langgraph_service(agent=AssertingAgent()):
+        resp = client.post(f"/threads/{thread_id}/history", json={"limit": 10})
+
+    assert resp.status_code == 200, resp.text
+    assert session_closed, "session was never released"
+    assert len(resp.json()) == 1

--- a/libs/aegra-api/tests/integration/test_api/test_threads_history.py
+++ b/libs/aegra-api/tests/integration/test_api/test_threads_history.py
@@ -1,4 +1,6 @@
 import json
+from collections.abc import AsyncIterator, Callable
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -15,19 +17,16 @@ from tests.fixtures.langgraph import FakeAgent, make_snapshot, patch_langgraph_s
 from tests.fixtures.test_helpers import DummyThread
 
 
-def _make_session_maker(session_instance: DummySessionBase, on_exit=None) -> MagicMock:
+def _make_session_maker(session_instance: DummySessionBase, on_exit: Callable[[], None] | None = None) -> MagicMock:
     """Return a callable mimicking ``async_sessionmaker``.
 
-    Calling the returned object produces an async context manager that yields
-    *session_instance*, matching the ``async with maker() as session:`` pattern
-    ``get_thread_history_post`` uses (see ``aegra_api.api.runs`` for the same idiom).
-    ``on_exit``, if given, is invoked when the context manager exits (i.e. the
-    pooled connection would be released back to the pool).
+    Yields *session_instance* under ``async with maker() as session:``; ``on_exit``
+    fires on exit, i.e. when the pooled connection is released back to the pool.
     """
     ctx = MagicMock()
     ctx.__aenter__ = AsyncMock(return_value=session_instance)
 
-    async def _aexit(*_args):
+    async def _aexit(*_args: object) -> bool:
         if on_exit is not None:
             on_exit()
         return False
@@ -80,9 +79,8 @@ def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
     # POST /threads (used by _ensure_thread below) still uses Depends(get_session).
     app.dependency_overrides[core_get_session] = override_get_session_dep(Session)
 
-    # get_thread_history_post/get manage their own session via
-    # _get_session_maker() (not Depends), scoped to the thread lookup only —
-    # patch that instead of overriding the get_session dependency.
+    # history handlers manage their own session via _get_session_maker(), not
+    # Depends — patch that instead of overriding the get_session dependency.
     monkeypatch.setattr(
         "aegra_api.api.threads._get_session_maker",
         lambda: _make_session_maker(Session()),
@@ -322,28 +320,20 @@ class TestBeforeParameterFormats:
         assert captured[0] is None
 
 
-# ------------------------------------------------------------------
-# Regression: the thread-lookup session must be released back to the pool
-# before the (potentially long-running / abortable) aget_state_history
-# iteration starts, not held open across it. See: aegra#517.
-# ------------------------------------------------------------------
+# Regression: the thread-lookup session must be released before the
+# (potentially long-running) aget_state_history iteration. See: aegra#517.
 
 
 def test_post_history_session_released_before_state_history_iterates(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """The DB session used for the thread lookup must be closed before
-    ``aget_state_history`` is iterated, so an abort mid-iteration can't strand
-    a checked-out connection.
-
-    Fails before the fix: the session dependency stayed open for the whole
-    handler, so ``session_closed`` was still empty when the first snapshot
-    was pulled.
+    """Fails before the fix: the session stayed open for the whole handler,
+    so ``session_closed`` was still empty when the first snapshot was pulled.
     """
     app = create_test_app(include_runs=False, include_threads=True)
 
     class Session(DummySessionBase):
-        async def scalar(self, _stmt):
+        async def scalar(self, _stmt: Any) -> DummyThread:
             return _thread_row()
 
     app.dependency_overrides[core_get_session] = override_get_session_dep(Session)
@@ -364,7 +354,7 @@ def test_post_history_session_released_before_state_history_iterates(
                 ]
             )
 
-        async def aget_state_history(self, config, **kwargs):
+        async def aget_state_history(self, config: dict, **kwargs: dict) -> AsyncIterator[Any]:  # type: ignore[override]
             if not session_closed:
                 raise AssertionError("thread-lookup session still open when aget_state_history started")
             async for s in super().aget_state_history(config, **kwargs):

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.10.3"
+version = "0.10.4"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.10.3"
+version = "0.10.4"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -100,7 +100,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.10.3"
+version = "0.10.4"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
## Description
`get_thread_history_post` (and `get_thread_history_get`, which delegates to it) held
their DB session open via `Depends(get_session)` for the entire handler, including the
full `agent.aget_state_history(...)` iteration (`libs/aegra-api/src/aegra_api/api/threads.py:693-773`,
pre-fix). That session is only needed for the initial thread-ownership lookup
(`select(ThreadORM)...`); the history streaming that follows can run long. If the
client aborts the request mid-iteration, the checked-out asyncpg connection can be
left not cleanly returned to the SQLAlchemy pool.

This is the same shape of bug already fixed in #428 ("release db sessions before SSE
streaming"), which scoped `runs.py`/`stateless_runs.py` handlers to a short-lived
session via `_get_session_maker()` instead of holding the `Depends(get_session)`
session open across a long-lived async iteration. This PR applies the identical
pattern to the thread-history handlers.

## Type of Change
- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation changes
- [ ] `style`: Code style/formatting
- [ ] `refactor`: Code refactoring
- [ ] `perf`: Performance improvement
- [ ] `test`: Tests added/updated
- [ ] `chore`: Maintenance (dependencies, build, etc.)
- [ ] `ci`: CI/CD changes

## Related Issues
Fixes #517

## Changes Made
- `libs/aegra-api/src/aegra_api/api/threads.py`: removed the `Depends(get_session)`
  parameter from `get_thread_history_post`/`get_thread_history_get` and instead open a
  session from `_get_session_maker()` (already used the same way in `runs.py`) scoped
  with `async with maker() as session:` around only the thread-ownership lookup. The
  session is closed before `agent.aget_state_history(...)` starts iterating.
- `libs/aegra-api/tests/integration/test_api/test_threads_history.py`: updated the
  `client` fixture to patch `_get_session_maker` (since the handler no longer takes the
  session as a FastAPI dependency), and added a regression test,
  `test_post_history_session_released_before_state_history_iterates`, that fails before
  the fix — it asserts the session's `__aexit__` has already run before
  `aget_state_history` is first iterated.
- `libs/aegra-api/pyproject.toml`, `libs/aegra-cli/pyproject.toml`: version bump
  `0.10.3` -> `0.10.4` per this repo's release convention.

## Testing
- [x] Integration tests added/updated
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing performed

Ran the scoped unit+integration suite (`make test` / full `libs/aegra-api/tests/`
also includes `e2e/`, which needs a live Postgres + running server per the repo's own
setup docs, so it wasn't run for this local pass):

```
$ uv run --package aegra-api pytest libs/aegra-api/tests/unit libs/aegra-api/tests/integration -q
...
FAILED libs/aegra-api/tests/integration/test_assistant_large_config_db.py::test_insert_assistant_with_large_configurable_prompt_succeeds
1 failed, 1887 passed, 1 warning in 57.52s
```

The one failure is pre-existing and unrelated: it needs a live `aegra` Postgres
database (`asyncpg.exceptions.InvalidCatalogNameError: database "aegra" does not
exist`) that isn't provisioned in this environment. It fails identically on `main`
before this change, and again after the version-bump commit was added.

The new regression test,
`test_post_history_session_released_before_state_history_iterates`, fails on `main`
(the mock's exit callback never fires before the fake agent starts streaming, since
the session stays open for the whole handler) and passes with this fix.

## Checklist
- [x] Code follows project style (Ruff formatting)
- [x] All linting checks pass (`make lint`)
- [ ] Type checking passes (`make type-check`) — `uv run ty check libs/aegra-api/src/ libs/aegra-cli/src/` reports 56 diagnostics, all pre-existing (unrelated to `threads.py`, same count as on `main`); `ty` is non-blocking in `make ci-check`
- [ ] All tests pass (`make test`) — full `make test` needs a live Postgres + running server stack not available here; the scoped unit+integration command above passed with only the pre-existing DB-dependent failure noted
- [x] Documentation updated (if needed) — no user-facing behavior changed, no docs reference this internal session-scoping detail
- [x] Commit messages follow Conventional Commits
- [x] PR title follows Conventional Commits format
- [x] Version bumped per repo convention (`0.10.3` -> `0.10.4` in both `libs/aegra-api/pyproject.toml` and `libs/aegra-cli/pyproject.toml`)

## Screenshots (if applicable)
N/A — internal connection-handling fix, no UI/API surface change.

## Additional Notes
Same mechanism and fix pattern as #428, applied to the one remaining handler
(thread-history) that still held its session open across a long-lived async
generator. No public API, request/response shape, or config change — `_get_session_maker`
is already the established idiom for this in `runs.py`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread history retrieval by releasing database sessions before longer history processing begins.
  * Reduced the risk of requests unnecessarily holding database connections open, improving reliability during extended history retrieval.

* **Tests**
  * Added regression coverage to verify proper session release during thread history retrieval.

* **Chores**
  * Updated the API and CLI package versions to 0.10.4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR narrows the thread-history database session to the ownership lookup so it closes before history iteration begins.
- Replaces the request-scoped history dependency with a short-lived session maker.
- Adds regression coverage for session release ordering.
- Bumps the API and CLI package versions to 0.10.4 and updates the lockfile.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/api/threads.py | Scopes the ownership-query session to a local context that exits before state-history iteration. |
| libs/aegra-api/tests/integration/test_api/test_threads_history.py | Updates session-maker mocking and verifies that the lookup session exits before history iteration starts. |
| libs/aegra-api/pyproject.toml | Bumps the API package version to 0.10.4. |
| libs/aegra-cli/pyproject.toml | Bumps the CLI package version to 0.10.4. |
| uv.lock | Synchronizes workspace package versions with the manifest changes. |

</details>

<sub>Reviews (2): Last reviewed commit: ["style: shorten comments and annotate tes..."](https://github.com/aegra/aegra/commit/af37c892ef2f5b5279c646aa1427ff7da21c278f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55507676)</sub>

<!-- /greptile_comment -->