### PR TITLE
chore(release): v0.10.4

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Aegra",
     "description": "Production-ready Agent Protocol server",
-    "version": "0.10.3"
+    "version": "0.10.4"
   },
   "paths": {
     "/info": {
@@ -148,7 +148,7 @@
           "Assistants"
         ],
         "summary": "Create Assistant",
-        "description": "Create a new assistant.\n\nAn assistant is a configured instance of a graph. Provide a `graph_id`\nreferencing a graph defined in your `aegra.json`. If `assistant_id` is\nomitted, one is auto-generated. Set `if_exists` to `\"do_nothing\"` for\nidempotent creation.",
+        "description": "Create a new assistant.\n\nAn assistant is a configured instance of a graph. Provide a `graph_id`\nreferencing a graph defined in your `aegra.json`. If `assistant_id` is\nomitted, one is auto-generated. Set `if_exists` to `\"do_nothing\"` for\nidempotent creation; otherwise a taken `assistant_id` or an identical\ngraph/config pair answers 409.",
         "operationId": "create_assistant_assistants_post",
         "requestBody": {
           "content": {
@@ -167,6 +167,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Assistant"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Resource state conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentProtocolError"
                 }
               }
             }

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.10.3"
+version = "0.10.4"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.10.3"
+version = "0.10.4"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.10.3"
+version = "0.10.4"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -100,7 +100,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.10.3"
+version = "0.10.4"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
## Description
Batched patch release. Bumps both packages to 0.10.4, regenerates the lockfile and the OpenAPI spec version.

## Changes in this release
- #486 — thread creation atomic: concurrent creates no longer 500 (fixes #487)
- #499 — checkpoint data deleted when a thread is deleted
- #510 — serializer handles Path, UUID, Decimal, datetime, bytes, sets and mapping keys (fixes #480 and a reported production crash on Path-carrying state)
- #519 — graceful shutdown requeues in-flight runs instead of destroying them (fixes #474)
- #520 — assistant creation atomic, and the assistant commits with its version row
- #527 — docs: fixed star history chart

## Type of Change
- [x] `chore`: Release

## Testing
All six changes were verified individually before merge: unit and integration suites, live-server e2e in both executor modes where applicable, auth-mode e2e for the assistant collision path, and a live SIGTERM drain test for #519.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API documentation to version 0.10.4.
  * Documented conflict responses when creating assistants with duplicate IDs or identical configurations.

* **Release**
  * Updated the API and CLI packages to version 0.10.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prepares the 0.10.4 patch release and keeps package and generated contract metadata synchronized.
- Bumps both Python packages from 0.10.3 to 0.10.4.
- Updates matching workspace versions in `uv.lock` without changing resolved third-party dependencies.
- Updates the exported OpenAPI version and documents the assistant-creation conflict response.

<h3>Confidence Score: 5/5</h3>

The release metadata and generated API contract appear safe to merge, with no actionable changed-code defects identified.

Package versions, lockfile workspace metadata, and the OpenAPI version are aligned, and the newly documented conflict response introduces no runtime or dependency-resolution change.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/openapi.json | Updates the public API version and documents the 409 response for assistant creation. |
| libs/aegra-api/pyproject.toml | Bumps the API package version to 0.10.4 without changing dependencies or build metadata. |
| libs/aegra-cli/pyproject.toml | Bumps the CLI package version to 0.10.4 while retaining a compatible API dependency range. |
| uv.lock | Synchronizes the two workspace package versions; resolved third-party package versions remain unchanged. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(release): 0.10.4"](https://github.com/aegra/aegra/commit/42f15fe588fb4227a9fb5fe75121c78c15c866c0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55830197)</sub>

**Context used:**

- Knowledge Base — [Build, test, and release automation](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/build-test-and-release-automation.md)

<!-- /greptile_comment -->