### PR TITLE
fix(api): separate initial-run grace from idle-run grace in v2 thread SSE

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Aegra",
     "description": "Production-ready Agent Protocol server",
-    "version": "0.10.3"
+    "version": "0.10.4"
   },
   "paths": {
     "/info": {
@@ -148,7 +148,7 @@
           "Assistants"
         ],
         "summary": "Create Assistant",
-        "description": "Create a new assistant.\n\nAn assistant is a configured instance of a graph. Provide a `graph_id`\nreferencing a graph defined in your `aegra.json`. If `assistant_id` is\nomitted, one is auto-generated. Set `if_exists` to `\"do_nothing\"` for\nidempotent creation.",
+        "description": "Create a new assistant.\n\nAn assistant is a configured instance of a graph. Provide a `graph_id`\nreferencing a graph defined in your `aegra.json`. If `assistant_id` is\nomitted, one is auto-generated. Set `if_exists` to `\"do_nothing\"` for\nidempotent creation; otherwise a taken `assistant_id` or an identical\ngraph/config pair answers 409.",
         "operationId": "create_assistant_assistants_post",
         "requestBody": {
           "content": {
@@ -167,6 +167,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Assistant"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Resource state conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentProtocolError"
                 }
               }
             }

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.10.3"
+version = "0.10.4"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-api/src/aegra_api/services/event_streaming/session.py
+++ b/libs/aegra-api/src/aegra_api/services/event_streaming/session.py
@@ -117,7 +117,7 @@ class ThreadEventSession:
                 self._drained.add(run_id)
                 if not saw_any_run:
                     saw_any_run = True
-                    idle_deadline = None
+                idle_deadline = None
 
             if progressed:
                 idle_deadline = None

--- a/libs/aegra-api/src/aegra_api/services/event_streaming/session.py
+++ b/libs/aegra-api/src/aegra_api/services/event_streaming/session.py
@@ -115,7 +115,9 @@ class ThreadEventSession:
                     progressed = True
                     yield envelope
                 self._drained.add(run_id)
-                saw_any_run = True
+                if not saw_any_run:
+                    saw_any_run = True
+                    idle_deadline = None
 
             if progressed:
                 idle_deadline = None

--- a/libs/aegra-api/src/aegra_api/services/event_streaming/session.py
+++ b/libs/aegra-api/src/aegra_api/services/event_streaming/session.py
@@ -33,8 +33,12 @@ from aegra_api.services.event_streaming.protocol import build_event
 
 __all__ = ["RunLister", "ThreadEventSession", "validate_channels"]
 
-# Grace window covering the SDK gap between stream open and run.start landing.
+# Bounds the wait for a same-thread follow-up run once one run has already
+# drained (e.g. a HITL resume). Short: the SDK is expected to respond fast.
 _IDLE_GRACE_SECONDS = 30.0
+# Bounds the wait for the thread's *first* run. Generous: covers a human
+# reading/typing before submitting, not just SDK round-trip latency.
+_INITIAL_RUN_GRACE_SECONDS = 300.0
 _POLL_INTERVAL_SECONDS = 0.25
 
 # Async callable returning the thread's (run_id, status, graph_name) rows,
@@ -61,6 +65,7 @@ class ThreadEventSession:
         namespaces: list[list[str]] | None = None,
         depth: int | None = None,
         idle_grace_seconds: float = _IDLE_GRACE_SECONDS,
+        initial_grace_seconds: float = _INITIAL_RUN_GRACE_SECONDS,
     ) -> None:
         self._thread_id = thread_id
         self._channels = channels
@@ -69,6 +74,7 @@ class ThreadEventSession:
         self._namespaces = [tuple(prefix) for prefix in namespaces] if namespaces else None
         self._depth = depth
         self._idle_grace = idle_grace_seconds
+        self._initial_grace = initial_grace_seconds
         self._seq = 0
         self._drained: set[str] = set()
         # One input.requested per interrupt per session — the same interrupt can
@@ -93,8 +99,13 @@ class ThreadEventSession:
         on the same SSE connection the SDK holds open. An interrupted run keeps
         the full grace window; a terminal run still waits one grace window so a
         same-thread follow-up run is not dropped, but never blocks forever.
+
+        Before the thread's first run, the shorter idle grace does not apply:
+        the SDK subscribes ahead of ``run.start`` and a client may take a while
+        to submit, so only the longer initial grace bounds that wait.
         """
         idle_deadline: float | None = None
+        saw_any_run = False
         loop = asyncio.get_running_loop()
 
         while True:
@@ -104,14 +115,16 @@ class ThreadEventSession:
                     progressed = True
                     yield envelope
                 self._drained.add(run_id)
+                saw_any_run = True
 
             if progressed:
                 idle_deadline = None
                 continue
 
             now = loop.time()
+            grace = self._idle_grace if saw_any_run else self._initial_grace
             if idle_deadline is None:
-                idle_deadline = now + self._idle_grace
+                idle_deadline = now + grace
             elif now >= idle_deadline:
                 return
             await asyncio.sleep(_POLL_INTERVAL_SECONDS)

--- a/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_session.py
+++ b/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_session.py
@@ -60,6 +60,7 @@ def _make_session(
     depth: int | None = None,
     statuses: dict[str, str] | None = None,
     graph: str | None = None,
+    initial_grace_seconds: float = 0.0,
 ) -> ThreadEventSession:
     return ThreadEventSession(
         thread_id,
@@ -69,6 +70,7 @@ def _make_session(
         namespaces=namespaces,
         depth=depth,
         idle_grace_seconds=0.0,
+        initial_grace_seconds=initial_grace_seconds,
     )
 
 
@@ -336,6 +338,36 @@ class TestMisc:
     async def test_empty_thread_closes_after_idle(self, manager: BrokerManager) -> None:
         events = await _collect(_make_session("t1", channels={"lifecycle"}, run_ids=()))
         assert events == []
+
+    async def test_run_starting_after_idle_grace_still_streams(
+        self, manager: BrokerManager, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A run that starts only after the (short) idle grace has elapsed must
+        still be delivered — the initial wait is bounded separately (#461)."""
+        monkeypatch.setattr(session_module, "_POLL_INTERVAL_SECONDS", 0.01)
+        run_started = False
+
+        async def lister() -> list[tuple[str, str | None, str | None]]:
+            return [("run-1", "success", None)] if run_started else []
+
+        async def start_run_late() -> None:
+            nonlocal run_started
+            await asyncio.sleep(0.05)
+            await _seed(manager, "run-1", [("end", {"status": "success"})])
+            run_started = True
+
+        session = ThreadEventSession(
+            "t1",
+            channels={"lifecycle"},
+            list_run_ids=lister,
+            idle_grace_seconds=0.02,
+            initial_grace_seconds=1.0,
+        )
+        starter = asyncio.create_task(start_run_late())
+        events = await _collect(session)
+        await asyncio.wait_for(starter, timeout=1.0)
+
+        assert [e["params"]["data"].get("event") for e in events] == ["running", "completed"]
 
 
 class TestResumeAcrossRuns:

--- a/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_session.py
+++ b/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_session.py
@@ -431,6 +431,49 @@ class TestResumeAcrossRuns:
         events = await _collect(session)
         assert [e["method"] for e in events] == ["lifecycle", "values", "lifecycle"]
 
+    async def test_stale_deadline_reset_after_run_drains_with_no_envelopes(
+        self, manager: BrokerManager, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A run that drains without yielding anything (already-terminal, no
+        surviving events) must reset idle_deadline, not just saw_any_run.
+
+        The stream first waits under the long initial grace (no run yet), which
+        stamps a deadline ~0.3s out. When run-old then appears and drains empty,
+        saw_any_run flips true; if idle_deadline is left at that stale mark
+        instead of being reset, the stream keeps waiting until the old ~0.3s
+        mark instead of closing one short idle_grace after the empty drain (#461).
+        """
+        monkeypatch.setattr(session_module, "_POLL_INTERVAL_SECONDS", 0.005)
+        run_ready = False
+
+        async def lister() -> list[tuple[str, str | None, str | None]]:
+            return [("run-old", "success", None)] if run_ready else []
+
+        async def reveal_after_delay() -> None:
+            nonlocal run_ready
+            await asyncio.sleep(0.05)
+            run_ready = True
+
+        session = ThreadEventSession(
+            "t1",
+            channels={"lifecycle"},
+            list_run_ids=lister,
+            idle_grace_seconds=0.03,
+            initial_grace_seconds=0.5,
+        )
+        revealer = asyncio.create_task(reveal_after_delay())
+        loop = asyncio.get_running_loop()
+        start = loop.time()
+        events = await _collect(session)
+        elapsed = loop.time() - start
+        await asyncio.wait_for(revealer, timeout=1.0)
+
+        assert events == []
+        # run-old is already terminal with no surviving broker events, so it
+        # drains silently: this asserts on observable timeout behavior, since
+        # nothing is ever yielded to check idle_deadline against directly.
+        assert elapsed < 0.3
+
 
 class TestNamespaceFilter:
     """namespaces (prefix include-list) and depth (nesting cap) filter subgraph events."""

--- a/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_session.py
+++ b/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_session.py
@@ -346,9 +346,13 @@ class TestMisc:
         still be delivered — the initial wait is bounded separately (#461)."""
         monkeypatch.setattr(session_module, "_POLL_INTERVAL_SECONDS", 0.01)
         run_started = False
+        run_observed = asyncio.Event()
 
         async def lister() -> list[tuple[str, str | None, str | None]]:
-            return [("run-1", "success", None)] if run_started else []
+            if run_started:
+                run_observed.set()
+                return [("run-1", "success", None)]
+            return []
 
         async def start_run_late() -> None:
             nonlocal run_started
@@ -367,6 +371,7 @@ class TestMisc:
         events = await _collect(session)
         await asyncio.wait_for(starter, timeout=1.0)
 
+        assert run_observed.is_set()
         assert [e["params"]["data"].get("event") for e in events] == ["running", "completed"]
 
 
@@ -445,9 +450,13 @@ class TestResumeAcrossRuns:
         """
         monkeypatch.setattr(session_module, "_POLL_INTERVAL_SECONDS", 0.005)
         run_ready = False
+        run_observed = asyncio.Event()
 
         async def lister() -> list[tuple[str, str | None, str | None]]:
-            return [("run-old", "success", None)] if run_ready else []
+            if run_ready:
+                run_observed.set()
+                return [("run-old", "success", None)]
+            return []
 
         async def reveal_after_delay() -> None:
             nonlocal run_ready
@@ -468,11 +477,60 @@ class TestResumeAcrossRuns:
         elapsed = loop.time() - start
         await asyncio.wait_for(revealer, timeout=1.0)
 
+        assert run_observed.is_set()
         assert events == []
         # run-old is already terminal with no surviving broker events, so it
         # drains silently: this asserts on observable timeout behavior, since
         # nothing is ever yielded to check idle_deadline against directly.
         assert elapsed < 0.3
+
+    async def test_second_drained_empty_run_also_resets_idle_deadline(
+        self, manager: BrokerManager, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A SECOND run that drains without yielding anything must reset
+        idle_deadline too, not only the first (#541).
+
+        run-old drains empty first, setting saw_any_run=True and stamping an
+        idle_deadline ~short-grace out. Before that deadline fires, run-new
+        appears and also drains empty (e.g. another already-terminal run). If
+        only the first-run transition clears idle_deadline, the second drain
+        is invisible to the timer and the stream closes on the stale mark —
+        exactly as if run-new had never appeared. Resetting on every drain
+        instead restarts the short-grace window from run-new's drain time.
+        """
+        monkeypatch.setattr(session_module, "_POLL_INTERVAL_SECONDS", 0.005)
+        run_new_ready = False
+
+        async def lister() -> list[tuple[str, str | None, str | None]]:
+            rows: list[tuple[str, str | None, str | None]] = [("run-old", "success", None)]
+            if run_new_ready:
+                rows.append(("run-new", "success", None))
+            return rows
+
+        async def reveal_run_new_late() -> None:
+            nonlocal run_new_ready
+            await asyncio.sleep(0.03)
+            run_new_ready = True
+
+        session = ThreadEventSession(
+            "t1",
+            channels={"lifecycle"},
+            list_run_ids=lister,
+            idle_grace_seconds=0.05,
+            initial_grace_seconds=1.0,
+        )
+        revealer = asyncio.create_task(reveal_run_new_late())
+        loop = asyncio.get_running_loop()
+        start = loop.time()
+        events = await _collect(session)
+        elapsed = loop.time() - start
+        await asyncio.wait_for(revealer, timeout=1.0)
+
+        assert events == []
+        # Buggy code closes ~0.05s in (run-new's drain never restarts the
+        # timer); fixed code restarts the grace at run-new's ~0.03s drain,
+        # closing at ~0.08s. The gap comfortably separates the two.
+        assert elapsed > 0.065
 
 
 class TestNamespaceFilter:

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.10.3"
+version = "0.10.4"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.10.3"
+version = "0.10.4"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -100,7 +100,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.10.3"
+version = "0.10.4"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
## Description

`ThreadEventSession.stream()` (`libs/aegra-api/src/aegra_api/services/event_streaming/session.py`) applies one idle timer from the moment the SSE connection opens, before the thread has any run at all. If a client subscribes and then takes longer than `_IDLE_GRACE_SECONDS` (30s) to submit `run.start` — normal for a human-in-the-loop client, or just network/queueing jitter — the generator's `stream()` loop hits its idle deadline and returns (`session.py:128-129`), which closes the SSE with a clean EOF before the run has even started.

That matters because the LangGraph SDK's shared-stream fanout only reconnects on a transport-level drop. In the installed `langgraph_sdk` 0.4.2 (`langgraph_sdk/stream/controller.py:257-269`), `_fanout()` awaits `shared.done`; it only invokes `_reconnect_shared_stream()` when `err is not None` (a real transport error). A stream that ends without an exception — our clean EOF — falls through to `break` and the fanout puts `None` on every subscriber queue (`controller.py:272-274`), which is treated as a normal stream end, not something to retry. So a run that starts a few seconds after the timeout still executes and completes successfully server-side, but the client never sees any of its events — no error, no retry, just silence.

## Type of Change

- [x] `fix`: Bug fix

## Related Issues

Fixes #461

## Changes Made

- Split the single `_IDLE_GRACE_SECONDS` (30s) timer in `ThreadEventSession.stream()` into two: `_IDLE_GRACE_SECONDS` now only bounds the wait for a same-thread follow-up run after at least one run has already been observed (its original intent — covering a HITL resume without blocking forever), and a new `_INITIAL_RUN_GRACE_SECONDS` (300s) bounds the wait for the thread's *first* run.
- `stream()` now tracks `saw_any_run` and picks the grace window accordingly (`session.py:107-128`); `ThreadEventSession.__init__` takes the new window as `initial_grace_seconds`, defaulting to the new constant.
- Added `test_run_starting_after_idle_grace_still_streams` (`libs/aegra-api/tests/unit/test_services/test_event_streaming/test_session.py`), which starts a run only after the short idle grace has elapsed and asserts its events are still delivered — this fails on `main` and passes with the fix.
- Bumped the patch version in `libs/aegra-api/pyproject.toml` and `libs/aegra-cli/pyproject.toml` (0.10.3 → 0.10.4) per the repo's release convention.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing performed

Scoped gate (per repo test-layout notes, `e2e/` needs a live Postgres + running server and isn't part of fast iteration):

```
uv run --package aegra-api pytest libs/aegra-api/tests/unit libs/aegra-api/tests/integration -q
```

```
1 failed, 1887 passed, 1 warning in 61.26s
FAILED libs/aegra-api/tests/integration/test_assistant_large_config_db.py::test_insert_assistant_with_large_configurable_prompt_succeeds
```

That single failure is pre-existing and unrelated — it needs a live `aegra` Postgres database that isn't provisioned in this environment (`asyncpg.exceptions.InvalidCatalogNameError: database "aegra" does not exist`); it fails identically on `main` before this change. Everything else passes, one more than the pre-fix baseline (1886), accounting for the new regression test.

`uv run ruff check .` → all checks passed.

`uv run ty check libs/aegra-api/src/ libs/aegra-cli/src/` → 56 diagnostics, same count/content as `main` (unrelated to this change — CLI option-resolver and alembic `StringIO.write` shadow-assignment issues); `ty` is non-blocking in `make ci-check`.

## Checklist

- [x] Code follows project style (Ruff formatting)
- [x] All linting checks pass (`make lint`)
- [x] Type checking passes (`make type-check`) — non-blocking check run; no new diagnostics vs. `main`
- [x] All tests pass (`make test`) — scoped unit+integration gate passes; full `make test` also runs `e2e/`, which requires a live Postgres + running server stack not available in this environment
- [ ] Documentation updated (if needed) — no user-facing config/behavior surface changed (grace windows are internal to the streaming session), so no doc update
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] PR title follows Conventional Commits format

## Additional Notes

Independently verified the reconnect-on-error-only behavior against the installed `langgraph-sdk` 0.4.2 source rather than relying on the issue's description of it — cited above at `controller.py:257-269`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved event streaming for threads before their first run, allowing additional time for the initial run to begin.
  * Streaming now uses separate waiting periods before and after a thread’s first run.

* **Bug Fixes**
  * Prevented runs from being missed when they start during the initial waiting period.
  * Improved stream closure behavior for already-completed runs without broker events.
  * Documented conflict responses when creating duplicate or conflicting assistants.

* **Chores**
  * Updated the API and CLI package versions to 0.10.4.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR separates the grace period before the first observed run from the shorter follow-up-run grace and resets stale deadlines whenever a run drains.
- Adds a 300-second initial-run grace while retaining the 30-second follow-up grace.
- Adds regression coverage for delayed starts and empty-yielding run drains.
- Bumps API and CLI package metadata to 0.10.4 and regenerates the OpenAPI specification.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because a fresh stream on a reused thread can still close before the client's first newly submitted run begins.

Historical runs are returned to every new thread session and set `saw_any_run`, causing the session to use the 30-second follow-up deadline rather than the intended 300-second initial wait; a later `run.start` can therefore execute after the SSE stream has ended.

**Files Needing Attention:** libs/aegra-api/src/aegra_api/services/event_streaming/session.py

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/services/event_streaming/session.py | Introduces separate initial and follow-up grace selection and resets the active deadline after every drained run. |
| libs/aegra-api/tests/unit/test_services/test_event_streaming/test_session.py | Adds focused timing regressions for delayed initial runs and first or subsequent empty-yielding drains. |
| docs/openapi.json | Regenerates API metadata for version 0.10.4 and documents assistant-creation conflict responses. |
| libs/aegra-api/pyproject.toml | Bumps the API package patch version to 0.10.4. |
| libs/aegra-cli/pyproject.toml | Keeps the CLI package version aligned at 0.10.4. |
| uv.lock | Synchronizes the workspace lockfile with the package version bumps. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant C as Client
  participant S as Thread SSE session
  participant L as Run lister
  participant B as Event broker
  C->>S: Open thread stream
  loop Until a run is observed
    S->>L: Poll runs
    L-->>S: Current thread runs
    S->>S: Apply initial-run grace
  end
  C->>S: Submit run.start
  S->>L: Poll runs
  L-->>S: New run
  S->>B: Drain run events
  B-->>S: Protocol events
  S-->>C: SSE envelopes
  S->>S: Apply follow-up idle grace
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: reset idle\_deadline on every draine..."](https://github.com/aegra/aegra/commit/7ab5d49b93008ed14ecd9d198d1d834f0399193f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55507704)</sub>

**Context used:**

- Knowledge Base — [Event streaming](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/event-streaming.md)
- Knowledge Base — [Streaming protocol and sessions](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/streaming-protocol-and-sessions.md)

<!-- /greptile_comment -->