### PR TITLE
feat(api): thread TTL with background sweep

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -100,6 +100,14 @@ CRON_ENABLED=true
 # Soft cap on the JSONB payload size (bytes) accepted on create/update.
 # CRON_MAX_PAYLOAD_BYTES=65536
 
+# --- Thread TTL ---
+# Automatic thread retention. Either a bare number (default TTL in minutes)
+# or a JSON object with any of: strategy ("delete" | "keep_latest"),
+# default_ttl, sweep_interval_minutes, sweep_limit. When set, this replaces
+# the checkpointer.ttl block in aegra.json entirely. Unset = threads never expire.
+# AEGRA_THREAD_TTL=43200
+# AEGRA_THREAD_TTL={"strategy": "keep_latest", "default_ttl": 1440, "sweep_interval_minutes": 5, "sweep_limit": 1000}
+
 # --- Event Streaming (Agent Protocol v2) ---
 # The v2 thread streaming endpoints (/threads/{id}/stream/events and
 # /threads/{id}/commands) used by the latest LangGraph JS/Python SDKs.

--- a/.env.example
+++ b/.env.example
@@ -105,8 +105,9 @@ CRON_ENABLED=true
 # or a JSON object with any of: strategy ("delete" | "keep_latest"),
 # default_ttl, sweep_interval_minutes, sweep_limit. When set, this replaces
 # the checkpointer.ttl block in aegra.json entirely. Unset = threads never expire.
+# LANGGRAPH_THREAD_TTL is accepted as a fallback alias (AEGRA_THREAD_TTL wins).
 # AEGRA_THREAD_TTL=43200
-# AEGRA_THREAD_TTL={"strategy": "keep_latest", "default_ttl": 1440, "sweep_interval_minutes": 5, "sweep_limit": 1000}
+# AEGRA_THREAD_TTL={"strategy": "keep_latest", "default_ttl": 1440, "sweep_interval_minutes": 5, "sweep_limit": 10000}
 
 # --- Event Streaming (Agent Protocol v2) ---
 # The v2 thread streaming endpoints (/threads/{id}/stream/events and

--- a/docs/guides/cron.mdx
+++ b/docs/guides/cron.mdx
@@ -80,7 +80,7 @@ run = await client.crons.create(
 print(run["cron_id"])
 ```
 
-When you keep stateless cron threads, you are responsible for cleaning them up. For long-lived deployments, use thread TTL policies or a separate cleanup job if you do not want preserved threads to accumulate.
+When you keep stateless cron threads, you are responsible for cleaning them up. For long-lived deployments, use [thread TTL policies](/guides/threads-and-state#thread-ttl) or a separate cleanup job if you do not want preserved threads to accumulate.
 
 ## Creating a thread-bound cron
 

--- a/docs/guides/threads-and-state.mdx
+++ b/docs/guides/threads-and-state.mdx
@@ -177,8 +177,10 @@ thread = await client.threads.create(ttl={"ttl": 10080, "strategy": "keep_latest
 Expired threads can also be cleaned up immediately for the calling user:
 
 ```python
-resp = httpx.post(f"{BASE_URL}/threads/prune")
-# {"deleted": 3, "pruned": 1}
+import httpx
+
+resp = httpx.post("http://localhost:2026/threads/prune")
+print(resp.json())  # {"deleted": 3, "pruned": 1}
 ```
 
 Threads with pending or running runs are never expired mid-run — they are

--- a/docs/guides/threads-and-state.mdx
+++ b/docs/guides/threads-and-state.mdx
@@ -153,6 +153,38 @@ the checkpoint history stored in the graph backend:
 await client.threads.delete(thread_id)
 ```
 
+## Thread TTL
+
+Threads can expire automatically. Configure a server-wide default under
+`checkpointer.ttl` in `aegra.json` (or the `AEGRA_THREAD_TTL` environment
+variable) — see the [configuration reference](/reference/configuration#checkpointer).
+A background sweep then applies each thread's policy:
+
+- `delete` — the thread, its runs and crons, and all checkpoint data are removed.
+- `keep_latest` — checkpoint history is compacted down to the latest state; the
+  thread stays usable and the TTL re-arms, so history is pruned periodically.
+
+Individual threads can override the default at creation:
+
+```python
+# Delete after 24 hours (minutes; the SDK sends strategy "delete")
+thread = await client.threads.create(ttl=1440)
+
+# Keep the thread, prune its history every 7 days
+thread = await client.threads.create(ttl={"ttl": 10080, "strategy": "keep_latest"})
+```
+
+Expired threads can also be cleaned up immediately for the calling user:
+
+```python
+resp = httpx.post(f"{BASE_URL}/threads/prune")
+# {"deleted": 3, "pruned": 1}
+```
+
+Threads with pending or running runs are never expired mid-run — they are
+picked up on a later sweep once their runs settle. TTL applies to threads
+created after it is enabled; pre-existing threads are not backfilled.
+
 ## Thread metadata
 
 Threads automatically track metadata about their usage:

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -5862,6 +5862,7 @@
             "anyOf": [
               {
                 "type": "number",
+                "maximum": 1000000000.0,
                 "exclusiveMinimum": 0.0
               },
               {
@@ -5869,7 +5870,7 @@
               }
             ],
             "title": "Default Ttl",
-            "description": "Thread TTL in minutes; falls back to the server default when omitted"
+            "description": "Thread TTL in minutes; also accepted under the key \"ttl\" (LangGraph SDK compatibility). Falls back to the server default when omitted"
           },
           "strategy": {
             "anyOf": [

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -148,7 +148,7 @@
           "Assistants"
         ],
         "summary": "Create Assistant",
-        "description": "Create a new assistant.\n\nAn assistant is a configured instance of a graph. Provide a `graph_id`\nreferencing a graph defined in your `aegra.json`. If `assistant_id` is\nomitted, one is auto-generated. Set `if_exists` to `\"do_nothing\"` for\nidempotent creation.",
+        "description": "Create a new assistant.\n\nAn assistant is a configured instance of a graph. Provide a `graph_id`\nreferencing a graph defined in your `aegra.json`. If `assistant_id` is\nomitted, one is auto-generated. Set `if_exists` to `\"do_nothing\"` for\nidempotent creation; otherwise a taken `assistant_id` or an identical\ngraph/config pair answers 409.",
         "operationId": "create_assistant_assistants_post",
         "requestBody": {
           "content": {
@@ -167,6 +167,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Assistant"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Resource state conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentProtocolError"
                 }
               }
             }
@@ -1529,6 +1539,28 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/threads/prune": {
+      "post": {
+        "tags": [
+          "Threads"
+        ],
+        "summary": "Prune Threads",
+        "description": "Immediately apply TTL policies to the caller's expired threads.\n\nThreads whose TTL has expired are deleted (strategy `delete`) or have\ntheir checkpoint history compacted (strategy `keep_latest`). Threads with\nactive runs are skipped and handled once their runs settle.",
+        "operationId": "prune_threads_threads_prune_post",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ThreadPruneResponse"
                 }
               }
             }
@@ -5362,6 +5394,17 @@
             "title": "Ifexists",
             "description": "Behavior when thread exists: 'raise' (default) or 'do_nothing'",
             "default": "raise"
+          },
+          "ttl": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ThreadTTLSpec"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Per-thread TTL override; requires TTL to be configured server-side or default_ttl set"
           }
         },
         "type": "object",
@@ -5478,6 +5521,25 @@
         ],
         "title": "ThreadList",
         "description": "Response model for listing threads"
+      },
+      "ThreadPruneResponse": {
+        "properties": {
+          "deleted": {
+            "type": "integer",
+            "title": "Deleted",
+            "description": "Expired threads fully deleted (strategy 'delete')",
+            "default": 0
+          },
+          "pruned": {
+            "type": "integer",
+            "title": "Pruned",
+            "description": "Expired threads whose history was pruned (strategy 'keep_latest')",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "title": "ThreadPruneResponse",
+        "description": "Response model for POST /threads/prune"
       },
       "ThreadSearchRequest": {
         "properties": {
@@ -5793,6 +5855,42 @@
         ],
         "title": "ThreadStateUpdateResponse",
         "description": "Response model for thread state update"
+      },
+      "ThreadTTLSpec": {
+        "properties": {
+          "default_ttl": {
+            "anyOf": [
+              {
+                "type": "number",
+                "exclusiveMinimum": 0.0
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Default Ttl",
+            "description": "Thread TTL in minutes; falls back to the server default when omitted"
+          },
+          "strategy": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "delete",
+                  "keep_latest"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Strategy",
+            "description": "Expiry strategy: 'delete' removes the thread, 'keep_latest' prunes history"
+          }
+        },
+        "type": "object",
+        "title": "ThreadTTLSpec",
+        "description": "Per-thread TTL override supplied on thread creation.\n\nThe langgraph SDK sends the minutes value as \"ttl\" while issue #288 names\nit \"default_ttl\" \u2014 AliasChoices accepts both spellings."
       },
       "ThreadUpdate": {
         "properties": {

--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -311,7 +311,7 @@ Notes:
 - Individual threads can override the default via the `ttl` field on `POST /threads`; expired threads can be cleaned immediately with `POST /threads/prune`. See the [threads guide](/guides/threads-and-state#thread-ttl).
 - The `AEGRA_THREAD_TTL` environment variable replaces this block entirely when set — see [environment variables](/reference/environment-variables#thread-ttl).
 
-If `checkpointer` is not configured, threads never expire.
+If neither `checkpointer.ttl` nor `AEGRA_THREAD_TTL` is configured, threads never expire.
 
 ## Common configurations
 

--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -3,7 +3,7 @@ title: "Configuration"
 description: "Complete reference for the aegra.json configuration file."
 ---
 
-Aegra uses a JSON configuration file (`aegra.json`) to define graphs, authentication, HTTP settings, and the semantic store.
+Aegra uses a JSON configuration file (`aegra.json`) to define graphs, authentication, HTTP settings, the semantic store, and checkpointer retention (thread TTL).
 
 ## Config file resolution
 
@@ -47,6 +47,14 @@ aegra dev
       "dims": 1536,
       "embed": "openai:text-embedding-3-small",
       "fields": ["$"]
+    }
+  },
+  "checkpointer": {
+    "ttl": {
+      "strategy": "delete",
+      "default_ttl": 43200,
+      "sweep_interval_minutes": 5,
+      "sweep_limit": 1000
     }
   }
 }
@@ -269,6 +277,41 @@ Configure semantic store with vector embeddings.
 If `store` is not configured, Aegra operates in basic key-value mode.
 
 See [semantic store guide](/guides/semantic-store) for details.
+
+## `checkpointer`
+
+Configure thread retention (TTL). When a `ttl` block is present, every newly
+created thread gets an expiry, and a background sweep deletes or compacts
+expired threads.
+
+```json
+{
+  "checkpointer": {
+    "ttl": {
+      "strategy": "delete",
+      "default_ttl": 43200,
+      "sweep_interval_minutes": 5,
+      "sweep_limit": 1000
+    }
+  }
+}
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `ttl.strategy` | `string` | `delete` | `delete` removes the thread, its runs/crons, and all checkpoint data. `keep_latest` prunes checkpoint history but keeps the thread and its latest state, then re-arms the TTL (periodic compaction). |
+| `ttl.default_ttl` | `number` | `43200` | Default thread TTL in minutes (43200 = 30 days), applied to threads created after TTL is enabled. |
+| `ttl.sweep_interval_minutes` | `number` | `5` | How often the background sweep runs. |
+| `ttl.sweep_limit` | `integer` | `1000` | Max threads processed per sweep iteration. |
+
+Notes:
+
+- Threads with pending or running runs are skipped and swept once their runs settle.
+- Deleting an expired thread cascades to its runs and thread-bound crons.
+- Individual threads can override the default via the `ttl` field on `POST /threads`; expired threads can be cleaned immediately with `POST /threads/prune`. See the [threads guide](/guides/threads-and-state#thread-ttl).
+- The `AEGRA_THREAD_TTL` environment variable replaces this block entirely when set — see [environment variables](/reference/environment-variables#thread-ttl).
+
+If `checkpointer` is not configured, threads never expire.
 
 ## Common configurations
 

--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -54,7 +54,7 @@ aegra dev
       "strategy": "delete",
       "default_ttl": 43200,
       "sweep_interval_minutes": 5,
-      "sweep_limit": 1000
+      "sweep_limit": 10000
     }
   }
 }
@@ -291,7 +291,7 @@ expired threads.
       "strategy": "delete",
       "default_ttl": 43200,
       "sweep_interval_minutes": 5,
-      "sweep_limit": 1000
+      "sweep_limit": 10000
     }
   }
 }
@@ -302,7 +302,7 @@ expired threads.
 | `ttl.strategy` | `string` | `delete` | `delete` removes the thread, its runs/crons, and all checkpoint data. `keep_latest` prunes checkpoint history but keeps the thread and its latest state, then re-arms the TTL (periodic compaction). |
 | `ttl.default_ttl` | `number` | `43200` | Default thread TTL in minutes (43200 = 30 days), applied to threads created after TTL is enabled. |
 | `ttl.sweep_interval_minutes` | `number` | `5` | How often the background sweep runs. |
-| `ttl.sweep_limit` | `integer` | `1000` | Max threads processed per sweep iteration. |
+| `ttl.sweep_limit` | `integer` | `10000` | Max threads processed per sweep iteration. |
 
 Notes:
 

--- a/docs/reference/environment-variables.mdx
+++ b/docs/reference/environment-variables.mdx
@@ -174,13 +174,14 @@ Cron firing is **at-least-once**: if a worker crashes after claiming a cron but 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `AEGRA_THREAD_TTL` | — | Thread retention policy. Either a bare number (`default_ttl` in minutes) or a JSON object with any of `strategy`, `default_ttl`, `sweep_interval_minutes`, `sweep_limit` |
+| `LANGGRAPH_THREAD_TTL` | — | Fallback alias for `AEGRA_THREAD_TTL` (same format), so env files migrated from LangGraph Platform work unchanged. `AEGRA_THREAD_TTL` wins when both are set |
 
 ```bash
 # 30-day TTL, delete strategy, other fields at defaults
 AEGRA_THREAD_TTL=43200
 
 # Full policy as JSON
-AEGRA_THREAD_TTL='{"strategy": "keep_latest", "default_ttl": 1440, "sweep_interval_minutes": 5, "sweep_limit": 1000}'
+AEGRA_THREAD_TTL='{"strategy": "keep_latest", "default_ttl": 1440, "sweep_interval_minutes": 5, "sweep_limit": 10000}'
 ```
 
 <Note>

--- a/docs/reference/environment-variables.mdx
+++ b/docs/reference/environment-variables.mdx
@@ -169,6 +169,24 @@ Set `CRON_ENABLED=false` to disable scheduling without removing cron records. Jo
 Cron firing is **at-least-once**: if a worker crashes after claiming a cron but before the run setup commits, the claim eventually expires (after `CRON_CLAIM_DURATION_SECONDS`) and another tick re-fires the cron. Make agent runs idempotent if duplicate firings are unacceptable.
 </Note>
 
+## Thread TTL
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `AEGRA_THREAD_TTL` | — | Thread retention policy. Either a bare number (`default_ttl` in minutes) or a JSON object with any of `strategy`, `default_ttl`, `sweep_interval_minutes`, `sweep_limit` |
+
+```bash
+# 30-day TTL, delete strategy, other fields at defaults
+AEGRA_THREAD_TTL=43200
+
+# Full policy as JSON
+AEGRA_THREAD_TTL='{"strategy": "keep_latest", "default_ttl": 1440, "sweep_interval_minutes": 5, "sweep_limit": 1000}'
+```
+
+<Note>
+`AEGRA_THREAD_TTL` takes precedence. When set, the `checkpointer.ttl` block in `aegra.json` is ignored entirely and unset fields fall back to their defaults. See the [configuration reference](/reference/configuration#checkpointer) for field semantics.
+</Note>
+
 ## Prometheus metrics
 
 | Variable | Default | Description |

--- a/libs/aegra-api/alembic/versions/20260822000000_add_thread_ttl_table.py
+++ b/libs/aegra-api/alembic/versions/20260822000000_add_thread_ttl_table.py
@@ -1,0 +1,36 @@
+"""add_thread_ttl_table
+
+Revision ID: a3f7c1d9e2b4
+Revises: b88bb61be638
+Create Date: 2026-08-22 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a3f7c1d9e2b4"
+down_revision = "b88bb61be638"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "thread_ttl",
+        sa.Column("thread_id", sa.Text(), nullable=False),
+        sa.Column("strategy", sa.Text(), server_default=sa.text("'delete'"), nullable=False),
+        sa.Column("ttl_minutes", sa.Float(), nullable=False),
+        sa.Column("created_at", sa.TIMESTAMP(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("expires_at", sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(["thread_id"], ["thread.thread_id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("thread_id"),
+    )
+    op.create_index("idx_thread_ttl_expires_at", "thread_ttl", ["expires_at"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("idx_thread_ttl_expires_at", table_name="thread_ttl")
+    op.drop_table("thread_ttl")

--- a/libs/aegra-api/src/aegra_api/api/threads.py
+++ b/libs/aegra-api/src/aegra_api/api/threads.py
@@ -30,6 +30,7 @@ from aegra_api.models import (
     ThreadCreate,
     ThreadHistoryRequest,
     ThreadList,
+    ThreadPruneResponse,
     ThreadSearchRequest,
     ThreadState,
     ThreadStateUpdate,
@@ -41,7 +42,7 @@ from aegra_api.models import (
 from aegra_api.models.errors import CONFLICT, NOT_FOUND, AgentProtocolError
 from aegra_api.services.streaming_service import streaming_service
 from aegra_api.services.thread_state_service import ThreadStateService
-from aegra_api.services.thread_ttl import get_thread_ttl_config
+from aegra_api.services.thread_ttl import get_thread_ttl_config, prune_expired_threads_for_user
 from aegra_api.utils.run_utils import strip_pinned_config_keys
 
 router = APIRouter(tags=["Threads"], dependencies=auth_dependency)
@@ -925,6 +926,28 @@ async def delete_thread(
     await session.commit()
 
     return {"status": "deleted"}
+
+
+@router.post("/threads/prune", response_model=ThreadPruneResponse)
+async def prune_threads(
+    user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+) -> ThreadPruneResponse:
+    """Immediately apply TTL policies to the caller's expired threads.
+
+    Threads whose TTL has expired are deleted (strategy `delete`) or have
+    their checkpoint history compacted (strategy `keep_latest`). Threads with
+    active runs are skipped and handled once their runs settle.
+    """
+    # Authorization check — pruning is a bulk threads.delete
+    ctx = build_auth_context(user, "threads", "delete")
+    filters = await handle_event(ctx, {})
+    auth_filter = build_metadata_filter(ThreadORM.metadata_json, filters)
+
+    deleted, pruned = await prune_expired_threads_for_user(
+        session, user_id=user.identity, auth_filter=auth_filter
+    )
+    return ThreadPruneResponse(deleted=deleted, pruned=pruned)
 
 
 @router.post("/threads/search", response_model=list[Thread])

--- a/libs/aegra-api/src/aegra_api/api/threads.py
+++ b/libs/aegra-api/src/aegra_api/api/threads.py
@@ -944,9 +944,7 @@ async def prune_threads(
     filters = await handle_event(ctx, {})
     auth_filter = build_metadata_filter(ThreadORM.metadata_json, filters)
 
-    deleted, pruned = await prune_expired_threads_for_user(
-        session, user_id=user.identity, auth_filter=auth_filter
-    )
+    deleted, pruned = await prune_expired_threads_for_user(session, user_id=user.identity, auth_filter=auth_filter)
     return ThreadPruneResponse(deleted=deleted, pruned=pruned)
 
 

--- a/libs/aegra-api/src/aegra_api/api/threads.py
+++ b/libs/aegra-api/src/aegra_api/api/threads.py
@@ -4,7 +4,7 @@ import asyncio
 import contextlib
 import json
 import warnings
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from uuid import uuid4
 
@@ -21,6 +21,7 @@ from aegra_api.core.auth_handlers import build_auth_context, handle_event
 from aegra_api.core.database import db_manager
 from aegra_api.core.orm import Run as RunORM
 from aegra_api.core.orm import Thread as ThreadORM
+from aegra_api.core.orm import ThreadTTL as ThreadTTLORM
 from aegra_api.core.orm import get_session
 from aegra_api.models import (
     Thread,
@@ -33,12 +34,14 @@ from aegra_api.models import (
     ThreadState,
     ThreadStateUpdate,
     ThreadStateUpdateResponse,
+    ThreadTTLSpec,
     ThreadUpdate,
     User,
 )
 from aegra_api.models.errors import CONFLICT, NOT_FOUND, AgentProtocolError
 from aegra_api.services.streaming_service import streaming_service
 from aegra_api.services.thread_state_service import ThreadStateService
+from aegra_api.services.thread_ttl import get_thread_ttl_config
 from aegra_api.utils.run_utils import strip_pinned_config_keys
 
 router = APIRouter(tags=["Threads"], dependencies=auth_dependency)
@@ -153,6 +156,38 @@ def _serialize_thread(thread_orm: ThreadORM, default_metadata: dict[str, Any] | 
 # --- Endpoints ---
 
 
+def _resolve_ttl_row(thread_id: str, requested: ThreadTTLSpec | None) -> ThreadTTLORM | None:
+    """Build the thread_ttl row for a new thread, or None when TTL doesn't apply.
+
+    Server config supplies defaults; a request-level ttl overrides per field.
+    Without server config, an explicit request must carry default_ttl.
+    """
+    config = get_thread_ttl_config()
+    if config is None and requested is None:
+        return None
+
+    requested_ttl = requested.default_ttl if requested else None
+    requested_strategy = requested.strategy if requested else None
+
+    if config is not None:
+        ttl_minutes = requested_ttl if requested_ttl is not None else config.default_ttl
+        strategy = requested_strategy or config.strategy
+    else:
+        if requested_ttl is None:
+            raise HTTPException(422, "ttl.default_ttl is required when no server-side TTL default is configured")
+        ttl_minutes = requested_ttl
+        strategy = requested_strategy or "delete"
+
+    now = datetime.now(UTC)
+    return ThreadTTLORM(
+        thread_id=thread_id,
+        strategy=strategy,
+        ttl_minutes=ttl_minutes,
+        created_at=now,
+        expires_at=now + timedelta(minutes=ttl_minutes),
+    )
+
+
 @router.post("/threads", response_model=Thread, responses={**CONFLICT})
 async def create_thread(
     request: ThreadCreate,
@@ -183,6 +218,8 @@ async def create_thread(
             request.metadata = {**(request.metadata or {}), **handler_meta}
 
     thread_id = request.thread_id or str(uuid4())
+    # Resolve before the insert so an invalid ttl request 422s without DB work.
+    ttl_row = _resolve_ttl_row(thread_id, request.ttl)
 
     metadata = request.metadata or {}
     # Always enforce owner from authenticated user
@@ -208,6 +245,10 @@ async def create_thread(
         .returning(ThreadORM)
     )
     created = (await session.scalars(insert_stmt)).first()
+    # Same transaction as the thread insert: thread + ttl commit atomically.
+    # Conflict path skips — an idempotent re-create must not touch the incumbent's TTL.
+    if created is not None and ttl_row is not None:
+        session.add(ttl_row)
     await session.commit()
 
     if created is not None:

--- a/libs/aegra-api/src/aegra_api/config.py
+++ b/libs/aegra-api/src/aegra_api/config.py
@@ -68,6 +68,26 @@ class StoreConfig(TypedDict, total=False):
     """Map of namespace prefix -> list of User attributes used for configurable store scoping."""
 
 
+class CheckpointerTTLConfig(TypedDict, total=False):
+    """Thread TTL configuration nested under the checkpointer section."""
+
+    strategy: str
+    """Expiry strategy: 'delete' (thread + checkpoints) or 'keep_latest' (prune history)."""
+    default_ttl: float
+    """Default thread TTL in minutes applied to newly created threads."""
+    sweep_interval_minutes: float
+    """How often the background sweep runs."""
+    sweep_limit: int
+    """Max threads processed per sweep iteration."""
+
+
+class CheckpointerConfig(TypedDict, total=False):
+    """Checkpointer configuration options."""
+
+    ttl: CheckpointerTTLConfig | None
+    """Thread TTL / retention policy."""
+
+
 class AuthConfig(TypedDict, total=False):
     """Auth configuration options."""
 
@@ -173,6 +193,27 @@ def load_store_config() -> StoreConfig | None:
         config_path = _resolve_config_path()
         logger.info(f"Loaded store config from {config_path}")
         return store_config
+
+    return None
+
+
+def load_checkpointer_config() -> CheckpointerConfig | None:
+    """Load checkpointer config from aegra.json or langgraph.json.
+
+    Uses standard config resolution order.
+
+    Returns:
+        Checkpointer configuration dict or None if not found
+    """
+    config = load_config()
+    if config is None:
+        return None
+
+    checkpointer_config = config.get("checkpointer")
+    if checkpointer_config:
+        config_path = _resolve_config_path()
+        logger.info(f"Loaded checkpointer config from {config_path}")
+        return checkpointer_config
 
     return None
 

--- a/libs/aegra-api/src/aegra_api/core/auth_registry.py
+++ b/libs/aegra-api/src/aegra_api/core/auth_registry.py
@@ -39,6 +39,7 @@ ROUTE_AUTH_MAP: Final[dict[tuple[str, str], tuple[str, str]]] = {
     ("GET", "/threads/{thread_id}"): ("threads", "read"),
     ("PATCH", "/threads/{thread_id}"): ("threads", "update"),
     ("DELETE", "/threads/{thread_id}"): ("threads", "delete"),
+    ("POST", "/threads/prune"): ("threads", "delete"),
     # Reading or writing checkpointed state is a thread read/update, not a
     # separate resource: handlers scoping "threads" must cover it.
     ("GET", "/threads/{thread_id}/state"): ("threads", "read"),
@@ -116,6 +117,7 @@ SELF_DISPATCHING: Final[frozenset[tuple[str, str]]] = frozenset(
         ("POST", "/threads"),
         ("GET", "/threads"),
         ("POST", "/threads/search"),
+        ("POST", "/threads/prune"),
         ("GET", "/threads/{thread_id}"),
         ("PATCH", "/threads/{thread_id}"),
         ("DELETE", "/threads/{thread_id}"),

--- a/libs/aegra-api/src/aegra_api/core/orm.py
+++ b/libs/aegra-api/src/aegra_api/core/orm.py
@@ -227,9 +227,7 @@ class Cron(Base):
 class ThreadTTL(Base):
     __tablename__ = "thread_ttl"
 
-    thread_id: Mapped[str] = mapped_column(
-        Text, ForeignKey("thread.thread_id", ondelete="CASCADE"), primary_key=True
-    )
+    thread_id: Mapped[str] = mapped_column(Text, ForeignKey("thread.thread_id", ondelete="CASCADE"), primary_key=True)
     strategy: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("'delete'"))
     ttl_minutes: Mapped[float] = mapped_column(Float, nullable=False)
     created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), server_default=text("now()"))

--- a/libs/aegra-api/src/aegra_api/core/orm.py
+++ b/libs/aegra-api/src/aegra_api/core/orm.py
@@ -21,6 +21,7 @@ import structlog
 from sqlalchemy import (
     TIMESTAMP,
     Boolean,
+    Float,
     ForeignKey,
     Index,
     Integer,
@@ -221,6 +222,20 @@ class Cron(Base):
         Index("idx_cron_thread_id", "thread_id"),
         Index("idx_cron_next_run", "enabled", "next_run_date"),
     )
+
+
+class ThreadTTL(Base):
+    __tablename__ = "thread_ttl"
+
+    thread_id: Mapped[str] = mapped_column(
+        Text, ForeignKey("thread.thread_id", ondelete="CASCADE"), primary_key=True
+    )
+    strategy: Mapped[str] = mapped_column(Text, nullable=False, server_default=text("'delete'"))
+    ttl_minutes: Mapped[float] = mapped_column(Float, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), server_default=text("now()"))
+    expires_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), nullable=False)
+
+    __table_args__ = (Index("idx_thread_ttl_expires_at", "expires_at"),)
 
 
 # ---------------------------------------------------------------------------

--- a/libs/aegra-api/src/aegra_api/main.py
+++ b/libs/aegra-api/src/aegra_api/main.py
@@ -40,6 +40,7 @@ from aegra_api.services.cron_scheduler import cron_scheduler
 from aegra_api.services.executor import executor
 from aegra_api.services.langgraph_service import get_langgraph_service
 from aegra_api.services.lease_reaper import lease_reaper
+from aegra_api.services.thread_ttl import get_thread_ttl_config, thread_ttl_sweeper
 from aegra_api.settings import settings
 from aegra_api.utils.setup_logging import setup_logging
 
@@ -139,9 +140,16 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     if settings.cron.CRON_ENABLED:
         await cron_scheduler.start()
 
+    # Start thread TTL sweeper (deletes/compacts expired threads); resolving
+    # the config here also fails fast on an invalid retention policy.
+    if get_thread_ttl_config() is not None:
+        await thread_ttl_sweeper.start()
+
     yield
 
-    # Shutdown order: cron → reaper → executor (drains jobs) → broker → Redis → DB
+    # Shutdown order: ttl sweeper → cron → reaper → executor (drains jobs) → broker → Redis → DB
+    if get_thread_ttl_config() is not None:
+        await thread_ttl_sweeper.stop()
     if settings.cron.CRON_ENABLED:
         await cron_scheduler.stop()
     if settings.redis.REDIS_BROKER_ENABLED:

--- a/libs/aegra-api/src/aegra_api/models/__init__.py
+++ b/libs/aegra-api/src/aegra_api/models/__init__.py
@@ -35,11 +35,13 @@ from aegra_api.models.threads import (
     ThreadCreate,
     ThreadHistoryRequest,
     ThreadList,
+    ThreadPruneResponse,
     ThreadSearchRequest,
     ThreadSearchResponse,
     ThreadState,
     ThreadStateUpdate,
     ThreadStateUpdateResponse,
+    ThreadTTLSpec,
     ThreadUpdate,
 )
 
@@ -63,6 +65,8 @@ __all__ = [
     "ThreadCheckpoint",
     "ThreadCheckpointPostRequest",
     "ThreadHistoryRequest",
+    "ThreadPruneResponse",
+    "ThreadTTLSpec",
     # Runs
     "Run",
     "RunCreate",

--- a/libs/aegra-api/src/aegra_api/models/threads.py
+++ b/libs/aegra-api/src/aegra_api/models/threads.py
@@ -3,9 +3,30 @@
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator
 
 from aegra_api.utils.status_compat import validate_thread_status
+
+
+class ThreadTTLSpec(BaseModel):
+    """Per-thread TTL override supplied on thread creation.
+
+    The langgraph SDK sends the minutes value as "ttl" while issue #288 names
+    it "default_ttl" — AliasChoices accepts both spellings.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    default_ttl: float | None = Field(
+        None,
+        gt=0,
+        validation_alias=AliasChoices("default_ttl", "ttl"),
+        description="Thread TTL in minutes; falls back to the server default when omitted",
+    )
+    strategy: Literal["delete", "keep_latest"] | None = Field(
+        None,
+        description="Expiry strategy: 'delete' removes the thread, 'keep_latest' prunes history",
+    )
 
 
 class ThreadCreate(BaseModel):
@@ -25,12 +46,23 @@ class ThreadCreate(BaseModel):
         alias="ifExists",
         description="Behavior when thread exists: 'raise' (default) or 'do_nothing'",
     )
+    ttl: ThreadTTLSpec | None = Field(
+        None,
+        description="Per-thread TTL override; requires TTL to be configured server-side or default_ttl set",
+    )
 
 
 class ThreadUpdate(BaseModel):
     """Request model for updating threads"""
 
     metadata: dict[str, Any] | None = Field(None, description="Thread metadata to update")
+
+
+class ThreadPruneResponse(BaseModel):
+    """Response model for POST /threads/prune"""
+
+    deleted: int = Field(0, description="Expired threads fully deleted (strategy 'delete')")
+    pruned: int = Field(0, description="Expired threads whose history was pruned (strategy 'keep_latest')")
 
 
 class Thread(BaseModel):

--- a/libs/aegra-api/src/aegra_api/models/threads.py
+++ b/libs/aegra-api/src/aegra_api/models/threads.py
@@ -7,6 +7,10 @@ from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator
 
 from aegra_api.utils.status_compat import validate_thread_status
 
+# Upper bound keeping now + timedelta(minutes=ttl) finite and timedelta-safe
+# (timedelta.max is ~1.44e9 minutes); rejects inf/1e308 at validation time.
+MAX_TTL_MINUTES = 1_000_000_000
+
 
 class ThreadTTLSpec(BaseModel):
     """Per-thread TTL override supplied on thread creation.
@@ -20,8 +24,10 @@ class ThreadTTLSpec(BaseModel):
     default_ttl: float | None = Field(
         None,
         gt=0,
+        le=MAX_TTL_MINUTES,
         validation_alias=AliasChoices("default_ttl", "ttl"),
-        description="Thread TTL in minutes; falls back to the server default when omitted",
+        description='Thread TTL in minutes; also accepted under the key "ttl" (LangGraph SDK '
+        "compatibility). Falls back to the server default when omitted",
     )
     strategy: Literal["delete", "keep_latest"] | None = Field(
         None,

--- a/libs/aegra-api/src/aegra_api/observability/metrics.py
+++ b/libs/aegra-api/src/aegra_api/observability/metrics.py
@@ -29,6 +29,17 @@ REAPER_RECOVERED_RUNS = prometheus_client.Counter(
 for _outcome in ("crashed_retried", "crashed_exhausted", "stuck_pending"):
     REAPER_RECOVERED_RUNS.labels(outcome=_outcome)
 
+THREAD_TTL_SWEPT = prometheus_client.Counter(
+    "aegra_thread_ttl_swept_threads_total",
+    "Threads processed by the TTL sweep or POST /threads/prune, by outcome: "
+    "deleted (strategy=delete, thread removed), pruned (strategy=keep_latest, "
+    "history compacted), error (item failed and will be retried next tick).",
+    labelnames=["outcome"],
+)
+
+for _outcome in ("deleted", "pruned", "error"):
+    THREAD_TTL_SWEPT.labels(outcome=_outcome)
+
 
 def setup_prometheus_metrics(
     app: FastAPI,

--- a/libs/aegra-api/src/aegra_api/services/thread_ttl.py
+++ b/libs/aegra-api/src/aegra_api/services/thread_ttl.py
@@ -46,6 +46,17 @@ _CLAIM_BATCH = 100
 # schema-drift canary in tests/unit/test_services/test_thread_ttl.py fails
 # loudly if a package bump changes the assumptions below.
 
+# Cheap probe so idle keep_latest cycles skip the three DELETEs: history is
+# prunable only when some namespace holds more than one checkpoint (PK-indexed).
+_HAS_PRUNABLE_HISTORY_SQL = """
+SELECT EXISTS (
+    SELECT 1 FROM checkpoints
+    WHERE thread_id = %(tid)s
+    GROUP BY checkpoint_ns
+    HAVING count(*) > 1
+)
+"""
+
 # Latest checkpoint per (thread_id, checkpoint_ns) = max(checkpoint_id):
 # checkpoint_ids are monotonic and langgraph's own "latest" is
 # ORDER BY checkpoint_id DESC.
@@ -140,10 +151,15 @@ async def _prune_checkpoint_history(thread_id: str) -> None:
     pool = db_manager.lg_pool
     if pool is None:
         raise RuntimeError("Database not initialized")
-    async with pool.connection() as conn, conn.transaction():
-        await conn.execute(_PRUNE_CHECKPOINTS_SQL, {"tid": thread_id})
-        await conn.execute(_PRUNE_WRITES_SQL, {"tid": thread_id})
-        await conn.execute(_PRUNE_BLOBS_SQL, {"tid": thread_id})
+    async with pool.connection() as conn:
+        cursor = await conn.execute(_HAS_PRUNABLE_HISTORY_SQL, {"tid": thread_id})
+        row = await cursor.fetchone()
+        if row is None or not row[0]:
+            return
+        async with conn.transaction():
+            await conn.execute(_PRUNE_CHECKPOINTS_SQL, {"tid": thread_id})
+            await conn.execute(_PRUNE_WRITES_SQL, {"tid": thread_id})
+            await conn.execute(_PRUNE_BLOBS_SQL, {"tid": thread_id})
 
 
 async def _apply_strategy(

--- a/libs/aegra-api/src/aegra_api/services/thread_ttl.py
+++ b/libs/aegra-api/src/aegra_api/services/thread_ttl.py
@@ -14,6 +14,7 @@ and picked up on a later tick once their runs settle.
 import asyncio
 import contextlib
 import json
+from collections.abc import Collection
 from datetime import UTC, datetime, timedelta
 from functools import cache
 from typing import Literal
@@ -189,6 +190,7 @@ def _expired_claim_stmt(
     *,
     user_id: str | None = None,
     auth_filter: ColumnElement[bool] | None = None,
+    exclude_ids: Collection[str] = (),
 ) -> Select[tuple[str, str, float]]:
     """Claim query for expired thread_ttl rows, locking thread_ttl AND thread.
 
@@ -219,6 +221,10 @@ def _expired_claim_stmt(
         stmt = stmt.where(ThreadORM.user_id == user_id)
         if auth_filter is not None:
             stmt = stmt.where(auth_filter)
+    if exclude_ids:
+        # Rows that already failed this pass sit first in expiry order; without
+        # the exclusion they'd be re-claimed every batch and starve later rows.
+        stmt = stmt.where(ThreadTTLORM.thread_id.not_in(exclude_ids))
     return (
         stmt.order_by(ThreadTTLORM.expires_at.asc())
         .limit(limit)
@@ -228,19 +234,20 @@ def _expired_claim_stmt(
 
 async def _process_expired_batch(
     session: AsyncSession, stmt: Select[tuple[str, str, float]], now: datetime
-) -> tuple[int, int, int]:
+) -> tuple[int, int, int, list[str]]:
     """Claim and process one batch in a single transaction.
 
-    Returns (claimed, deleted, pruned). The thread-row DELETE must run in the
-    claim transaction: it cascades into the locked thread_ttl row, and a
-    separate session would wait forever on a lock this transaction holds.
+    Returns (claimed, deleted, pruned, failed_ids). The thread-row DELETE must
+    run in the claim transaction: it cascades into the locked thread_ttl row,
+    and a separate session would wait forever on a lock this transaction holds.
     """
     rows = (await session.execute(stmt)).all()
     if not rows:
-        return 0, 0, 0
+        return 0, 0, 0, []
 
     deleted = 0
     pruned = 0
+    failed_ids: list[str] = []
     for thread_id, strategy, ttl_minutes in rows:
         try:
             outcome = await _apply_strategy(session, thread_id, strategy, ttl_minutes, now)
@@ -249,6 +256,7 @@ async def _process_expired_batch(
             # untouched — skip the item, retry it on a later claim.
             THREAD_TTL_SWEPT.labels(outcome="error").inc()
             logger.exception("Thread TTL item failed", thread_id=thread_id, strategy=strategy)
+            failed_ids.append(thread_id)
             continue
         if outcome == "deleted":
             deleted += 1
@@ -257,7 +265,7 @@ async def _process_expired_batch(
         THREAD_TTL_SWEPT.labels(outcome=outcome).inc()
 
     await session.commit()
-    return len(rows), deleted, pruned
+    return len(rows), deleted, pruned, failed_ids
 
 
 async def prune_expired_threads_for_user(
@@ -275,21 +283,18 @@ async def prune_expired_threads_for_user(
     total_deleted = 0
     total_pruned = 0
     claimed_total = 0
+    failed: set[str] = set()
     while claimed_total < config.sweep_limit:
         now = datetime.now(UTC)
         limit = min(_CLAIM_BATCH, config.sweep_limit - claimed_total)
-        stmt = _expired_claim_stmt(now, limit, user_id=user_id, auth_filter=auth_filter)
-        claimed, deleted, pruned = await _process_expired_batch(session, stmt, now)
+        stmt = _expired_claim_stmt(now, limit, user_id=user_id, auth_filter=auth_filter, exclude_ids=failed)
+        claimed, deleted, pruned, failed_ids = await _process_expired_batch(session, stmt, now)
         if claimed == 0:
             break
         claimed_total += claimed
         total_deleted += deleted
         total_pruned += pruned
-        # A batch where every item failed would be re-claimed verbatim (its
-        # rows stay first in expiry order) and starve everything behind it —
-        # stop and let the next call retry.
-        if deleted + pruned == 0:
-            break
+        failed.update(failed_ids)
     return total_deleted, total_pruned
 
 
@@ -352,22 +357,19 @@ class ThreadTTLSweeper:
         claimed_total = 0
         deleted_total = 0
         pruned_total = 0
+        failed: set[str] = set()
         while claimed_total < config.sweep_limit:
             now = datetime.now(UTC)
             limit = min(_CLAIM_BATCH, config.sweep_limit - claimed_total)
-            stmt = _expired_claim_stmt(now, limit)
+            stmt = _expired_claim_stmt(now, limit, exclude_ids=failed)
             async with maker() as session:
-                claimed, deleted, pruned = await _process_expired_batch(session, stmt, now)
+                claimed, deleted, pruned, failed_ids = await _process_expired_batch(session, stmt, now)
             if claimed == 0:
                 break
             claimed_total += claimed
             deleted_total += deleted
             pruned_total += pruned
-            # A batch where every item failed would be re-claimed verbatim (its
-            # rows stay first in expiry order) and starve everything behind it
-            # for the rest of the tick — stop and retry next tick.
-            if deleted + pruned == 0:
-                break
+            failed.update(failed_ids)
 
         if claimed_total:
             logger.info(

--- a/libs/aegra-api/src/aegra_api/services/thread_ttl.py
+++ b/libs/aegra-api/src/aegra_api/services/thread_ttl.py
@@ -112,7 +112,8 @@ class ThreadTTLConfig(BaseModel):
     strategy: Literal["delete", "keep_latest"] = "delete"
     default_ttl: float = Field(43200, gt=0, le=MAX_TTL_MINUTES)  # minutes; 30 days
     sweep_interval_minutes: float = Field(5, gt=0, le=MAX_TTL_MINUTES)
-    sweep_limit: int = Field(1000, gt=0)
+    # 10000 matches the documented LangGraph Platform default for this block.
+    sweep_limit: int = Field(10000, gt=0)
 
 
 @cache
@@ -126,7 +127,10 @@ def get_thread_ttl_config() -> ThreadTTLConfig | None:
     raises so a misconfigured retention policy fails at startup instead of
     silently deleting (or retaining) the wrong data.
     """
+    # LANGGRAPH_THREAD_TTL is a migration alias; the AEGRA_ var wins when both set.
     raw = settings.thread_ttl.AEGRA_THREAD_TTL
+    if raw is None or not raw.strip():
+        raw = settings.thread_ttl.LANGGRAPH_THREAD_TTL
     if raw is not None and raw.strip():
         try:
             data: dict[str, object] = {"default_ttl": float(raw)}

--- a/libs/aegra-api/src/aegra_api/services/thread_ttl.py
+++ b/libs/aegra-api/src/aegra_api/services/thread_ttl.py
@@ -1,0 +1,57 @@
+"""Thread TTL: config resolution and expiry sweep (issue #288 phase 2).
+
+Threads opt into a TTL via a ``thread_ttl`` row (server default on creation or
+per-thread override). A background sweep claims expired rows with
+``FOR UPDATE SKIP LOCKED`` and applies the row's strategy:
+
+- ``delete``  — remove checkpoints then the thread row (cascades runs/crons).
+- ``keep_latest`` — prune checkpoint history, keep the latest state, re-arm.
+"""
+
+import json
+from functools import cache
+from typing import Literal
+
+import structlog
+from pydantic import BaseModel, Field
+
+from aegra_api.config import load_checkpointer_config
+from aegra_api.settings import settings
+
+logger = structlog.getLogger(__name__)
+
+
+class ThreadTTLConfig(BaseModel):
+    """Validated TTL configuration merged from env and aegra.json."""
+
+    strategy: Literal["delete", "keep_latest"] = "delete"
+    default_ttl: float = Field(43200, gt=0)  # minutes; 30 days
+    sweep_interval_minutes: float = Field(5, gt=0)
+    sweep_limit: int = Field(1000, gt=0)
+
+
+@cache
+def get_thread_ttl_config() -> ThreadTTLConfig | None:
+    """Resolve TTL config: AEGRA_THREAD_TTL env var wins over aegra.json.
+
+    The env var is either a bare number (default_ttl in minutes) or a JSON
+    object; when set it replaces the checkpointer.ttl block entirely (same
+    whole-source precedence as DATABASE_URL over POSTGRES_*). Returns None
+    when neither source is configured — the feature is off. Invalid config
+    raises so a misconfigured retention policy fails at startup instead of
+    silently deleting (or retaining) the wrong data.
+    """
+    raw = settings.thread_ttl.AEGRA_THREAD_TTL
+    if raw is not None and raw.strip():
+        try:
+            data: dict[str, object] = {"default_ttl": float(raw)}
+        except ValueError:
+            data = json.loads(raw)
+        return ThreadTTLConfig.model_validate(data)
+
+    checkpointer_config = load_checkpointer_config()
+    ttl_config = checkpointer_config.get("ttl") if checkpointer_config else None
+    if ttl_config is not None:
+        return ThreadTTLConfig.model_validate(ttl_config)
+
+    return None

--- a/libs/aegra-api/src/aegra_api/services/thread_ttl.py
+++ b/libs/aegra-api/src/aegra_api/services/thread_ttl.py
@@ -165,7 +165,7 @@ async def _prune_checkpoint_history(thread_id: str) -> None:
 
 
 async def _apply_strategy(
-    session: AsyncSession, thread_id: str, strategy: str, ttl_minutes: float, now: datetime
+    session: AsyncSession, *, thread_id: str, strategy: str, ttl_minutes: float, now: datetime
 ) -> str:
     """Apply one expired row's strategy inside the claim transaction; return the outcome label."""
     if strategy == "keep_latest":
@@ -251,7 +251,9 @@ async def _process_expired_batch(
     failed_ids: list[str] = []
     for thread_id, strategy, ttl_minutes in rows:
         try:
-            outcome = await _apply_strategy(session, thread_id, strategy, ttl_minutes, now)
+            outcome = await _apply_strategy(
+                session, thread_id=thread_id, strategy=strategy, ttl_minutes=ttl_minutes, now=now
+            )
         except (PsycopgError, OSError):
             # Checkpointer-side failure on the other pool: this transaction is
             # untouched — skip the item, retry it on a later claim.

--- a/libs/aegra-api/src/aegra_api/services/thread_ttl.py
+++ b/libs/aegra-api/src/aegra_api/services/thread_ttl.py
@@ -186,9 +186,9 @@ async def _apply_strategy(
 
 
 def _expired_claim_stmt(
+    *,
     now: datetime,
     limit: int,
-    *,
     user_id: str | None = None,
     auth_filter: ColumnElement[bool] | None = None,
     exclude_ids: Collection[str] = (),
@@ -290,7 +290,7 @@ async def prune_expired_threads_for_user(
     while claimed_total < config.sweep_limit:
         now = datetime.now(UTC)
         limit = min(_CLAIM_BATCH, config.sweep_limit - claimed_total)
-        stmt = _expired_claim_stmt(now, limit, user_id=user_id, auth_filter=auth_filter, exclude_ids=failed)
+        stmt = _expired_claim_stmt(now=now, limit=limit, user_id=user_id, auth_filter=auth_filter, exclude_ids=failed)
         claimed, deleted, pruned, failed_ids = await _process_expired_batch(session, stmt, now)
         if claimed == 0:
             break
@@ -364,7 +364,7 @@ class ThreadTTLSweeper:
         while claimed_total < config.sweep_limit:
             now = datetime.now(UTC)
             limit = min(_CLAIM_BATCH, config.sweep_limit - claimed_total)
-            stmt = _expired_claim_stmt(now, limit, exclude_ids=failed)
+            stmt = _expired_claim_stmt(now=now, limit=limit, exclude_ids=failed)
             async with maker() as session:
                 claimed, deleted, pruned, failed_ids = await _process_expired_batch(session, stmt, now)
             if claimed == 0:

--- a/libs/aegra-api/src/aegra_api/services/thread_ttl.py
+++ b/libs/aegra-api/src/aegra_api/services/thread_ttl.py
@@ -191,16 +191,10 @@ def _expired_claim_stmt(
         ~active_runs_exist,
     )
     if user_id is not None:
-        stmt = stmt.join(ThreadORM, ThreadORM.thread_id == ThreadTTLORM.thread_id).where(
-            ThreadORM.user_id == user_id
-        )
+        stmt = stmt.join(ThreadORM, ThreadORM.thread_id == ThreadTTLORM.thread_id).where(ThreadORM.user_id == user_id)
         if auth_filter is not None:
             stmt = stmt.where(auth_filter)
-    return (
-        stmt.order_by(ThreadTTLORM.expires_at.asc())
-        .limit(limit)
-        .with_for_update(skip_locked=True, of=ThreadTTLORM)
-    )
+    return stmt.order_by(ThreadTTLORM.expires_at.asc()).limit(limit).with_for_update(skip_locked=True, of=ThreadTTLORM)
 
 
 async def _process_expired_batch(

--- a/libs/aegra-api/src/aegra_api/services/thread_ttl.py
+++ b/libs/aegra-api/src/aegra_api/services/thread_ttl.py
@@ -55,7 +55,7 @@ SELECT EXISTS (
     WHERE thread_id = %(tid)s
     GROUP BY checkpoint_ns
     HAVING count(*) > 1
-)
+) AS has_prunable_history
 """
 
 # Latest checkpoint per (thread_id, checkpoint_ns) = max(checkpoint_id):
@@ -155,7 +155,8 @@ async def _prune_checkpoint_history(thread_id: str) -> None:
     async with pool.connection() as conn:
         cursor = await conn.execute(_HAS_PRUNABLE_HISTORY_SQL, {"tid": thread_id})
         row = await cursor.fetchone()
-        if row is None or not row[0]:
+        # The lg_pool is configured with row_factory=dict_row — access by name.
+        if row is None or not row["has_prunable_history"]:
             return
         async with conn.transaction():
             await conn.execute(_PRUNE_CHECKPOINTS_SQL, {"tid": thread_id})

--- a/libs/aegra-api/src/aegra_api/services/thread_ttl.py
+++ b/libs/aegra-api/src/aegra_api/services/thread_ttl.py
@@ -6,19 +6,91 @@ per-thread override). A background sweep claims expired rows with
 
 - ``delete``  — remove checkpoints then the thread row (cascades runs/crons).
 - ``keep_latest`` — prune checkpoint history, keep the latest state, re-arm.
+
+The sweep never cancels runs: threads with pending/running runs are skipped
+and picked up on a later tick once their runs settle.
 """
 
+import asyncio
+import contextlib
 import json
+from datetime import UTC, datetime, timedelta
 from functools import cache
 from typing import Literal
 
 import structlog
+from psycopg import Error as PsycopgError
 from pydantic import BaseModel, Field
+from sqlalchemy import ColumnElement, Select, delete, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from aegra_api.config import load_checkpointer_config
+from aegra_api.core.database import db_manager
+from aegra_api.core.orm import Run as RunORM
+from aegra_api.core.orm import Thread as ThreadORM
+from aegra_api.core.orm import ThreadTTL as ThreadTTLORM
+from aegra_api.core.orm import _get_session_maker
+from aegra_api.observability.metrics import THREAD_TTL_SWEPT
 from aegra_api.settings import settings
 
 logger = structlog.getLogger(__name__)
+
+# Rows claimed per transaction. Bounds lock-hold time and the window a user
+# DELETE on a claimed thread blocks on the thread_ttl cascade.
+_CLAIM_BATCH = 100
+
+# --- keep_latest pruning SQL -------------------------------------------------
+# Raw SQL over the psycopg lg_pool against checkpointer-owned tables. Pinned to
+# the schema of langgraph-checkpoint-postgres 3.x (base.py MIGRATIONS); the
+# schema-drift canary in tests/unit/test_services/test_thread_ttl.py fails
+# loudly if a package bump changes the assumptions below.
+
+# Latest checkpoint per (thread_id, checkpoint_ns) = max(checkpoint_id):
+# checkpoint_ids are monotonic and langgraph's own "latest" is
+# ORDER BY checkpoint_id DESC.
+_PRUNE_CHECKPOINTS_SQL = """
+DELETE FROM checkpoints c
+USING (
+    SELECT checkpoint_ns, max(checkpoint_id) AS latest_id
+    FROM checkpoints
+    WHERE thread_id = %(tid)s
+    GROUP BY checkpoint_ns
+) keep
+WHERE c.thread_id = %(tid)s
+  AND c.checkpoint_ns = keep.checkpoint_ns
+  AND c.checkpoint_id <> keep.latest_id
+"""
+
+# Writes of surviving checkpoints are pending writes needed on resume — keep
+# them; drop writes whose checkpoint is gone.
+_PRUNE_WRITES_SQL = """
+DELETE FROM checkpoint_writes w
+WHERE w.thread_id = %(tid)s
+  AND NOT EXISTS (
+      SELECT 1 FROM checkpoints c
+      WHERE c.thread_id = w.thread_id
+        AND c.checkpoint_ns = w.checkpoint_ns
+        AND c.checkpoint_id = w.checkpoint_id
+  )
+"""
+
+# A kept checkpoint may reference OLD blob versions for unchanged channels, so
+# keeping max(version) would corrupt state. Keep exactly the (channel, version)
+# pairs the surviving checkpoints reference — the same join langgraph's own
+# SELECT_SQL performs to load channel_values.
+_PRUNE_BLOBS_SQL = """
+DELETE FROM checkpoint_blobs b
+WHERE b.thread_id = %(tid)s
+  AND NOT EXISTS (
+      SELECT 1
+      FROM checkpoints c,
+           jsonb_each_text(c.checkpoint -> 'channel_versions') AS cv(channel, version)
+      WHERE c.thread_id = b.thread_id
+        AND c.checkpoint_ns = b.checkpoint_ns
+        AND cv.channel = b.channel
+        AND cv.version = b.version
+  )
+"""
 
 
 class ThreadTTLConfig(BaseModel):
@@ -55,3 +127,222 @@ def get_thread_ttl_config() -> ThreadTTLConfig | None:
         return ThreadTTLConfig.model_validate(ttl_config)
 
     return None
+
+
+async def _prune_checkpoint_history(thread_id: str) -> None:
+    """Delete all checkpoint history for a thread except the latest state.
+
+    One explicit transaction (the lg_pool is autocommit): a concurrent reader
+    sees pre- or post-prune state, never a torn middle. Idempotent — a re-run
+    deletes nothing further.
+    """
+    pool = db_manager.lg_pool
+    if pool is None:
+        raise RuntimeError("Database not initialized")
+    async with pool.connection() as conn, conn.transaction():
+        await conn.execute(_PRUNE_CHECKPOINTS_SQL, {"tid": thread_id})
+        await conn.execute(_PRUNE_WRITES_SQL, {"tid": thread_id})
+        await conn.execute(_PRUNE_BLOBS_SQL, {"tid": thread_id})
+
+
+async def _apply_strategy(
+    session: AsyncSession, thread_id: str, strategy: str, ttl_minutes: float, now: datetime
+) -> str:
+    """Apply one expired row's strategy inside the claim transaction; return the outcome label."""
+    if strategy == "keep_latest":
+        await _prune_checkpoint_history(thread_id)
+        # Re-arm: keep_latest is periodic compaction, not a one-shot.
+        await session.execute(
+            update(ThreadTTLORM)
+            .where(ThreadTTLORM.thread_id == thread_id)
+            .values(expires_at=now + timedelta(minutes=ttl_minutes))
+        )
+        return "pruned"
+
+    # Checkpoints first — ordering rationale from the delete_thread route: a
+    # failure here leaves the thread row intact and retryable, never orphans.
+    await db_manager.get_checkpointer().adelete_thread(thread_id)
+    await session.execute(delete(ThreadORM).where(ThreadORM.thread_id == thread_id))
+    return "deleted"
+
+
+def _expired_claim_stmt(
+    now: datetime,
+    limit: int,
+    *,
+    user_id: str | None = None,
+    auth_filter: ColumnElement[bool] | None = None,
+) -> Select[tuple[str, str, float]]:
+    """Claim query for expired thread_ttl rows, locking only thread_ttl.
+
+    ``skip_locked`` partitions work across instances (and between the sweeper
+    and /threads/prune). Threads with active runs are skipped, not cancelled.
+    """
+    active_runs_exist = (
+        select(RunORM.run_id)
+        .where(
+            RunORM.thread_id == ThreadTTLORM.thread_id,
+            RunORM.status.in_(("pending", "running")),
+        )
+        .exists()
+    )
+    stmt = select(ThreadTTLORM.thread_id, ThreadTTLORM.strategy, ThreadTTLORM.ttl_minutes).where(
+        ThreadTTLORM.expires_at <= now,
+        ~active_runs_exist,
+    )
+    if user_id is not None:
+        stmt = stmt.join(ThreadORM, ThreadORM.thread_id == ThreadTTLORM.thread_id).where(
+            ThreadORM.user_id == user_id
+        )
+        if auth_filter is not None:
+            stmt = stmt.where(auth_filter)
+    return (
+        stmt.order_by(ThreadTTLORM.expires_at.asc())
+        .limit(limit)
+        .with_for_update(skip_locked=True, of=ThreadTTLORM)
+    )
+
+
+async def _process_expired_batch(
+    session: AsyncSession, stmt: Select[tuple[str, str, float]], now: datetime
+) -> tuple[int, int, int]:
+    """Claim and process one batch in a single transaction.
+
+    Returns (claimed, deleted, pruned). The thread-row DELETE must run in the
+    claim transaction: it cascades into the locked thread_ttl row, and a
+    separate session would wait forever on a lock this transaction holds.
+    """
+    rows = (await session.execute(stmt)).all()
+    if not rows:
+        return 0, 0, 0
+
+    deleted = 0
+    pruned = 0
+    for thread_id, strategy, ttl_minutes in rows:
+        try:
+            outcome = await _apply_strategy(session, thread_id, strategy, ttl_minutes, now)
+        except (PsycopgError, OSError):
+            # Checkpointer-side failure on the other pool: this transaction is
+            # untouched — skip the item, retry it on a later claim.
+            THREAD_TTL_SWEPT.labels(outcome="error").inc()
+            logger.exception("Thread TTL item failed", thread_id=thread_id, strategy=strategy)
+            continue
+        if outcome == "deleted":
+            deleted += 1
+        else:
+            pruned += 1
+        THREAD_TTL_SWEPT.labels(outcome=outcome).inc()
+
+    await session.commit()
+    return len(rows), deleted, pruned
+
+
+async def prune_expired_threads_for_user(
+    session: AsyncSession,
+    *,
+    user_id: str,
+    auth_filter: ColumnElement[bool] | None = None,
+) -> tuple[int, int]:
+    """Immediately apply TTL strategies to the caller's expired threads.
+
+    Backs POST /threads/prune; works without server-side TTL config (rows may
+    exist from per-thread opt-ins). Returns (deleted, pruned).
+    """
+    config = get_thread_ttl_config() or ThreadTTLConfig()
+    total_deleted = 0
+    total_pruned = 0
+    claimed_total = 0
+    while claimed_total < config.sweep_limit:
+        now = datetime.now(UTC)
+        limit = min(_CLAIM_BATCH, config.sweep_limit - claimed_total)
+        stmt = _expired_claim_stmt(now, limit, user_id=user_id, auth_filter=auth_filter)
+        claimed, deleted, pruned = await _process_expired_batch(session, stmt, now)
+        if claimed == 0:
+            break
+        claimed_total += claimed
+        total_deleted += deleted
+        total_pruned += pruned
+    return total_deleted, total_pruned
+
+
+class ThreadTTLSweeper:
+    """Periodically deletes or compacts expired threads."""
+
+    def __init__(self) -> None:
+        """Initialize the sweeper state for the background polling loop."""
+        self._task: asyncio.Task[None] | None = None
+        self._running = False
+
+    async def start(self) -> None:
+        """Start the background sweep task."""
+        self._running = True
+        self._task = asyncio.create_task(self._loop())
+        config = get_thread_ttl_config()
+        logger.info(
+            "Thread TTL sweeper started",
+            interval_minutes=config.sweep_interval_minutes if config else None,
+            sweep_limit=config.sweep_limit if config else None,
+        )
+
+    async def stop(self) -> None:
+        """Stop the background sweep task and wait for cancellation to finish."""
+        self._running = False
+        if self._task is not None:
+            self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._task
+            self._task = None
+        logger.info("Thread TTL sweeper stopped")
+
+    async def _loop(self) -> None:
+        """Tick then sleep so overdue threads are swept right after startup.
+
+        The sleep sits in its own try so a persistent _tick failure (DB down)
+        cannot spin the loop at CPU speed.
+        """
+        config = get_thread_ttl_config()
+        interval_seconds = (config.sweep_interval_minutes if config else 5.0) * 60
+        while self._running:
+            try:
+                await self._tick()
+            except asyncio.CancelledError:
+                break
+            except Exception:
+                logger.exception("Error in thread TTL sweep tick")
+            try:
+                await asyncio.sleep(interval_seconds)
+            except asyncio.CancelledError:
+                break
+
+    async def _tick(self) -> None:
+        """Sweep up to sweep_limit expired threads in sub-batched transactions."""
+        config = get_thread_ttl_config()
+        if config is None:
+            return
+
+        maker = _get_session_maker()
+        claimed_total = 0
+        deleted_total = 0
+        pruned_total = 0
+        while claimed_total < config.sweep_limit:
+            now = datetime.now(UTC)
+            limit = min(_CLAIM_BATCH, config.sweep_limit - claimed_total)
+            stmt = _expired_claim_stmt(now, limit)
+            async with maker() as session:
+                claimed, deleted, pruned = await _process_expired_batch(session, stmt, now)
+            if claimed == 0:
+                break
+            claimed_total += claimed
+            deleted_total += deleted
+            pruned_total += pruned
+
+        if claimed_total:
+            logger.info(
+                "Thread TTL sweep completed",
+                claimed=claimed_total,
+                deleted=deleted_total,
+                pruned=pruned_total,
+            )
+
+
+thread_ttl_sweeper = ThreadTTLSweeper()

--- a/libs/aegra-api/src/aegra_api/services/thread_ttl.py
+++ b/libs/aegra-api/src/aegra_api/services/thread_ttl.py
@@ -30,6 +30,7 @@ from aegra_api.core.orm import Run as RunORM
 from aegra_api.core.orm import Thread as ThreadORM
 from aegra_api.core.orm import ThreadTTL as ThreadTTLORM
 from aegra_api.core.orm import _get_session_maker
+from aegra_api.models.threads import MAX_TTL_MINUTES
 from aegra_api.observability.metrics import THREAD_TTL_SWEPT
 from aegra_api.settings import settings
 
@@ -97,8 +98,8 @@ class ThreadTTLConfig(BaseModel):
     """Validated TTL configuration merged from env and aegra.json."""
 
     strategy: Literal["delete", "keep_latest"] = "delete"
-    default_ttl: float = Field(43200, gt=0)  # minutes; 30 days
-    sweep_interval_minutes: float = Field(5, gt=0)
+    default_ttl: float = Field(43200, gt=0, le=MAX_TTL_MINUTES)  # minutes; 30 days
+    sweep_interval_minutes: float = Field(5, gt=0, le=MAX_TTL_MINUTES)
     sweep_limit: int = Field(1000, gt=0)
 
 
@@ -173,10 +174,14 @@ def _expired_claim_stmt(
     user_id: str | None = None,
     auth_filter: ColumnElement[bool] | None = None,
 ) -> Select[tuple[str, str, float]]:
-    """Claim query for expired thread_ttl rows, locking only thread_ttl.
+    """Claim query for expired thread_ttl rows, locking thread_ttl AND thread.
 
     ``skip_locked`` partitions work across instances (and between the sweeper
     and /threads/prune). Threads with active runs are skipped, not cancelled.
+    Locking the thread row too closes the check-then-act race with run
+    creation: a run INSERT takes FOR KEY SHARE on the thread (FK), so it waits
+    for the claim transaction instead of slipping in after the active-run
+    check and being cascade-deleted mid-flight.
     """
     active_runs_exist = (
         select(RunORM.run_id)
@@ -186,15 +191,23 @@ def _expired_claim_stmt(
         )
         .exists()
     )
-    stmt = select(ThreadTTLORM.thread_id, ThreadTTLORM.strategy, ThreadTTLORM.ttl_minutes).where(
-        ThreadTTLORM.expires_at <= now,
-        ~active_runs_exist,
+    stmt = (
+        select(ThreadTTLORM.thread_id, ThreadTTLORM.strategy, ThreadTTLORM.ttl_minutes)
+        .join(ThreadORM, ThreadORM.thread_id == ThreadTTLORM.thread_id)
+        .where(
+            ThreadTTLORM.expires_at <= now,
+            ~active_runs_exist,
+        )
     )
     if user_id is not None:
-        stmt = stmt.join(ThreadORM, ThreadORM.thread_id == ThreadTTLORM.thread_id).where(ThreadORM.user_id == user_id)
+        stmt = stmt.where(ThreadORM.user_id == user_id)
         if auth_filter is not None:
             stmt = stmt.where(auth_filter)
-    return stmt.order_by(ThreadTTLORM.expires_at.asc()).limit(limit).with_for_update(skip_locked=True, of=ThreadTTLORM)
+    return (
+        stmt.order_by(ThreadTTLORM.expires_at.asc())
+        .limit(limit)
+        .with_for_update(skip_locked=True, of=(ThreadTTLORM, ThreadORM))
+    )
 
 
 async def _process_expired_batch(
@@ -256,6 +269,11 @@ async def prune_expired_threads_for_user(
         claimed_total += claimed
         total_deleted += deleted
         total_pruned += pruned
+        # A batch where every item failed would be re-claimed verbatim (its
+        # rows stay first in expiry order) and starve everything behind it —
+        # stop and let the next call retry.
+        if deleted + pruned == 0:
+            break
     return total_deleted, total_pruned
 
 
@@ -329,6 +347,11 @@ class ThreadTTLSweeper:
             claimed_total += claimed
             deleted_total += deleted
             pruned_total += pruned
+            # A batch where every item failed would be re-claimed verbatim (its
+            # rows stay first in expiry order) and starve everything behind it
+            # for the rest of the tick — stop and retry next tick.
+            if deleted + pruned == 0:
+                break
 
         if claimed_total:
             logger.info(

--- a/libs/aegra-api/src/aegra_api/settings.py
+++ b/libs/aegra-api/src/aegra_api/settings.py
@@ -440,10 +440,13 @@ class ThreadTTLSettings(EnvBase):
     AEGRA_THREAD_TTL is either a bare number (default_ttl in minutes) or a
     JSON object with any of: strategy, default_ttl, sweep_interval_minutes,
     sweep_limit. When set it replaces the aegra.json checkpointer.ttl block
-    entirely. Parsed and validated in services.thread_ttl.
+    entirely. LANGGRAPH_THREAD_TTL is accepted as a fallback alias so env
+    files migrated from LangGraph Platform work unchanged; AEGRA_THREAD_TTL
+    wins when both are set. Parsed and validated in services.thread_ttl.
     """
 
     AEGRA_THREAD_TTL: str | None = None
+    LANGGRAPH_THREAD_TTL: str | None = None
 
 
 class EventStreamingSettings(EnvBase):

--- a/libs/aegra-api/src/aegra_api/settings.py
+++ b/libs/aegra-api/src/aegra_api/settings.py
@@ -434,6 +434,18 @@ class CronSettings(EnvBase):
         return self
 
 
+class ThreadTTLSettings(EnvBase):
+    """Thread TTL sweeper configuration.
+
+    AEGRA_THREAD_TTL is either a bare number (default_ttl in minutes) or a
+    JSON object with any of: strategy, default_ttl, sweep_interval_minutes,
+    sweep_limit. When set it replaces the aegra.json checkpointer.ttl block
+    entirely. Parsed and validated in services.thread_ttl.
+    """
+
+    AEGRA_THREAD_TTL: str | None = None
+
+
 class EventStreamingSettings(EnvBase):
     """Agent Protocol v2 event streaming (/threads/{id}/stream/events + /commands).
 
@@ -459,6 +471,7 @@ class Settings:
         self.redis = RedisSettings()
         self.worker = WorkerSettings()
         self.cron = CronSettings()
+        self.thread_ttl = ThreadTTLSettings()
         self.event_streaming = EventStreamingSettings()
 
 

--- a/libs/aegra-api/tests/e2e/test_threads/test_thread_ttl.py
+++ b/libs/aegra-api/tests/e2e/test_threads/test_thread_ttl.py
@@ -1,0 +1,98 @@
+"""E2E tests for thread TTL: per-thread opt-in and POST /threads/prune.
+
+Deterministic via /threads/prune instead of waiting on the background sweep
+(its loop is unit-tested; the minimum useful interval is minutes). Uses the
+hermetic stress_test graph — no LLM key required.
+"""
+
+import asyncio
+import json
+
+import httpx
+import pytest
+
+from aegra_api.settings import settings
+from tests.e2e._utils import elog, get_e2e_client
+from tests.e2e.test_threads.test_thread_deletion import _CHECKPOINT_TABLES, _count_checkpoint_rows
+
+_RUN_INPUT = {"messages": [{"role": "user", "content": json.dumps({"delay": 0.1, "steps": 2})}]}
+
+
+async def _run_to_completion(client, thread_id: str, assistant_id: str) -> None:
+    run = await client.runs.create(thread_id=thread_id, assistant_id=assistant_id, input=_RUN_INPUT)
+    await client.runs.join(thread_id, run["run_id"])
+    finished = await client.runs.get(thread_id, run["run_id"])
+    assert finished["status"] == "success", f"run ended as {finished['status']}"
+
+
+def _prune() -> dict:
+    resp = httpx.post(f"{settings.app.SERVER_URL}/threads/prune", timeout=30.0)
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_prune_deletes_expired_thread() -> None:
+    """An expired delete-strategy thread is fully removed, checkpoints included."""
+    client = get_e2e_client()
+    assistant = await client.assistants.create(graph_id="stress_test", if_exists="do_nothing")
+
+    # SDK ttl kwarg: number = minutes with strategy=delete. 0.001 min = 60 ms.
+    thread = await client.threads.create(ttl=0.001)
+    thread_id = thread["thread_id"]
+    await _run_to_completion(client, thread_id, assistant["assistant_id"])
+
+    before = await _count_checkpoint_rows(thread_id)
+    elog("Checkpoint rows before prune", {"thread_id": thread_id, **before})
+    assert before["checkpoints"] > 0
+
+    await asyncio.sleep(1.0)  # let the 60 ms TTL expire
+    result = _prune()
+    elog("Prune result", result)
+    assert result["deleted"] >= 1
+
+    with pytest.raises(Exception, match="404|not found|Not Found"):
+        await client.threads.get(thread_id)
+
+    after = await _count_checkpoint_rows(thread_id)
+    elog("Checkpoint rows after prune", {"thread_id": thread_id, **after})
+    assert after == dict.fromkeys(_CHECKPOINT_TABLES, 0)
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_prune_keep_latest_preserves_latest_state() -> None:
+    """keep_latest compacts history to one checkpoint but keeps the thread usable."""
+    client = get_e2e_client()
+    assistant = await client.assistants.create(graph_id="stress_test", if_exists="do_nothing")
+
+    thread = await client.threads.create(ttl={"ttl": 0.001, "strategy": "keep_latest"})
+    thread_id = thread["thread_id"]
+    await _run_to_completion(client, thread_id, assistant["assistant_id"])
+
+    history_before = await client.threads.get_history(thread_id)
+    state_before = await client.threads.get_state(thread_id)
+    assert len(history_before) > 1, "run should have produced multiple checkpoints"
+
+    await asyncio.sleep(1.0)
+    result = _prune()
+    elog("Prune result", result)
+    assert result["pruned"] >= 1
+
+    # Thread survives with exactly the latest state
+    thread_after = await client.threads.get(thread_id)
+    assert thread_after["thread_id"] == thread_id
+    history_after = await client.threads.get_history(thread_id)
+    assert len(history_after) == 1
+    state_after = await client.threads.get_state(thread_id)
+    assert state_after["values"] == state_before["values"]
+
+    # Strongest proof the kept checkpoint/blobs are self-consistent: the graph
+    # resumes from the compacted state and completes again.
+    await _run_to_completion(client, thread_id, assistant["assistant_id"])
+    counts = await _count_checkpoint_rows(thread_id)
+    elog("Checkpoint rows after second run", {"thread_id": thread_id, **counts})
+    assert counts["checkpoints"] > 1
+
+    await client.threads.delete(thread_id)

--- a/libs/aegra-api/tests/e2e/test_threads/test_thread_ttl.py
+++ b/libs/aegra-api/tests/e2e/test_threads/test_thread_ttl.py
@@ -10,15 +10,16 @@ import json
 
 import httpx
 import pytest
+from langgraph_sdk.client import LangGraphClient
 
 from aegra_api.settings import settings
 from tests.e2e._utils import elog, get_e2e_client
-from tests.e2e.test_threads.test_thread_deletion import _CHECKPOINT_TABLES, _count_checkpoint_rows
+from tests.e2e.test_threads.test_thread_deletion import _CHECKPOINT_COUNT_QUERIES, _count_checkpoint_rows
 
 _RUN_INPUT = {"messages": [{"role": "user", "content": json.dumps({"delay": 0.1, "steps": 2})}]}
 
 
-async def _run_to_completion(client, thread_id: str, assistant_id: str) -> None:
+async def _run_to_completion(client: LangGraphClient, thread_id: str, assistant_id: str) -> None:
     run = await client.runs.create(thread_id=thread_id, assistant_id=assistant_id, input=_RUN_INPUT)
     await client.runs.join(thread_id, run["run_id"])
     finished = await client.runs.get(thread_id, run["run_id"])
@@ -57,7 +58,7 @@ async def test_prune_deletes_expired_thread() -> None:
 
     after = await _count_checkpoint_rows(thread_id)
     elog("Checkpoint rows after prune", {"thread_id": thread_id, **after})
-    assert after == dict.fromkeys(_CHECKPOINT_TABLES, 0)
+    assert after == dict.fromkeys(_CHECKPOINT_COUNT_QUERIES, 0)
 
 
 @pytest.mark.e2e

--- a/libs/aegra-api/tests/integration/test_api/test_threads_ttl.py
+++ b/libs/aegra-api/tests/integration/test_api/test_threads_ttl.py
@@ -156,9 +156,7 @@ class TestPruneEndpoint:
     def test_prune_returns_counts_for_caller(self, monkeypatch: pytest.MonkeyPatch) -> None:
         called: dict[str, object] = {}
 
-        async def fake_prune(
-            session: object, *, user_id: str, auth_filter: object = None
-        ) -> tuple[int, int]:
+        async def fake_prune(session: object, *, user_id: str, auth_filter: object = None) -> tuple[int, int]:
             called["user_id"] = user_id
             called["auth_filter"] = auth_filter
             return 2, 1
@@ -174,9 +172,7 @@ class TestPruneEndpoint:
         assert called["user_id"] == "test-user"
 
     def test_prune_with_nothing_expired_returns_zeros(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        async def fake_prune(
-            session: object, *, user_id: str, auth_filter: object = None
-        ) -> tuple[int, int]:
+        async def fake_prune(session: object, *, user_id: str, auth_filter: object = None) -> tuple[int, int]:
             return 0, 0
 
         monkeypatch.setattr(threads_module, "prune_expired_threads_for_user", fake_prune)

--- a/libs/aegra-api/tests/integration/test_api/test_threads_ttl.py
+++ b/libs/aegra-api/tests/integration/test_api/test_threads_ttl.py
@@ -148,3 +148,42 @@ class TestCreateThreadTTL:
 
         assert resp.status_code == 200
         assert session.added == []
+
+
+class TestPruneEndpoint:
+    """POST /threads/prune maps the service result and scopes to the caller."""
+
+    def test_prune_returns_counts_for_caller(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        called: dict[str, object] = {}
+
+        async def fake_prune(
+            session: object, *, user_id: str, auth_filter: object = None
+        ) -> tuple[int, int]:
+            called["user_id"] = user_id
+            called["auth_filter"] = auth_filter
+            return 2, 1
+
+        monkeypatch.setattr(threads_module, "prune_expired_threads_for_user", fake_prune)
+        session = RecordingSession()
+        client = _make_client(session)
+
+        resp = client.post("/threads/prune")
+
+        assert resp.status_code == 200
+        assert resp.json() == {"deleted": 2, "pruned": 1}
+        assert called["user_id"] == "test-user"
+
+    def test_prune_with_nothing_expired_returns_zeros(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        async def fake_prune(
+            session: object, *, user_id: str, auth_filter: object = None
+        ) -> tuple[int, int]:
+            return 0, 0
+
+        monkeypatch.setattr(threads_module, "prune_expired_threads_for_user", fake_prune)
+        session = RecordingSession()
+        client = _make_client(session)
+
+        resp = client.post("/threads/prune")
+
+        assert resp.status_code == 200
+        assert resp.json() == {"deleted": 0, "pruned": 0}

--- a/libs/aegra-api/tests/integration/test_api/test_threads_ttl.py
+++ b/libs/aegra-api/tests/integration/test_api/test_threads_ttl.py
@@ -1,0 +1,150 @@
+"""Integration tests for per-thread TTL on POST /threads."""
+
+from datetime import timedelta
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import Insert
+
+from aegra_api.api import threads as threads_module
+from aegra_api.core.orm import ThreadTTL as ThreadTTLORM
+from aegra_api.core.orm import get_session as core_get_session
+from aegra_api.services.thread_ttl import ThreadTTLConfig
+from tests.fixtures.clients import create_test_app, make_client
+from tests.fixtures.database import DummyScalarResult, DummySessionBase, override_get_session_dep
+from tests.fixtures.test_helpers import DummyThread
+
+
+class RecordingSession(DummySessionBase):
+    """Session that records add() calls and commits."""
+
+    def __init__(self) -> None:
+        self.added: list[object] = []
+        self.commits: int = 0
+
+    def add(self, obj: object) -> None:
+        self.added.append(obj)
+
+    async def commit(self) -> None:
+        self.commits += 1
+
+
+def _make_client(session: DummySessionBase) -> TestClient:
+    app: FastAPI = create_test_app(include_runs=False, include_threads=True)
+    app.dependency_overrides[core_get_session] = override_get_session_dep(lambda: session)
+    return make_client(app)
+
+
+@pytest.fixture
+def ttl_config_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(threads_module, "get_thread_ttl_config", lambda: None)
+
+
+class TestCreateThreadTTL:
+    """POST /threads with a ttl payload writes a thread_ttl row atomically."""
+
+    def test_create_with_ttl_adds_row_before_single_commit(self, ttl_config_off: None) -> None:
+        session = RecordingSession()
+        client = _make_client(session)
+
+        resp = client.post("/threads", json={"ttl": {"default_ttl": 10, "strategy": "keep_latest"}})
+
+        assert resp.status_code == 200
+        assert len(session.added) == 1
+        row = session.added[0]
+        assert isinstance(row, ThreadTTLORM)
+        assert row.thread_id == resp.json()["thread_id"]
+        assert row.strategy == "keep_latest"
+        assert row.ttl_minutes == 10
+        assert row.expires_at - row.created_at == timedelta(minutes=10)
+        assert session.commits == 1
+
+    def test_create_accepts_sdk_ttl_key(self, ttl_config_off: None) -> None:
+        """langgraph-sdk sends {'ttl': {'ttl': N}} — minutes under 'ttl'."""
+        session = RecordingSession()
+        client = _make_client(session)
+
+        resp = client.post("/threads", json={"ttl": {"ttl": 5}})
+
+        assert resp.status_code == 200
+        row = session.added[0]
+        assert isinstance(row, ThreadTTLORM)
+        assert row.ttl_minutes == 5
+        assert row.strategy == "delete"
+
+    def test_create_without_ttl_and_no_config_adds_no_row(self, ttl_config_off: None) -> None:
+        session = RecordingSession()
+        client = _make_client(session)
+
+        resp = client.post("/threads", json={"metadata": {}})
+
+        assert resp.status_code == 200
+        assert session.added == []
+
+    def test_create_gets_default_row_when_server_config_enabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            threads_module,
+            "get_thread_ttl_config",
+            lambda: ThreadTTLConfig(default_ttl=100, strategy="delete"),
+        )
+        session = RecordingSession()
+        client = _make_client(session)
+
+        resp = client.post("/threads", json={"metadata": {}})
+
+        assert resp.status_code == 200
+        row = session.added[0]
+        assert isinstance(row, ThreadTTLORM)
+        assert row.ttl_minutes == 100
+        assert row.strategy == "delete"
+
+    def test_request_ttl_overrides_server_default_per_field(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            threads_module,
+            "get_thread_ttl_config",
+            lambda: ThreadTTLConfig(default_ttl=100, strategy="delete"),
+        )
+        session = RecordingSession()
+        client = _make_client(session)
+
+        resp = client.post("/threads", json={"ttl": {"strategy": "keep_latest"}})
+
+        assert resp.status_code == 200
+        row = session.added[0]
+        assert isinstance(row, ThreadTTLORM)
+        assert row.ttl_minutes == 100  # falls back to server default
+        assert row.strategy == "keep_latest"  # request override
+
+    def test_returns_422_when_ttl_lacks_default_and_no_server_config(self, ttl_config_off: None) -> None:
+        session = RecordingSession()
+        client = _make_client(session)
+
+        resp = client.post("/threads", json={"ttl": {"strategy": "delete"}})
+
+        assert resp.status_code == 422
+        assert session.added == []
+        assert session.commits == 0
+
+    def test_conflict_path_does_not_touch_incumbent_ttl(self, ttl_config_off: None) -> None:
+        """An idempotent re-create must not add a ttl row for the existing thread."""
+
+        class ConflictSession(RecordingSession):
+            async def scalars(self, stmt: object = None) -> DummyScalarResult:
+                if isinstance(stmt, Insert):
+                    return DummyScalarResult()  # ON CONFLICT DO NOTHING: no row returned
+                return DummyScalarResult()
+
+            async def scalar(self, _stmt: object) -> object:
+                return DummyThread("taken-id", "idle", {}, "test-user")
+
+        session = ConflictSession()
+        client = _make_client(session)
+
+        resp = client.post(
+            "/threads",
+            json={"thread_id": "taken-id", "if_exists": "do_nothing", "ttl": {"default_ttl": 10}},
+        )
+
+        assert resp.status_code == 200
+        assert session.added == []

--- a/libs/aegra-api/tests/unit/test_core/test_auth_registry.py
+++ b/libs/aegra-api/tests/unit/test_core/test_auth_registry.py
@@ -185,6 +185,7 @@ _SPEC_TUPLES: dict[tuple[str, str], tuple[str, str]] = {
     ("POST", "/threads"): ("threads", "create"),
     ("GET", "/threads"): ("threads", "search"),
     ("POST", "/threads/search"): ("threads", "search"),
+    ("POST", "/threads/prune"): ("threads", "delete"),
     ("GET", "/threads/{thread_id}"): ("threads", "read"),
     ("PATCH", "/threads/{thread_id}"): ("threads", "update"),
     ("DELETE", "/threads/{thread_id}"): ("threads", "delete"),

--- a/libs/aegra-api/tests/unit/test_core/test_config.py
+++ b/libs/aegra-api/tests/unit/test_core/test_config.py
@@ -2,7 +2,7 @@
 
 import json
 
-from aegra_api.config import load_http_config, load_store_config
+from aegra_api.config import load_checkpointer_config, load_http_config, load_store_config
 
 
 def test_load_http_config_from_aegra_json(tmp_path, monkeypatch):
@@ -200,3 +200,50 @@ def test_load_store_config_from_langgraph_json(tmp_path, monkeypatch):
     assert config is not None
     assert config["index"]["dims"] == 768
     assert config["index"]["embed"] == "cohere:embed-english-v3.0"
+
+
+# ============================================================================
+# Checkpointer Config Tests
+# ============================================================================
+
+
+def test_load_checkpointer_config_with_ttl(tmp_path, monkeypatch):
+    """Test loading checkpointer config with a ttl block"""
+    monkeypatch.chdir(tmp_path)
+
+    config_file = tmp_path / "aegra.json"
+    config_file.write_text(
+        json.dumps(
+            {
+                "graphs": {"test": "./test.py:graph"},
+                "checkpointer": {"ttl": {"strategy": "delete", "default_ttl": 43200}},
+            }
+        )
+    )
+
+    config = load_checkpointer_config()
+
+    assert config is not None
+    assert config["ttl"]["strategy"] == "delete"
+    assert config["ttl"]["default_ttl"] == 43200
+
+
+def test_load_checkpointer_config_no_section(tmp_path, monkeypatch):
+    """Test loading when config exists but has no checkpointer section"""
+    monkeypatch.chdir(tmp_path)
+
+    config_file = tmp_path / "aegra.json"
+    config_file.write_text(json.dumps({"graphs": {"test": "./test.py:graph"}}))
+
+    config = load_checkpointer_config()
+
+    assert config is None
+
+
+def test_load_checkpointer_config_no_config(tmp_path, monkeypatch):
+    """Test loading when no config file exists"""
+    monkeypatch.chdir(tmp_path)
+
+    config = load_checkpointer_config()
+
+    assert config is None

--- a/libs/aegra-api/tests/unit/test_core/test_config.py
+++ b/libs/aegra-api/tests/unit/test_core/test_config.py
@@ -1,6 +1,9 @@
 """Unit tests for HTTP and store configuration loading"""
 
 import json
+from pathlib import Path
+
+import pytest
 
 from aegra_api.config import load_checkpointer_config, load_http_config, load_store_config
 
@@ -207,7 +210,7 @@ def test_load_store_config_from_langgraph_json(tmp_path, monkeypatch):
 # ============================================================================
 
 
-def test_load_checkpointer_config_with_ttl(tmp_path, monkeypatch):
+def test_load_checkpointer_config_with_ttl(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Test loading checkpointer config with a ttl block"""
     monkeypatch.chdir(tmp_path)
 
@@ -228,7 +231,7 @@ def test_load_checkpointer_config_with_ttl(tmp_path, monkeypatch):
     assert config["ttl"]["default_ttl"] == 43200
 
 
-def test_load_checkpointer_config_no_section(tmp_path, monkeypatch):
+def test_load_checkpointer_config_no_section(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Test loading when config exists but has no checkpointer section"""
     monkeypatch.chdir(tmp_path)
 
@@ -240,7 +243,7 @@ def test_load_checkpointer_config_no_section(tmp_path, monkeypatch):
     assert config is None
 
 
-def test_load_checkpointer_config_no_config(tmp_path, monkeypatch):
+def test_load_checkpointer_config_no_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Test loading when no config file exists"""
     monkeypatch.chdir(tmp_path)
 

--- a/libs/aegra-api/tests/unit/test_main.py
+++ b/libs/aegra-api/tests/unit/test_main.py
@@ -164,3 +164,66 @@ async def test_lifespan_runs_migrations_when_enabled(monkeypatch):
             pass
 
         mock_migrations.assert_called_once()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_lifespan_starts_ttl_sweeper_when_configured():
+    """The TTL sweeper starts when a TTL config resolves and stops before DB close."""
+    import aegra_api.main as main_module
+
+    importlib.reload(main_module)
+
+    with (
+        patch("aegra_api.main.run_migrations_async", new_callable=AsyncMock),
+        patch("aegra_api.main.db_manager") as mock_db_manager,
+        patch("aegra_api.main.get_langgraph_service") as mock_get_langgraph_service,
+        patch("aegra_api.main.setup_observability"),
+        patch("aegra_api.main.get_thread_ttl_config", return_value=MagicMock()),
+        patch("aegra_api.main.thread_ttl_sweeper") as mock_sweeper,
+    ):
+        mock_db_manager.initialize = AsyncMock()
+        mock_db_manager.close = AsyncMock()
+        mock_langgraph_service = MagicMock()
+        mock_langgraph_service.initialize = AsyncMock()
+        mock_get_langgraph_service.return_value = mock_langgraph_service
+        mock_sweeper.start = AsyncMock()
+        mock_sweeper.stop = AsyncMock()
+
+        async with main_module.lifespan(MagicMock()):
+            mock_sweeper.start.assert_awaited_once()
+            mock_sweeper.stop.assert_not_awaited()
+
+        mock_sweeper.stop.assert_awaited_once()
+        mock_db_manager.close.assert_called_once()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_lifespan_skips_ttl_sweeper_without_config():
+    """No TTL config resolved → the sweeper never starts."""
+    import aegra_api.main as main_module
+
+    importlib.reload(main_module)
+
+    with (
+        patch("aegra_api.main.run_migrations_async", new_callable=AsyncMock),
+        patch("aegra_api.main.db_manager") as mock_db_manager,
+        patch("aegra_api.main.get_langgraph_service") as mock_get_langgraph_service,
+        patch("aegra_api.main.setup_observability"),
+        patch("aegra_api.main.get_thread_ttl_config", return_value=None),
+        patch("aegra_api.main.thread_ttl_sweeper") as mock_sweeper,
+    ):
+        mock_db_manager.initialize = AsyncMock()
+        mock_db_manager.close = AsyncMock()
+        mock_langgraph_service = MagicMock()
+        mock_langgraph_service.initialize = AsyncMock()
+        mock_get_langgraph_service.return_value = mock_langgraph_service
+        mock_sweeper.start = AsyncMock()
+        mock_sweeper.stop = AsyncMock()
+
+        async with main_module.lifespan(MagicMock()):
+            pass
+
+        mock_sweeper.start.assert_not_awaited()
+        mock_sweeper.stop.assert_not_awaited()

--- a/libs/aegra-api/tests/unit/test_main.py
+++ b/libs/aegra-api/tests/unit/test_main.py
@@ -168,7 +168,7 @@ async def test_lifespan_runs_migrations_when_enabled(monkeypatch):
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_lifespan_starts_ttl_sweeper_when_configured():
+async def test_lifespan_starts_ttl_sweeper_when_configured() -> None:
     """The TTL sweeper starts when a TTL config resolves and stops before DB close."""
     import aegra_api.main as main_module
 
@@ -200,7 +200,7 @@ async def test_lifespan_starts_ttl_sweeper_when_configured():
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_lifespan_skips_ttl_sweeper_without_config():
+async def test_lifespan_skips_ttl_sweeper_without_config() -> None:
     """No TTL config resolved → the sweeper never starts."""
     import aegra_api.main as main_module
 

--- a/libs/aegra-api/tests/unit/test_models/test_thread_ttl_validation.py
+++ b/libs/aegra-api/tests/unit/test_models/test_thread_ttl_validation.py
@@ -33,6 +33,12 @@ class TestThreadTTLSpec:
         with pytest.raises(ValidationError):
             ThreadTTLSpec.model_validate({"default_ttl": value})
 
+    @pytest.mark.parametrize("value", [float("inf"), 1e308])
+    def test_rejects_timedelta_unsafe_ttl(self, value: float) -> None:
+        """Values above MAX_TTL_MINUTES would overflow timedelta in create_thread."""
+        with pytest.raises(ValidationError):
+            ThreadTTLSpec.model_validate({"default_ttl": value})
+
     def test_rejects_unknown_strategy(self) -> None:
         with pytest.raises(ValidationError):
             ThreadTTLSpec.model_validate({"strategy": "purge"})

--- a/libs/aegra-api/tests/unit/test_models/test_thread_ttl_validation.py
+++ b/libs/aegra-api/tests/unit/test_models/test_thread_ttl_validation.py
@@ -1,0 +1,58 @@
+"""Validation tests for the per-thread TTL request models."""
+
+import pytest
+from pydantic import ValidationError
+
+from aegra_api.models import ThreadCreate, ThreadTTLSpec
+
+
+class TestThreadTTLSpec:
+    """ThreadTTLSpec accepts both spec and SDK key spellings."""
+
+    def test_accepts_default_ttl_key(self) -> None:
+        spec = ThreadTTLSpec.model_validate({"default_ttl": 1440, "strategy": "delete"})
+
+        assert spec.default_ttl == 1440
+        assert spec.strategy == "delete"
+
+    def test_accepts_sdk_ttl_key(self) -> None:
+        """langgraph-sdk sends the minutes value under 'ttl', not 'default_ttl'."""
+        spec = ThreadTTLSpec.model_validate({"ttl": 60, "strategy": "keep_latest"})
+
+        assert spec.default_ttl == 60
+        assert spec.strategy == "keep_latest"
+
+    def test_all_fields_optional(self) -> None:
+        spec = ThreadTTLSpec.model_validate({})
+
+        assert spec.default_ttl is None
+        assert spec.strategy is None
+
+    @pytest.mark.parametrize("value", [0, -1, -0.5])
+    def test_rejects_non_positive_ttl(self, value: float) -> None:
+        with pytest.raises(ValidationError):
+            ThreadTTLSpec.model_validate({"default_ttl": value})
+
+    def test_rejects_unknown_strategy(self) -> None:
+        with pytest.raises(ValidationError):
+            ThreadTTLSpec.model_validate({"strategy": "purge"})
+
+
+class TestThreadCreateTTL:
+    """ThreadCreate carries an optional nested ttl object."""
+
+    def test_defaults_to_no_ttl(self) -> None:
+        request = ThreadCreate.model_validate({})
+
+        assert request.ttl is None
+
+    def test_nested_ttl_parsed(self) -> None:
+        request = ThreadCreate.model_validate({"ttl": {"ttl": 5, "strategy": "delete"}})
+
+        assert request.ttl is not None
+        assert request.ttl.default_ttl == 5
+        assert request.ttl.strategy == "delete"
+
+    def test_invalid_nested_ttl_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            ThreadCreate.model_validate({"ttl": {"default_ttl": 0}})

--- a/libs/aegra-api/tests/unit/test_services/test_thread_ttl.py
+++ b/libs/aegra-api/tests/unit/test_services/test_thread_ttl.py
@@ -31,8 +31,13 @@ def _swept_count(outcome: str) -> float:
 
 
 def _make_lg_pool() -> tuple[MagicMock, AsyncMock]:
-    """Fake db_manager.lg_pool: connection() and transaction() async CMs."""
+    """Fake db_manager.lg_pool: connection() and transaction() async CMs.
+
+    The prunable-history probe answers True by default; override
+    conn.execute.return_value.fetchone for the skip path.
+    """
     conn = AsyncMock()
+    conn.execute.return_value.fetchone = AsyncMock(return_value=(True,))
     tx = AsyncMock()
     tx.__aenter__ = AsyncMock(return_value=None)
     tx.__aexit__ = AsyncMock(return_value=False)
@@ -259,10 +264,11 @@ class TestKeepLatest:
 
         assert outcome == "pruned"
         statements = [call.args[0] for call in conn.execute.await_args_list]
-        assert len(statements) == 3
-        assert "DELETE FROM checkpoints" in statements[0]
-        assert "DELETE FROM checkpoint_writes" in statements[1]
-        assert "DELETE FROM checkpoint_blobs" in statements[2]
+        assert len(statements) == 4
+        assert "SELECT EXISTS" in statements[0]  # prunable-history probe first
+        assert "DELETE FROM checkpoints" in statements[1]
+        assert "DELETE FROM checkpoint_writes" in statements[2]
+        assert "DELETE FROM checkpoint_blobs" in statements[3]
         for call in conn.execute.await_args_list:
             assert "%(tid)s" in call.args[0]
             assert call.args[1] == {"tid": "t-1"}
@@ -270,6 +276,25 @@ class TestKeepLatest:
         rearm_sql = str(session.execute.await_args_list[0].args[0].compile(dialect=postgresql.dialect()))
         assert "UPDATE thread_ttl" in rearm_sql
         assert "expires_at" in rearm_sql
+
+    @pytest.mark.asyncio
+    async def test_skips_deletes_when_history_already_compact(self) -> None:
+        """Idle expiry cycles cost one PK-indexed probe, not three DELETEs."""
+        pool, conn = _make_lg_pool()
+        conn.execute.return_value.fetchone = AsyncMock(return_value=(False,))
+        db = MagicMock()
+        db.lg_pool = pool
+        session = AsyncMock()
+
+        with patch("aegra_api.services.thread_ttl.db_manager", db):
+            outcome = await _apply_strategy(session, "t-1", "keep_latest", 30.0, datetime.now(UTC))
+
+        assert outcome == "pruned"
+        assert conn.execute.await_count == 1  # probe only
+        conn.transaction.assert_not_called()
+        # Still re-arms so the next cycle stays scheduled
+        rearm_sql = str(session.execute.await_args_list[0].args[0].compile(dialect=postgresql.dialect()))
+        assert "UPDATE thread_ttl" in rearm_sql
 
     @pytest.mark.asyncio
     async def test_raises_when_db_not_initialized(self) -> None:

--- a/libs/aegra-api/tests/unit/test_services/test_thread_ttl.py
+++ b/libs/aegra-api/tests/unit/test_services/test_thread_ttl.py
@@ -220,6 +220,12 @@ class TestClaimQuery:
         assert "LIMIT" in sql
         assert "runs" in sql  # active-run guard subquery
 
+    def test_exclude_ids_renders_not_in(self) -> None:
+        stmt = _expired_claim_stmt(datetime.now(UTC), 10, exclude_ids={"failed-1"})
+        sql = str(stmt.compile(dialect=postgresql.dialect()))
+
+        assert "NOT IN" in sql
+
     def test_prune_claim_is_user_scoped(self) -> None:
         stmt = _expired_claim_stmt(datetime.now(UTC), 10, user_id="user-1")
         sql = str(stmt.compile(dialect=postgresql.dialect()))
@@ -326,9 +332,10 @@ class TestFailureIsolation:
 
         errors_before = _swept_count("error")
         with patch("aegra_api.services.thread_ttl.db_manager", db):
-            claimed, deleted, pruned = await _process_expired_batch(session, MagicMock(), datetime.now(UTC))
+            claimed, deleted, pruned, failed_ids = await _process_expired_batch(session, MagicMock(), datetime.now(UTC))
 
         assert (claimed, deleted, pruned) == (2, 1, 0)
+        assert failed_ids == ["t-1"]
         assert checkpointer.adelete_thread.await_count == 2
         session.commit.assert_awaited_once()
         assert _swept_count("error") == errors_before + 1
@@ -340,9 +347,9 @@ class TestFailureIsolation:
         session = AsyncMock()
         session.execute.return_value = claim_result
 
-        claimed, deleted, pruned = await _process_expired_batch(session, MagicMock(), datetime.now(UTC))
+        claimed, deleted, pruned, failed_ids = await _process_expired_batch(session, MagicMock(), datetime.now(UTC))
 
-        assert (claimed, deleted, pruned) == (0, 0, 0)
+        assert (claimed, deleted, pruned, failed_ids) == (0, 0, 0, [])
         session.commit.assert_not_awaited()
 
 
@@ -360,7 +367,7 @@ class TestSweepLimit:
         maker.return_value.__aenter__ = AsyncMock(return_value=session)
         maker.return_value.__aexit__ = AsyncMock(return_value=False)
 
-        batches = [(100, 100, 0), (100, 100, 0), (50, 50, 0), (0, 0, 0)]
+        batches = [(100, 100, 0, []), (100, 100, 0, []), (50, 50, 0, []), (0, 0, 0, [])]
         with (
             patch("aegra_api.services.thread_ttl._get_session_maker", return_value=maker),
             patch(
@@ -376,9 +383,9 @@ class TestSweepLimit:
         assert limits == [100, 100, 50]
 
     @pytest.mark.asyncio
-    async def test_fully_failed_batch_ends_tick_early(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """A batch where every item errored would be re-claimed verbatim and
-        starve later expirations for the rest of the tick — the loop must stop."""
+    async def test_failed_rows_excluded_from_subsequent_claims(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Persistently failing rows sit first in expiry order; without the
+        exclusion they'd be re-claimed every batch and starve later rows."""
         sweeper = ThreadTTLSweeper()
         config = ThreadTTLConfig(sweep_limit=1000)
         monkeypatch.setattr("aegra_api.services.thread_ttl.get_thread_ttl_config", lambda: config)
@@ -388,17 +395,20 @@ class TestSweepLimit:
         maker.return_value.__aenter__ = AsyncMock(return_value=session)
         maker.return_value.__aexit__ = AsyncMock(return_value=False)
 
+        batches = [(2, 1, 0, ["bad-1"]), (1, 1, 0, []), (0, 0, 0, [])]
         with (
             patch("aegra_api.services.thread_ttl._get_session_maker", return_value=maker),
             patch(
                 "aegra_api.services.thread_ttl._process_expired_batch",
                 new_callable=AsyncMock,
-                return_value=(100, 0, 0),
+                side_effect=batches,
             ) as mock_batch,
         ):
             await sweeper._tick()
 
-        assert mock_batch.await_count == 1
+        assert mock_batch.await_count == 3
+        second_claim = str(mock_batch.await_args_list[1].args[1].compile(dialect=postgresql.dialect()))
+        assert "NOT IN" in second_claim
 
     @pytest.mark.asyncio
     async def test_tick_is_noop_without_config(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -494,7 +504,7 @@ class TestPruneForUser:
         monkeypatch.setattr("aegra_api.services.thread_ttl.get_thread_ttl_config", lambda: None)
         session = AsyncMock()
 
-        batches = [(2, 1, 1), (1, 1, 0), (0, 0, 0)]
+        batches = [(2, 1, 1, ["bad-1"]), (1, 1, 0, []), (0, 0, 0, [])]
         with patch(
             "aegra_api.services.thread_ttl._process_expired_batch",
             new_callable=AsyncMock,

--- a/libs/aegra-api/tests/unit/test_services/test_thread_ttl.py
+++ b/libs/aegra-api/tests/unit/test_services/test_thread_ttl.py
@@ -37,7 +37,7 @@ def _make_lg_pool() -> tuple[MagicMock, AsyncMock]:
     conn.execute.return_value.fetchone for the skip path.
     """
     conn = AsyncMock()
-    conn.execute.return_value.fetchone = AsyncMock(return_value=(True,))
+    conn.execute.return_value.fetchone = AsyncMock(return_value={"has_prunable_history": True})
     tx = AsyncMock()
     tx.__aenter__ = AsyncMock(return_value=None)
     tx.__aexit__ = AsyncMock(return_value=False)
@@ -287,7 +287,7 @@ class TestKeepLatest:
     async def test_skips_deletes_when_history_already_compact(self) -> None:
         """Idle expiry cycles cost one PK-indexed probe, not three DELETEs."""
         pool, conn = _make_lg_pool()
-        conn.execute.return_value.fetchone = AsyncMock(return_value=(False,))
+        conn.execute.return_value.fetchone = AsyncMock(return_value={"has_prunable_history": False})
         db = MagicMock()
         db.lg_pool = pool
         session = AsyncMock()

--- a/libs/aegra-api/tests/unit/test_services/test_thread_ttl.py
+++ b/libs/aegra-api/tests/unit/test_services/test_thread_ttl.py
@@ -1,10 +1,13 @@
 """Unit tests for thread TTL config resolution and the expiry sweep."""
 
 import json
+from collections.abc import Iterator
 from datetime import UTC, datetime
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from langgraph.checkpoint.postgres.base import MIGRATIONS, SELECT_SQL
 from psycopg import Error as PsycopgError
 from pydantic import ValidationError
 from sqlalchemy.dialects import postgresql
@@ -43,7 +46,7 @@ def _make_lg_pool() -> tuple[MagicMock, AsyncMock]:
 
 
 @pytest.fixture(autouse=True)
-def _clear_ttl_config_cache() -> None:
+def _clear_ttl_config_cache() -> Iterator[None]:
     get_thread_ttl_config.cache_clear()
     yield
     get_thread_ttl_config.cache_clear()
@@ -57,12 +60,12 @@ def _no_env_ttl(monkeypatch: pytest.MonkeyPatch) -> None:
 class TestResolveConfig:
     """Tests for get_thread_ttl_config source precedence and validation."""
 
-    def test_returns_none_when_no_source_configured(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_returns_none_when_no_source_configured(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.chdir(tmp_path)
 
         assert get_thread_ttl_config() is None
 
-    def test_loads_from_aegra_json_checkpointer_ttl(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_loads_from_aegra_json_checkpointer_ttl(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.chdir(tmp_path)
         (tmp_path / "aegra.json").write_text(
             json.dumps(
@@ -81,7 +84,7 @@ class TestResolveConfig:
         assert config.sweep_interval_minutes == 5
         assert config.sweep_limit == 1000
 
-    def test_env_bare_number_sets_default_ttl(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_env_bare_number_sets_default_ttl(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.chdir(tmp_path)
         monkeypatch.setattr(settings.thread_ttl, "AEGRA_THREAD_TTL", "43200")
 
@@ -91,7 +94,7 @@ class TestResolveConfig:
         assert config.default_ttl == 43200
         assert config.strategy == "delete"
 
-    def test_env_json_object_sets_all_fields(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_env_json_object_sets_all_fields(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.chdir(tmp_path)
         monkeypatch.setattr(
             settings.thread_ttl,
@@ -114,7 +117,7 @@ class TestResolveConfig:
         assert config.sweep_interval_minutes == 1
         assert config.sweep_limit == 50
 
-    def test_env_replaces_aegra_json_block_entirely(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_env_replaces_aegra_json_block_entirely(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Whole-source override: json keys do not leak under an env config."""
         monkeypatch.chdir(tmp_path)
         (tmp_path / "aegra.json").write_text(
@@ -134,28 +137,28 @@ class TestResolveConfig:
         assert config.strategy == "delete"
         assert config.sweep_limit == 1000
 
-    def test_invalid_env_json_raises(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_invalid_env_json_raises(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.chdir(tmp_path)
         monkeypatch.setattr(settings.thread_ttl, "AEGRA_THREAD_TTL", "{not json")
 
         with pytest.raises(json.JSONDecodeError):
             get_thread_ttl_config()
 
-    def test_invalid_strategy_raises(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_invalid_strategy_raises(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.chdir(tmp_path)
         monkeypatch.setattr(settings.thread_ttl, "AEGRA_THREAD_TTL", json.dumps({"strategy": "purge"}))
 
         with pytest.raises(ValidationError):
             get_thread_ttl_config()
 
-    def test_non_positive_default_ttl_raises(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_non_positive_default_ttl_raises(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.chdir(tmp_path)
         monkeypatch.setattr(settings.thread_ttl, "AEGRA_THREAD_TTL", "0")
 
         with pytest.raises(ValidationError):
             get_thread_ttl_config()
 
-    def test_blank_env_falls_back_to_json(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_blank_env_falls_back_to_json(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.chdir(tmp_path)
         (tmp_path / "aegra.json").write_text(
             json.dumps(
@@ -192,15 +195,21 @@ class TestThreadTTLConfigModel:
         with pytest.raises(ValidationError):
             ThreadTTLConfig.model_validate({field: 0})
 
+    @pytest.mark.parametrize("value", [float("inf"), 1e308])
+    def test_rejects_timedelta_unsafe_ttl(self, value: float) -> None:
+        """Values above MAX_TTL_MINUTES would overflow timedelta at insert time."""
+        with pytest.raises(ValidationError):
+            ThreadTTLConfig.model_validate({"default_ttl": value})
+
 
 class TestClaimQuery:
-    """The claim statement locks only thread_ttl rows and skips busy threads."""
+    """The claim statement locks thread_ttl and thread rows and skips busy threads."""
 
     def test_sweep_claim_shape(self) -> None:
         stmt = _expired_claim_stmt(datetime.now(UTC), 10)
         sql = str(stmt.compile(dialect=postgresql.dialect()))
 
-        assert "FOR UPDATE OF thread_ttl SKIP LOCKED" in sql
+        assert "FOR UPDATE OF thread_ttl, thread SKIP LOCKED" in sql
         assert "EXISTS" in sql
         assert "expires_at <=" in sql
         assert "LIMIT" in sql
@@ -211,7 +220,7 @@ class TestClaimQuery:
         sql = str(stmt.compile(dialect=postgresql.dialect()))
 
         assert "thread.user_id" in sql
-        assert "FOR UPDATE OF thread_ttl SKIP LOCKED" in sql
+        assert "FOR UPDATE OF thread_ttl, thread SKIP LOCKED" in sql
 
 
 class TestDeleteStrategy:
@@ -342,6 +351,31 @@ class TestSweepLimit:
         assert limits == [100, 100, 50]
 
     @pytest.mark.asyncio
+    async def test_fully_failed_batch_ends_tick_early(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A batch where every item errored would be re-claimed verbatim and
+        starve later expirations for the rest of the tick — the loop must stop."""
+        sweeper = ThreadTTLSweeper()
+        config = ThreadTTLConfig(sweep_limit=1000)
+        monkeypatch.setattr("aegra_api.services.thread_ttl.get_thread_ttl_config", lambda: config)
+
+        session = AsyncMock()
+        maker = MagicMock()
+        maker.return_value.__aenter__ = AsyncMock(return_value=session)
+        maker.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        with (
+            patch("aegra_api.services.thread_ttl._get_session_maker", return_value=maker),
+            patch(
+                "aegra_api.services.thread_ttl._process_expired_batch",
+                new_callable=AsyncMock,
+                return_value=(100, 0, 0),
+            ) as mock_batch,
+        ):
+            await sweeper._tick()
+
+        assert mock_batch.await_count == 1
+
+    @pytest.mark.asyncio
     async def test_tick_is_noop_without_config(self, monkeypatch: pytest.MonkeyPatch) -> None:
         sweeper = ThreadTTLSweeper()
         monkeypatch.setattr("aegra_api.services.thread_ttl.get_thread_ttl_config", lambda: None)
@@ -418,8 +452,6 @@ class TestSchemaCanary:
     the keep_latest pruning SQL is pinned to."""
 
     def test_checkpoint_tables_match_pruning_assumptions(self) -> None:
-        from langgraph.checkpoint.postgres.base import MIGRATIONS, SELECT_SQL
-
         ddl = "\n".join(MIGRATIONS)
         assert "PRIMARY KEY (thread_id, checkpoint_ns, checkpoint_id)" in ddl
         assert "PRIMARY KEY (thread_id, checkpoint_ns, channel, version)" in ddl
@@ -449,4 +481,4 @@ class TestPruneForUser:
         assert mock_batch.await_count == 3
         claim_sql = str(mock_batch.await_args_list[0].args[1].compile(dialect=postgresql.dialect()))
         assert "thread.user_id" in claim_sql
-        assert "FOR UPDATE OF thread_ttl SKIP LOCKED" in claim_sql
+        assert "FOR UPDATE OF thread_ttl, thread SKIP LOCKED" in claim_sql

--- a/libs/aegra-api/tests/unit/test_services/test_thread_ttl.py
+++ b/libs/aegra-api/tests/unit/test_services/test_thread_ttl.py
@@ -1,0 +1,163 @@
+"""Unit tests for thread TTL config resolution and the expiry sweep."""
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from aegra_api.services.thread_ttl import (
+    ThreadTTLConfig,
+    get_thread_ttl_config,
+)
+from aegra_api.settings import settings
+
+
+@pytest.fixture(autouse=True)
+def _clear_ttl_config_cache() -> None:
+    get_thread_ttl_config.cache_clear()
+    yield
+    get_thread_ttl_config.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def _no_env_ttl(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings.thread_ttl, "AEGRA_THREAD_TTL", None)
+
+
+class TestResolveConfig:
+    """Tests for get_thread_ttl_config source precedence and validation."""
+
+    def test_returns_none_when_no_source_configured(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.chdir(tmp_path)
+
+        assert get_thread_ttl_config() is None
+
+    def test_loads_from_aegra_json_checkpointer_ttl(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "aegra.json").write_text(
+            json.dumps(
+                {
+                    "graphs": {"test": "./test.py:graph"},
+                    "checkpointer": {"ttl": {"strategy": "keep_latest", "default_ttl": 1440}},
+                }
+            )
+        )
+
+        config = get_thread_ttl_config()
+
+        assert config is not None
+        assert config.strategy == "keep_latest"
+        assert config.default_ttl == 1440
+        assert config.sweep_interval_minutes == 5
+        assert config.sweep_limit == 1000
+
+    def test_env_bare_number_sets_default_ttl(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(settings.thread_ttl, "AEGRA_THREAD_TTL", "43200")
+
+        config = get_thread_ttl_config()
+
+        assert config is not None
+        assert config.default_ttl == 43200
+        assert config.strategy == "delete"
+
+    def test_env_json_object_sets_all_fields(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(
+            settings.thread_ttl,
+            "AEGRA_THREAD_TTL",
+            json.dumps(
+                {
+                    "strategy": "keep_latest",
+                    "default_ttl": 60,
+                    "sweep_interval_minutes": 1,
+                    "sweep_limit": 50,
+                }
+            ),
+        )
+
+        config = get_thread_ttl_config()
+
+        assert config is not None
+        assert config.strategy == "keep_latest"
+        assert config.default_ttl == 60
+        assert config.sweep_interval_minutes == 1
+        assert config.sweep_limit == 50
+
+    def test_env_replaces_aegra_json_block_entirely(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Whole-source override: json keys do not leak under an env config."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "aegra.json").write_text(
+            json.dumps(
+                {
+                    "graphs": {"test": "./test.py:graph"},
+                    "checkpointer": {"ttl": {"strategy": "keep_latest", "sweep_limit": 7}},
+                }
+            )
+        )
+        monkeypatch.setattr(settings.thread_ttl, "AEGRA_THREAD_TTL", "120")
+
+        config = get_thread_ttl_config()
+
+        assert config is not None
+        assert config.default_ttl == 120
+        assert config.strategy == "delete"
+        assert config.sweep_limit == 1000
+
+    def test_invalid_env_json_raises(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(settings.thread_ttl, "AEGRA_THREAD_TTL", "{not json")
+
+        with pytest.raises(json.JSONDecodeError):
+            get_thread_ttl_config()
+
+    def test_invalid_strategy_raises(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(settings.thread_ttl, "AEGRA_THREAD_TTL", json.dumps({"strategy": "purge"}))
+
+        with pytest.raises(ValidationError):
+            get_thread_ttl_config()
+
+    def test_non_positive_default_ttl_raises(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(settings.thread_ttl, "AEGRA_THREAD_TTL", "0")
+
+        with pytest.raises(ValidationError):
+            get_thread_ttl_config()
+
+    def test_blank_env_falls_back_to_json(self, tmp_path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "aegra.json").write_text(
+            json.dumps(
+                {
+                    "graphs": {"test": "./test.py:graph"},
+                    "checkpointer": {"ttl": {"default_ttl": 15}},
+                }
+            )
+        )
+        monkeypatch.setattr(settings.thread_ttl, "AEGRA_THREAD_TTL", "   ")
+
+        config = get_thread_ttl_config()
+
+        assert config is not None
+        assert config.default_ttl == 15
+
+
+class TestThreadTTLConfigModel:
+    """Bounds validation on the config model itself."""
+
+    def test_defaults(self) -> None:
+        config = ThreadTTLConfig()
+
+        assert config.strategy == "delete"
+        assert config.default_ttl == 43200
+        assert config.sweep_interval_minutes == 5
+        assert config.sweep_limit == 1000
+
+    @pytest.mark.parametrize(
+        "field",
+        ["default_ttl", "sweep_interval_minutes", "sweep_limit"],
+    )
+    def test_rejects_non_positive_values(self, field: str) -> None:
+        with pytest.raises(ValidationError):
+            ThreadTTLConfig.model_validate({field: 0})

--- a/libs/aegra-api/tests/unit/test_services/test_thread_ttl.py
+++ b/libs/aegra-api/tests/unit/test_services/test_thread_ttl.py
@@ -17,6 +17,7 @@ from aegra_api.services.thread_ttl import (
     _expired_claim_stmt,
     _process_expired_batch,
     get_thread_ttl_config,
+    prune_expired_threads_for_user,
 )
 from aegra_api.settings import settings
 
@@ -428,3 +429,26 @@ class TestSchemaCanary:
         # keep_latest keeps exactly the blob versions the latest checkpoint
         # references — the same join langgraph's reader performs.
         assert "jsonb_each_text(checkpoint -> 'channel_versions')" in SELECT_SQL
+
+
+class TestPruneForUser:
+    """prune_expired_threads_for_user loops user-scoped claims until dry."""
+
+    @pytest.mark.asyncio
+    async def test_accumulates_counts_until_no_more_claims(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("aegra_api.services.thread_ttl.get_thread_ttl_config", lambda: None)
+        session = AsyncMock()
+
+        batches = [(2, 1, 1), (1, 1, 0), (0, 0, 0)]
+        with patch(
+            "aegra_api.services.thread_ttl._process_expired_batch",
+            new_callable=AsyncMock,
+            side_effect=batches,
+        ) as mock_batch:
+            deleted, pruned = await prune_expired_threads_for_user(session, user_id="user-1")
+
+        assert (deleted, pruned) == (2, 1)
+        assert mock_batch.await_count == 3
+        claim_sql = str(mock_batch.await_args_list[0].args[1].compile(dialect=postgresql.dialect()))
+        assert "thread.user_id" in claim_sql
+        assert "FOR UPDATE OF thread_ttl SKIP LOCKED" in claim_sql

--- a/libs/aegra-api/tests/unit/test_services/test_thread_ttl.py
+++ b/libs/aegra-api/tests/unit/test_services/test_thread_ttl.py
@@ -268,9 +268,11 @@ class TestKeepLatest:
         db.lg_pool = None
         session = AsyncMock()
 
-        with patch("aegra_api.services.thread_ttl.db_manager", db):
-            with pytest.raises(RuntimeError, match="not initialized"):
-                await _apply_strategy(session, "t-1", "keep_latest", 30.0, datetime.now(UTC))
+        with (
+            patch("aegra_api.services.thread_ttl.db_manager", db),
+            pytest.raises(RuntimeError, match="not initialized"),
+        ):
+            await _apply_strategy(session, "t-1", "keep_latest", 30.0, datetime.now(UTC))
 
 
 class TestFailureIsolation:
@@ -290,9 +292,7 @@ class TestFailureIsolation:
 
         errors_before = _swept_count("error")
         with patch("aegra_api.services.thread_ttl.db_manager", db):
-            claimed, deleted, pruned = await _process_expired_batch(
-                session, MagicMock(), datetime.now(UTC)
-            )
+            claimed, deleted, pruned = await _process_expired_batch(session, MagicMock(), datetime.now(UTC))
 
         assert (claimed, deleted, pruned) == (2, 1, 0)
         assert checkpointer.adelete_thread.await_count == 2
@@ -346,9 +346,7 @@ class TestSweepLimit:
         sweeper = ThreadTTLSweeper()
         monkeypatch.setattr("aegra_api.services.thread_ttl.get_thread_ttl_config", lambda: None)
 
-        with patch(
-            "aegra_api.services.thread_ttl._process_expired_batch", new_callable=AsyncMock
-        ) as mock_batch:
+        with patch("aegra_api.services.thread_ttl._process_expired_batch", new_callable=AsyncMock) as mock_batch:
             await sweeper._tick()
 
         mock_batch.assert_not_awaited()

--- a/libs/aegra-api/tests/unit/test_services/test_thread_ttl.py
+++ b/libs/aegra-api/tests/unit/test_services/test_thread_ttl.py
@@ -1,15 +1,44 @@
 """Unit tests for thread TTL config resolution and the expiry sweep."""
 
 import json
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from psycopg import Error as PsycopgError
 from pydantic import ValidationError
+from sqlalchemy.dialects import postgresql
 
+from aegra_api.observability.metrics import THREAD_TTL_SWEPT
 from aegra_api.services.thread_ttl import (
     ThreadTTLConfig,
+    ThreadTTLSweeper,
+    _apply_strategy,
+    _expired_claim_stmt,
+    _process_expired_batch,
     get_thread_ttl_config,
 )
 from aegra_api.settings import settings
+
+
+def _swept_count(outcome: str) -> float:
+    """Read the current value of the TTL counter for one outcome label."""
+    return THREAD_TTL_SWEPT.labels(outcome=outcome)._value.get()
+
+
+def _make_lg_pool() -> tuple[MagicMock, AsyncMock]:
+    """Fake db_manager.lg_pool: connection() and transaction() async CMs."""
+    conn = AsyncMock()
+    tx = AsyncMock()
+    tx.__aenter__ = AsyncMock(return_value=None)
+    tx.__aexit__ = AsyncMock(return_value=False)
+    conn.transaction = MagicMock(return_value=tx)
+    pool_cm = AsyncMock()
+    pool_cm.__aenter__ = AsyncMock(return_value=conn)
+    pool_cm.__aexit__ = AsyncMock(return_value=False)
+    pool = MagicMock()
+    pool.connection = MagicMock(return_value=pool_cm)
+    return pool, conn
 
 
 @pytest.fixture(autouse=True)
@@ -161,3 +190,241 @@ class TestThreadTTLConfigModel:
     def test_rejects_non_positive_values(self, field: str) -> None:
         with pytest.raises(ValidationError):
             ThreadTTLConfig.model_validate({field: 0})
+
+
+class TestClaimQuery:
+    """The claim statement locks only thread_ttl rows and skips busy threads."""
+
+    def test_sweep_claim_shape(self) -> None:
+        stmt = _expired_claim_stmt(datetime.now(UTC), 10)
+        sql = str(stmt.compile(dialect=postgresql.dialect()))
+
+        assert "FOR UPDATE OF thread_ttl SKIP LOCKED" in sql
+        assert "EXISTS" in sql
+        assert "expires_at <=" in sql
+        assert "LIMIT" in sql
+        assert "runs" in sql  # active-run guard subquery
+
+    def test_prune_claim_is_user_scoped(self) -> None:
+        stmt = _expired_claim_stmt(datetime.now(UTC), 10, user_id="user-1")
+        sql = str(stmt.compile(dialect=postgresql.dialect()))
+
+        assert "thread.user_id" in sql
+        assert "FOR UPDATE OF thread_ttl SKIP LOCKED" in sql
+
+
+class TestDeleteStrategy:
+    """strategy=delete removes checkpoints strictly before the thread row."""
+
+    @pytest.mark.asyncio
+    async def test_deletes_checkpoints_before_thread_row(self) -> None:
+        order: list[str] = []
+        checkpointer = AsyncMock()
+        checkpointer.adelete_thread.side_effect = lambda _tid: order.append("checkpoints")
+        db = MagicMock()
+        db.get_checkpointer.return_value = checkpointer
+        session = AsyncMock()
+        session.execute.side_effect = lambda _stmt: order.append("thread_row")
+
+        with patch("aegra_api.services.thread_ttl.db_manager", db):
+            outcome = await _apply_strategy(session, "t-1", "delete", 5.0, datetime.now(UTC))
+
+        assert outcome == "deleted"
+        assert order == ["checkpoints", "thread_row"]
+        checkpointer.adelete_thread.assert_awaited_once_with("t-1")
+
+
+class TestKeepLatest:
+    """strategy=keep_latest prunes history on the lg_pool and re-arms the TTL."""
+
+    @pytest.mark.asyncio
+    async def test_prunes_three_tables_in_order_and_rearms(self) -> None:
+        pool, conn = _make_lg_pool()
+        db = MagicMock()
+        db.lg_pool = pool
+        session = AsyncMock()
+
+        with patch("aegra_api.services.thread_ttl.db_manager", db):
+            outcome = await _apply_strategy(session, "t-1", "keep_latest", 30.0, datetime.now(UTC))
+
+        assert outcome == "pruned"
+        statements = [call.args[0] for call in conn.execute.await_args_list]
+        assert len(statements) == 3
+        assert "DELETE FROM checkpoints" in statements[0]
+        assert "DELETE FROM checkpoint_writes" in statements[1]
+        assert "DELETE FROM checkpoint_blobs" in statements[2]
+        for call in conn.execute.await_args_list:
+            assert "%(tid)s" in call.args[0]
+            assert call.args[1] == {"tid": "t-1"}
+        # Re-arm lands on the SQLAlchemy session, not the lg_pool
+        rearm_sql = str(session.execute.await_args_list[0].args[0].compile(dialect=postgresql.dialect()))
+        assert "UPDATE thread_ttl" in rearm_sql
+        assert "expires_at" in rearm_sql
+
+    @pytest.mark.asyncio
+    async def test_raises_when_db_not_initialized(self) -> None:
+        db = MagicMock()
+        db.lg_pool = None
+        session = AsyncMock()
+
+        with patch("aegra_api.services.thread_ttl.db_manager", db):
+            with pytest.raises(RuntimeError, match="not initialized"):
+                await _apply_strategy(session, "t-1", "keep_latest", 30.0, datetime.now(UTC))
+
+
+class TestFailureIsolation:
+    """A checkpointer failure skips the item without poisoning the batch."""
+
+    @pytest.mark.asyncio
+    async def test_psycopg_error_skips_item_and_continues(self) -> None:
+        checkpointer = AsyncMock()
+        checkpointer.adelete_thread.side_effect = [PsycopgError("backend down"), None]
+        db = MagicMock()
+        db.get_checkpointer.return_value = checkpointer
+
+        claim_result = MagicMock()
+        claim_result.all.return_value = [("t-1", "delete", 5.0), ("t-2", "delete", 5.0)]
+        session = AsyncMock()
+        session.execute.side_effect = [claim_result, MagicMock()]
+
+        errors_before = _swept_count("error")
+        with patch("aegra_api.services.thread_ttl.db_manager", db):
+            claimed, deleted, pruned = await _process_expired_batch(
+                session, MagicMock(), datetime.now(UTC)
+            )
+
+        assert (claimed, deleted, pruned) == (2, 1, 0)
+        assert checkpointer.adelete_thread.await_count == 2
+        session.commit.assert_awaited_once()
+        assert _swept_count("error") == errors_before + 1
+
+    @pytest.mark.asyncio
+    async def test_empty_claim_returns_zero_without_commit(self) -> None:
+        claim_result = MagicMock()
+        claim_result.all.return_value = []
+        session = AsyncMock()
+        session.execute.return_value = claim_result
+
+        claimed, deleted, pruned = await _process_expired_batch(session, MagicMock(), datetime.now(UTC))
+
+        assert (claimed, deleted, pruned) == (0, 0, 0)
+        session.commit.assert_not_awaited()
+
+
+class TestSweepLimit:
+    """_tick claims sub-batches until sweep_limit is reached."""
+
+    @pytest.mark.asyncio
+    async def test_stops_at_sweep_limit(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        sweeper = ThreadTTLSweeper()
+        config = ThreadTTLConfig(sweep_limit=250)
+        monkeypatch.setattr("aegra_api.services.thread_ttl.get_thread_ttl_config", lambda: config)
+
+        session = AsyncMock()
+        maker = MagicMock()
+        maker.return_value.__aenter__ = AsyncMock(return_value=session)
+        maker.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        batches = [(100, 100, 0), (100, 100, 0), (50, 50, 0), (0, 0, 0)]
+        with (
+            patch("aegra_api.services.thread_ttl._get_session_maker", return_value=maker),
+            patch(
+                "aegra_api.services.thread_ttl._process_expired_batch",
+                new_callable=AsyncMock,
+                side_effect=batches,
+            ) as mock_batch,
+        ):
+            await sweeper._tick()
+
+        assert mock_batch.await_count == 3
+        limits = [call.args[1]._limit_clause.value for call in mock_batch.await_args_list]
+        assert limits == [100, 100, 50]
+
+    @pytest.mark.asyncio
+    async def test_tick_is_noop_without_config(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        sweeper = ThreadTTLSweeper()
+        monkeypatch.setattr("aegra_api.services.thread_ttl.get_thread_ttl_config", lambda: None)
+
+        with patch(
+            "aegra_api.services.thread_ttl._process_expired_batch", new_callable=AsyncMock
+        ) as mock_batch:
+            await sweeper._tick()
+
+        mock_batch.assert_not_awaited()
+
+
+class TestStartStop:
+    """Sweeper lifecycle mirrors the cron scheduler."""
+
+    @pytest.mark.asyncio
+    async def test_loop_ticks_first_then_sleeps(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        sweeper = ThreadTTLSweeper()
+        config = ThreadTTLConfig(sweep_interval_minutes=0.001)
+        monkeypatch.setattr("aegra_api.services.thread_ttl.get_thread_ttl_config", lambda: config)
+
+        tick_count = 0
+
+        async def counting_tick() -> None:
+            nonlocal tick_count
+            tick_count += 1
+            sweeper._running = False
+
+        sweeper._running = True
+        with patch.object(sweeper, "_tick", side_effect=counting_tick):
+            await sweeper._loop()
+
+        assert tick_count == 1
+
+    @pytest.mark.asyncio
+    async def test_loop_survives_tick_exception(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        sweeper = ThreadTTLSweeper()
+        config = ThreadTTLConfig(sweep_interval_minutes=0.001)
+        monkeypatch.setattr("aegra_api.services.thread_ttl.get_thread_ttl_config", lambda: config)
+
+        call_count = 0
+
+        async def failing_tick() -> None:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise ValueError("boom")
+            sweeper._running = False
+
+        sweeper._running = True
+        with patch.object(sweeper, "_tick", side_effect=failing_tick):
+            await sweeper._loop()
+
+        assert call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_start_creates_task_and_stop_cancels_it(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        sweeper = ThreadTTLSweeper()
+        config = ThreadTTLConfig(sweep_interval_minutes=60)
+        monkeypatch.setattr("aegra_api.services.thread_ttl.get_thread_ttl_config", lambda: config)
+
+        with patch.object(sweeper, "_tick", new_callable=AsyncMock):
+            await sweeper.start()
+            task = sweeper._task
+            assert task is not None
+            assert not task.done()
+
+            await sweeper.stop()
+
+        assert sweeper._task is None
+        assert task.done()
+
+
+class TestSchemaCanary:
+    """Fail loudly if a langgraph-checkpoint-postgres bump changes the schema
+    the keep_latest pruning SQL is pinned to."""
+
+    def test_checkpoint_tables_match_pruning_assumptions(self) -> None:
+        from langgraph.checkpoint.postgres.base import MIGRATIONS, SELECT_SQL
+
+        ddl = "\n".join(MIGRATIONS)
+        assert "PRIMARY KEY (thread_id, checkpoint_ns, checkpoint_id)" in ddl
+        assert "PRIMARY KEY (thread_id, checkpoint_ns, channel, version)" in ddl
+        assert "PRIMARY KEY (thread_id, checkpoint_ns, checkpoint_id, task_id, idx)" in ddl
+        # keep_latest keeps exactly the blob versions the latest checkpoint
+        # references — the same join langgraph's reader performs.
+        assert "jsonb_each_text(checkpoint -> 'channel_versions')" in SELECT_SQL

--- a/libs/aegra-api/tests/unit/test_services/test_thread_ttl.py
+++ b/libs/aegra-api/tests/unit/test_services/test_thread_ttl.py
@@ -60,6 +60,7 @@ def _clear_ttl_config_cache() -> Iterator[None]:
 @pytest.fixture(autouse=True)
 def _no_env_ttl(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(settings.thread_ttl, "AEGRA_THREAD_TTL", None)
+    monkeypatch.setattr(settings.thread_ttl, "LANGGRAPH_THREAD_TTL", None)
 
 
 class TestResolveConfig:
@@ -87,7 +88,7 @@ class TestResolveConfig:
         assert config.strategy == "keep_latest"
         assert config.default_ttl == 1440
         assert config.sweep_interval_minutes == 5
-        assert config.sweep_limit == 1000
+        assert config.sweep_limit == 10000
 
     def test_env_bare_number_sets_default_ttl(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.chdir(tmp_path)
@@ -140,7 +141,7 @@ class TestResolveConfig:
         assert config is not None
         assert config.default_ttl == 120
         assert config.strategy == "delete"
-        assert config.sweep_limit == 1000
+        assert config.sweep_limit == 10000
 
     def test_invalid_env_json_raises(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.chdir(tmp_path)
@@ -162,6 +163,26 @@ class TestResolveConfig:
 
         with pytest.raises(ValidationError):
             get_thread_ttl_config()
+
+    def test_langgraph_alias_used_as_fallback(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Env files migrated from LangGraph Platform work unchanged."""
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(settings.thread_ttl, "LANGGRAPH_THREAD_TTL", "777")
+
+        config = get_thread_ttl_config()
+
+        assert config is not None
+        assert config.default_ttl == 777
+
+    def test_aegra_var_wins_over_langgraph_alias(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setattr(settings.thread_ttl, "AEGRA_THREAD_TTL", "111")
+        monkeypatch.setattr(settings.thread_ttl, "LANGGRAPH_THREAD_TTL", "777")
+
+        config = get_thread_ttl_config()
+
+        assert config is not None
+        assert config.default_ttl == 111
 
     def test_blank_env_falls_back_to_json(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.chdir(tmp_path)
@@ -190,7 +211,7 @@ class TestThreadTTLConfigModel:
         assert config.strategy == "delete"
         assert config.default_ttl == 43200
         assert config.sweep_interval_minutes == 5
-        assert config.sweep_limit == 1000
+        assert config.sweep_limit == 10000
 
     @pytest.mark.parametrize(
         "field",

--- a/libs/aegra-api/tests/unit/test_services/test_thread_ttl.py
+++ b/libs/aegra-api/tests/unit/test_services/test_thread_ttl.py
@@ -211,7 +211,7 @@ class TestClaimQuery:
     """The claim statement locks thread_ttl and thread rows and skips busy threads."""
 
     def test_sweep_claim_shape(self) -> None:
-        stmt = _expired_claim_stmt(datetime.now(UTC), 10)
+        stmt = _expired_claim_stmt(now=datetime.now(UTC), limit=10)
         sql = str(stmt.compile(dialect=postgresql.dialect()))
 
         assert "FOR UPDATE OF thread_ttl, thread SKIP LOCKED" in sql
@@ -221,13 +221,13 @@ class TestClaimQuery:
         assert "runs" in sql  # active-run guard subquery
 
     def test_exclude_ids_renders_not_in(self) -> None:
-        stmt = _expired_claim_stmt(datetime.now(UTC), 10, exclude_ids={"failed-1"})
+        stmt = _expired_claim_stmt(now=datetime.now(UTC), limit=10, exclude_ids={"failed-1"})
         sql = str(stmt.compile(dialect=postgresql.dialect()))
 
         assert "NOT IN" in sql
 
     def test_prune_claim_is_user_scoped(self) -> None:
-        stmt = _expired_claim_stmt(datetime.now(UTC), 10, user_id="user-1")
+        stmt = _expired_claim_stmt(now=datetime.now(UTC), limit=10, user_id="user-1")
         sql = str(stmt.compile(dialect=postgresql.dialect()))
 
         assert "thread.user_id" in sql

--- a/libs/aegra-api/tests/unit/test_services/test_thread_ttl.py
+++ b/libs/aegra-api/tests/unit/test_services/test_thread_ttl.py
@@ -248,7 +248,9 @@ class TestDeleteStrategy:
         session.execute.side_effect = lambda _stmt: order.append("thread_row")
 
         with patch("aegra_api.services.thread_ttl.db_manager", db):
-            outcome = await _apply_strategy(session, "t-1", "delete", 5.0, datetime.now(UTC))
+            outcome = await _apply_strategy(
+                session, thread_id="t-1", strategy="delete", ttl_minutes=5.0, now=datetime.now(UTC)
+            )
 
         assert outcome == "deleted"
         assert order == ["checkpoints", "thread_row"]
@@ -266,7 +268,9 @@ class TestKeepLatest:
         session = AsyncMock()
 
         with patch("aegra_api.services.thread_ttl.db_manager", db):
-            outcome = await _apply_strategy(session, "t-1", "keep_latest", 30.0, datetime.now(UTC))
+            outcome = await _apply_strategy(
+                session, thread_id="t-1", strategy="keep_latest", ttl_minutes=30.0, now=datetime.now(UTC)
+            )
 
         assert outcome == "pruned"
         statements = [call.args[0] for call in conn.execute.await_args_list]
@@ -293,7 +297,9 @@ class TestKeepLatest:
         session = AsyncMock()
 
         with patch("aegra_api.services.thread_ttl.db_manager", db):
-            outcome = await _apply_strategy(session, "t-1", "keep_latest", 30.0, datetime.now(UTC))
+            outcome = await _apply_strategy(
+                session, thread_id="t-1", strategy="keep_latest", ttl_minutes=30.0, now=datetime.now(UTC)
+            )
 
         assert outcome == "pruned"
         assert conn.execute.await_count == 1  # probe only
@@ -312,7 +318,9 @@ class TestKeepLatest:
             patch("aegra_api.services.thread_ttl.db_manager", db),
             pytest.raises(RuntimeError, match="not initialized"),
         ):
-            await _apply_strategy(session, "t-1", "keep_latest", 30.0, datetime.now(UTC))
+            await _apply_strategy(
+                session, thread_id="t-1", strategy="keep_latest", ttl_minutes=30.0, now=datetime.now(UTC)
+            )
 
 
 class TestFailureIsolation:

--- a/libs/aegra-api/tests/unit/test_settings.py
+++ b/libs/aegra-api/tests/unit/test_settings.py
@@ -651,9 +651,11 @@ class TestThreadTTLSettings:
 
     def test_defaults_to_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.delenv("AEGRA_THREAD_TTL", raising=False)
+        monkeypatch.delenv("LANGGRAPH_THREAD_TTL", raising=False)
         ttl = ThreadTTLSettings(_env_file=None)
 
         assert ttl.AEGRA_THREAD_TTL is None
+        assert ttl.LANGGRAPH_THREAD_TTL is None
 
     def test_raw_string_passthrough(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("AEGRA_THREAD_TTL", '{"default_ttl": 60}')

--- a/libs/aegra-api/tests/unit/test_settings.py
+++ b/libs/aegra-api/tests/unit/test_settings.py
@@ -6,7 +6,14 @@ import pytest
 from pydantic import ValidationError
 from sqlalchemy.engine import make_url
 
-from aegra_api.settings import AppSettings, CronSettings, DatabaseSettings, RedisSettings, WorkerSettings
+from aegra_api.settings import (
+    AppSettings,
+    CronSettings,
+    DatabaseSettings,
+    RedisSettings,
+    ThreadTTLSettings,
+    WorkerSettings,
+)
 
 
 class TestAppSettingsServerURL:
@@ -637,3 +644,19 @@ class TestCronSettingsValidation:
 
         with pytest.raises((ValueError, ValidationError), match="CRON_POLL_INTERVAL_SECONDS"):
             CronSettings(_env_file=None)
+
+
+class TestThreadTTLSettings:
+    """AEGRA_THREAD_TTL is passed through raw; parsing lives in services.thread_ttl."""
+
+    def test_defaults_to_none(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("AEGRA_THREAD_TTL", raising=False)
+        ttl = ThreadTTLSettings(_env_file=None)
+
+        assert ttl.AEGRA_THREAD_TTL is None
+
+    def test_raw_string_passthrough(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("AEGRA_THREAD_TTL", '{"default_ttl": 60}')
+        ttl = ThreadTTLSettings(_env_file=None)
+
+        assert ttl.AEGRA_THREAD_TTL == '{"default_ttl": 60}'

--- a/libs/aegra-cli/src/aegra_cli/templates/env.example.template
+++ b/libs/aegra-cli/src/aegra_cli/templates/env.example.template
@@ -100,6 +100,14 @@ CRON_ENABLED=true
 # Soft cap on the JSONB payload size (bytes) accepted on create/update.
 # CRON_MAX_PAYLOAD_BYTES=65536
 
+# --- Thread TTL ---
+# Automatic thread retention. Either a bare number (default TTL in minutes)
+# or a JSON object with any of: strategy ("delete" | "keep_latest"),
+# default_ttl, sweep_interval_minutes, sweep_limit. When set, this replaces
+# the checkpointer.ttl block in aegra.json entirely. Unset = threads never expire.
+# AEGRA_THREAD_TTL=43200
+# AEGRA_THREAD_TTL={"strategy": "keep_latest", "default_ttl": 1440, "sweep_interval_minutes": 5, "sweep_limit": 1000}
+
 # --- Event Streaming (Agent Protocol v2) ---
 # The v2 thread streaming endpoints (/threads/{id}/stream/events and
 # /threads/{id}/commands) used by the latest LangGraph JS/Python SDKs.

--- a/libs/aegra-cli/src/aegra_cli/templates/env.example.template
+++ b/libs/aegra-cli/src/aegra_cli/templates/env.example.template
@@ -105,8 +105,9 @@ CRON_ENABLED=true
 # or a JSON object with any of: strategy ("delete" | "keep_latest"),
 # default_ttl, sweep_interval_minutes, sweep_limit. When set, this replaces
 # the checkpointer.ttl block in aegra.json entirely. Unset = threads never expire.
+# LANGGRAPH_THREAD_TTL is accepted as a fallback alias (AEGRA_THREAD_TTL wins).
 # AEGRA_THREAD_TTL=43200
-# AEGRA_THREAD_TTL={"strategy": "keep_latest", "default_ttl": 1440, "sweep_interval_minutes": 5, "sweep_limit": 1000}
+# AEGRA_THREAD_TTL={"strategy": "keep_latest", "default_ttl": 1440, "sweep_interval_minutes": 5, "sweep_limit": 10000}
 
 # --- Event Streaming (Agent Protocol v2) ---
 # The v2 thread streaming endpoints (/threads/{id}/stream/events and


### PR DESCRIPTION
## Summary

Phase 2 of #288 (phase 1 was #499): automatic thread lifecycle management.

- New `thread_ttl` table (alembic migration, FK → `thread` ON DELETE CASCADE, index on `expires_at`).
- Config: `checkpointer.ttl` in `aegra.json` **or** the `AEGRA_THREAD_TTL` env var (a bare number = `default_ttl` in minutes, or a JSON object). The env var replaces the json block entirely when set — same whole-source precedence as `DATABASE_URL` over `POSTGRES_*`. No config → feature fully off, zero behavior change.
- Background sweeper (`services/thread_ttl.py`): claims expired rows in sub-batches of 100 with `SELECT ... FOR UPDATE SKIP LOCKED` (multi-instance safe, pattern from the cron scheduler / #484 reaper) up to `sweep_limit` per tick, runs in both dev and prod modes, wired into the lifespan next to the cron scheduler.
- Both strategies from the spec:
  - `delete` — checkpoints first (`adelete_thread`), then the thread row (cascades runs/crons/thread_ttl). Same ordering rationale as #499.
  - `keep_latest` — prunes checkpoint history down to the latest state per `(thread_id, checkpoint_ns)`, then re-arms `expires_at` (periodic compaction). See "keep_latest details" below.
- Per-thread override: optional `ttl` field on `POST /threads`, written in the same transaction as the thread insert (atomic; the ON CONFLICT path never touches the incumbent's TTL).
- `POST /threads/prune`: immediately applies TTL policies to the **caller's** expired threads (user-scoped + auth handler metadata filters, mirroring `DELETE /threads/{id}`). Registered in the auth route map. Works even without server-side config, acting on per-thread opt-ins.
- Metric: `aegra_thread_ttl_swept_threads_total{outcome=deleted|pruned|error}`.

## Decisions the spec left open

- **`sweep_interval_minutes` default = 5** (the issue's table said 5, the example said 60 — went with 5: an idle tick is one cheap indexed query, and expired data gets at most ~5 min of lag).
- **SDK key mismatch (needs your blessing):** the issue names the per-thread minutes key `default_ttl`, but langgraph-sdk 0.4.x `threads.create(ttl=...)` actually posts `{"ttl": {"ttl": N, "strategy": "delete"}}`. `ThreadTTLSpec` accepts **both** spellings via `AliasChoices("default_ttl", "ttl")`, so real SDK traffic and the spec shape both work.
- **Active runs are never expired mid-run**: the claim query skips threads with pending/running runs (`NOT EXISTS`); they're picked up on a later tick. A background loop cancelling runs cross-instance felt riskier than a bounded delay.
- **keep_latest re-arms** `expires_at = now + ttl_minutes` after each prune — it's periodic compaction, not a one-shot (deleting the row after the first prune would silently stop compaction).
- TTL applies to threads created after it's enabled; pre-existing threads aren't backfilled (possible follow-up if wanted).
- Timestamps are `TIMESTAMP(timezone=True)` per repo convention, not the spec's naive `TIMESTAMP`.

## keep_latest details (the risky part — flagging it honestly)

There's no LangGraph API for "delete history, keep latest", so this is raw parameterized SQL over the psycopg `lg_pool` in one transaction, pinned to langgraph-checkpoint-postgres 3.x internals:

1. Delete `checkpoints` except `max(checkpoint_id)` per `(thread_id, checkpoint_ns)` — langgraph's own "latest" is `ORDER BY checkpoint_id DESC`.
2. Delete `checkpoint_writes` whose checkpoint is gone (the kept checkpoint's pending writes survive).
3. Delete `checkpoint_blobs` not referenced by a surviving checkpoint's `channel_versions` — the exact join langgraph's `SELECT_SQL` uses to load state. (Keeping `max(version)` per channel instead would corrupt state: a latest checkpoint can reference old versions for unchanged channels.)

Mitigations for the version-pinning: a schema-drift canary unit test asserting the package's DDL/`SELECT_SQL` still match these assumptions, a loud module comment, and an e2e test that **runs the graph again on a pruned thread** and asserts it completes with unchanged state. Known accepted edges: the kept checkpoint's `parent_checkpoint_id` dangles (harmless — only dereferenced for legacy v<4 checkpoints, and that lookup tolerates zero rows), and a millisecond writer/pruner race exists for direct `update_state` calls on an expired thread (runs are excluded by the active-run guard).

## Deadlock note for reviewers

The thread-row `DELETE` must run **in the same transaction** that holds the `FOR UPDATE` claim locks: it cascades into the locked `thread_ttl` row, so routing it through `delete_thread_by_id` (which opens its own session) would wait forever on a lock the claim transaction holds while the claim transaction awaits the helper. There's a pointed comment at the claim site; please flag any future refactor in that direction.

## Tests

- **Unit** (26 new): config resolution precedence/validation, compiled claim-query shape (SKIP LOCKED / active-run guard / user scoping), delete ordering, keep_latest statement order + re-arm, failure isolation (psycopg error skips item, batch still commits), sweep_limit sub-batching, loop lifecycle, schema-drift canary.
- **Integration**: per-thread ttl written atomically before the single commit (both key spellings), conflict path skips, server-default row, 422 without a resolvable TTL, prune endpoint mapping + zero case, auth registry snapshot updated.
- **E2E** (deterministic via `/threads/prune`; hermetic `stress_test` graph): expired delete-thread fully gone including all three checkpoint tables; keep_latest compacts history to 1 entry, `get_state` values unchanged, and the thread completes another run afterwards. Passing in both dev and prod modes.
- **Live-loop verification**: ran the server with `AEGRA_THREAD_TTL='{"default_ttl": 0.05, "sweep_interval_minutes": 0.1}'` — the background sweep deleted an expired thread ~8s after expiry (`sweep completed claimed=1 deleted=1`), orphaned-checkpoint count 0.
- Migration round-trip verified against live Postgres (`upgrade head` → `downgrade -1` → `upgrade head`).

## Docs

`configuration.mdx` (new `## checkpointer` section + complete example), `environment-variables.mdx` (`## Thread TTL`), `threads-and-state.mdx` (Thread TTL guide section), linked the existing TTL forward-reference in `cron.mdx`, both `.env.example` files, regenerated `openapi.json`. No version bump (auto-release handles it).

## Out of scope / follow-ups

- Store item TTL (part E of #288) — separate concern per the spec.
- An `archive` strategy (export thread state somewhere before deletion) came up on our side — if that's interesting I can write it up as an issue; the `strategy` enum extends without schema changes.

cc @ibbybuilds


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable thread expiration and retention policies.
  * Supports automatic deletion or preservation of the latest thread state.
  * Added per-thread TTL overrides when creating threads.
  * Added manual and scheduled pruning with deletion and compaction results.
  * Added environment-variable configuration, precedence rules, and validation limits.
  * Prevents cleanup of threads with active runs.

* **Documentation**
  * Expanded guidance for TTL configuration, cleanup behavior, retention strategies, and cron-managed threads.
  * Updated the API reference with TTL fields, pruning, and assistant conflict responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->









<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds configurable per-thread retention, automatic background sweeping, and an authenticated manual pruning endpoint.

- Adds persisted TTL policies and migration support for thread expiry.
- Implements delete and keep-latest cleanup strategies with bounded, multi-instance-safe claims.
- Adds configuration, metrics, documentation, and API, integration, unit, and end-to-end coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/services/thread_ttl.py | Implements TTL configuration resolution, locked batch claiming, checkpoint cleanup strategies, failure isolation, and the background sweep lifecycle. |
| libs/aegra-api/src/aegra_api/api/threads.py | Persists per-thread TTL settings atomically during creation and adds user-scoped manual pruning. |
| libs/aegra-api/alembic/versions/20260822000000_add_thread_ttl_table.py | Adds the indexed TTL policy table with cascading thread ownership. |
| libs/aegra-api/src/aegra_api/main.py | Starts and stops the TTL sweeper alongside other persistence-dependent background services. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  C[Thread creation] --> T[(thread_ttl row)]
  T --> E{Expiry reached}
  E --> S[Background sweep or manual prune]
  S --> A{Active run exists?}
  A -->|Yes| D[Defer until later]
  A -->|No| P{Strategy}
  P -->|delete| X[Delete checkpoints then thread]
  P -->|keep_latest| K[Compact checkpoint history]
  K --> R[Re-arm expiry]
```
</details>

<sub>Reviews (5): Last reviewed commit: ["docs: document LANGGRAPH\_THREAD\_TTL alia..."](https://github.com/aegra/aegra/commit/ad150033b0ea8fec43e6c1590c7a2da1a3c9f92e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55832675)</sub>

<details><summary><h4>Context used (5)</h4></summary>

- Context used - CLAUDE.md ([source](https://github.com/aegra/aegra/blob/main/CLAUDE.md))
- Knowledge Base — [Assistants, threads, and state](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/assistant-thread-state.md)
- Knowledge Base — [Persistence and distributed coordination](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/persistence-and-coordination.md)
- Knowledge Base — [Authentication and authorization](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/authentication-authorization.md)
- Knowledge Base — [HTTP API contracts](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/api-contracts.md)
</details>


<!-- /greptile_comment -->