### PR TITLE
feat(observability): add span enrichment hooks

### DIFF
--- a/docs/guides/observability.mdx
+++ b/docs/guides/observability.mdx
@@ -86,6 +86,36 @@ PHOENIX_COLLECTOR_ENDPOINT=http://127.0.0.1:6006/v1/traces
 
 Each backend receives the same trace data through separate `BatchSpanProcessor` instances.
 
+### Custom span attributes
+
+Register an enricher to add your own attributes to every span before it is exported.
+The callback receives the finished span, so response-time values — token costs, rate-limit headers, feature flags — are available at this point.
+
+```python
+from collections.abc import Mapping
+
+from opentelemetry.sdk.trace import ReadableSpan
+
+from aegra_api.observability.otel import otel_provider
+
+
+def rate_limit_attrs(span: ReadableSpan) -> Mapping[str, int] | None:
+    remaining = span.attributes.get("llm.response.headers.x-ratelimit-remaining-requests")
+    if remaining is None:
+        return None
+    return {"langfuse.observation.metadata.ratelimit_remaining": int(remaining)}
+
+
+otel_provider.add_span_enricher(rate_limit_attrs)
+```
+
+Return a mapping of attributes, or `None` to add nothing.
+Enrichers run once per span, ahead of the fan-out, so every configured target sees the same result and `OTEL_TARGETS` needs no change.
+Register them at graph-module import time — before or after startup both work.
+
+Values must be `str`, `int`, `float`, or `bool`; anything else is dropped with a warning, matching the rule for run metadata below.
+An enricher that raises is logged and skipped for that span, so a broken callback cannot stop a trace from being exported.
+
 ## How it works
 
 Aegra uses a pure OpenTelemetry approach:

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.10.4"
+version = "0.10.5"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-api/src/aegra_api/observability/otel.py
+++ b/libs/aegra-api/src/aegra_api/observability/otel.py
@@ -13,7 +13,7 @@ from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor, ConsoleSpanExporter
 
 from aegra_api.observability.base import ObservabilityProvider
-from aegra_api.observability.span_enrichment import SpanEnrichmentProcessor
+from aegra_api.observability.span_enrichment import SpanEnricher, SpanEnrichmentProcessor
 from aegra_api.observability.targets import (
     BaseOtelTarget,
     GenericOtelTarget,
@@ -33,6 +33,7 @@ class OpenTelemetryProvider(ObservabilityProvider):
     def __init__(self) -> None:
         self._enabled = False
         self._tracer_provider: TracerProvider | None = None
+        self._enrichment_processor = SpanEnrichmentProcessor()
 
         # Defining the list of active targets
         self._active_targets: list[BaseOtelTarget] = self._resolve_targets()
@@ -83,6 +84,16 @@ class OpenTelemetryProvider(ObservabilityProvider):
             except Exception as e:
                 logger.error(f"Observability: Failed to attach target '{target.name}': {e}")
 
+    def add_span_enricher(self, enricher: SpanEnricher) -> None:
+        """Register a callback that adds attributes to every span before export.
+
+        The callback receives the ended span and returns a mapping of extra
+        attributes, or ``None``. It runs once per span, ahead of the fan-out to
+        every configured target, so ``OTEL_TARGETS`` needs no change. Enrichers
+        may be registered before or after :meth:`setup`.
+        """
+        self._enrichment_processor.add_enricher(enricher)
+
     def setup(self) -> None:
         """Initializes the Global Tracer Provider. Runs once."""
         if self._tracer_provider:
@@ -98,7 +109,7 @@ class OpenTelemetryProvider(ObservabilityProvider):
         )
 
         self._tracer_provider = TracerProvider(resource=resource)
-        self._tracer_provider.add_span_processor(SpanEnrichmentProcessor())
+        self._tracer_provider.add_span_processor(self._enrichment_processor)
         processors_count = 0
 
         # 2. Attach Exporters

--- a/libs/aegra-api/src/aegra_api/observability/span_enrichment.py
+++ b/libs/aegra-api/src/aegra_api/observability/span_enrichment.py
@@ -23,7 +23,8 @@ Usage::
 
 import contextvars
 import logging
-from typing import Any
+from collections.abc import Callable, Mapping, MutableMapping
+from typing import Any, cast
 
 import structlog
 from opentelemetry.context import Context
@@ -36,6 +37,9 @@ logger = logging.getLogger(__name__)
 # time, so we filter at this layer and emit an aegra-level warning
 # instead of letting drops happen invisibly inside the SDK.
 _PRIMITIVE_ATTR_TYPES: tuple[type, ...] = (str, int, float, bool)
+
+AttributeValue = str | int | float | bool
+SpanEnricher = Callable[[ReadableSpan], Mapping[str, AttributeValue] | None]
 
 # Per-request context variable holding span attributes to inject.
 # None means no trace context is set; on_start() is a no-op in that case.
@@ -58,6 +62,9 @@ class SpanEnrichmentProcessor(SpanProcessor):
     are created.
     """
 
+    def __init__(self) -> None:
+        self._enrichers: list[SpanEnricher] = []
+
     def on_start(self, span: Span, parent_context: Context | None = None) -> None:
         attrs = _trace_attrs.get()
         if not attrs:
@@ -65,8 +72,54 @@ class SpanEnrichmentProcessor(SpanProcessor):
         for key, value in attrs.items():
             span.set_attribute(key, value)
 
+    def add_enricher(self, enricher: SpanEnricher) -> None:
+        """Register a callback applied to every span once it ends."""
+        self._enrichers.append(enricher)
+
+    def clear_enrichers(self) -> None:
+        self._enrichers.clear()
+
     def on_end(self, span: ReadableSpan) -> None:
-        pass
+        """Apply registered enrichers to the ended span.
+
+        ``ReadableSpan`` exposes attributes through a read-only mapping proxy,
+        but the SDK hands the processor the span's own attribute container
+        rather than a copy, so writing through it reaches every exporter. The
+        contract test in ``test_span_enrichment.py`` fails loudly if a future
+        SDK release starts copying instead.
+        """
+        if not self._enrichers:
+            return
+
+        if span._attributes is None:
+            return
+        # Declared Mapping by the SDK, always a mutable BoundedAttributes at runtime.
+        attributes = cast(MutableMapping[str, AttributeValue], span._attributes)
+
+        for enricher in self._enrichers:
+            try:
+                produced = enricher(span)
+            except Exception:
+                logger.exception("Span enricher raised; skipping it for this span")
+                continue
+            if not produced:
+                continue
+            if not isinstance(produced, Mapping):
+                logger.warning(
+                    "Span enricher returned %s; expected a mapping of attributes",
+                    type(produced).__name__,
+                )
+                continue
+            for key, value in produced.items():
+                if not isinstance(value, _PRIMITIVE_ATTR_TYPES):
+                    logger.warning(
+                        "Span enricher key '%s' has non-primitive type %s; dropping "
+                        "(OTEL attributes accept str/int/float/bool only)",
+                        key,
+                        type(value).__name__,
+                    )
+                    continue
+                attributes[key] = value
 
     def shutdown(self) -> None:
         pass

--- a/libs/aegra-api/tests/unit/test_observability/test_otel.py
+++ b/libs/aegra-api/tests/unit/test_observability/test_otel.py
@@ -329,3 +329,73 @@ class TestOpenTelemetryProviderRuntime:
 
             meta = provider.get_metadata("run-1", "thread-1")
             assert meta == {}
+
+
+class TestAddSpanEnricher:
+    """Enrichers must work whether registered before or after setup()."""
+
+    def _provider(self) -> OpenTelemetryProvider:
+        with patch("aegra_api.observability.otel.settings") as mock_settings:
+            mock_settings.observability.OTEL_TARGETS = ""
+            mock_settings.observability.OTEL_CONSOLE_EXPORT = False
+            return OpenTelemetryProvider()
+
+    def test_enricher_registered_before_setup_is_kept(self) -> None:
+        provider = self._provider()
+
+        def enricher(span: object) -> dict[str, int]:
+            return {"a": 1}
+
+        provider.add_span_enricher(enricher)
+
+        assert enricher in provider._enrichment_processor._enrichers
+
+    def test_enricher_registered_after_setup_reaches_the_live_processor(self) -> None:
+        provider = self._provider()
+        processor_before_setup = provider._enrichment_processor
+
+        with (
+            patch("aegra_api.observability.otel.settings") as mock_settings,
+            patch("aegra_api.observability.otel.TracerProvider") as mock_tp,
+            patch("aegra_api.observability.otel.BatchSpanProcessor"),
+            patch("aegra_api.observability.otel.ConsoleSpanExporter"),
+            patch("aegra_api.observability.otel.LangChainInstrumentor"),
+            patch("aegra_api.observability.otel.trace"),
+        ):
+            mock_settings.observability.OTEL_SERVICE_NAME = "test"
+            mock_settings.observability.OTEL_CONSOLE_EXPORT = True
+            mock_settings.app.VERSION = "0.0.0"
+            mock_settings.app.ENV_MODE = "LOCAL"
+            provider.setup()
+
+        def enricher(span: object) -> dict[str, int]:
+            return {"a": 1}
+
+        provider.add_span_enricher(enricher)
+
+        # The processor attached to the tracer provider is the same object the
+        # late registration lands on, so no restart is needed.
+        assert provider._enrichment_processor is processor_before_setup
+        assert enricher in processor_before_setup._enrichers
+        mock_tp.return_value.add_span_processor.assert_any_call(processor_before_setup)
+
+    def test_setup_registers_the_enrichment_processor_before_the_exporters(self) -> None:
+        provider = self._provider()
+
+        with (
+            patch("aegra_api.observability.otel.settings") as mock_settings,
+            patch("aegra_api.observability.otel.TracerProvider") as mock_tp,
+            patch("aegra_api.observability.otel.BatchSpanProcessor") as mock_bsp,
+            patch("aegra_api.observability.otel.ConsoleSpanExporter"),
+            patch("aegra_api.observability.otel.LangChainInstrumentor"),
+            patch("aegra_api.observability.otel.trace"),
+        ):
+            mock_settings.observability.OTEL_SERVICE_NAME = "test"
+            mock_settings.observability.OTEL_CONSOLE_EXPORT = True
+            mock_settings.app.VERSION = "0.0.0"
+            mock_settings.app.ENV_MODE = "LOCAL"
+            provider.setup()
+
+            calls = mock_tp.return_value.add_span_processor.call_args_list
+            assert calls[0].args[0] is provider._enrichment_processor
+            assert mock_bsp.return_value in [c.args[0] for c in calls[1:]]

--- a/libs/aegra-api/tests/unit/test_observability/test_span_enrichment.py
+++ b/libs/aegra-api/tests/unit/test_observability/test_span_enrichment.py
@@ -570,3 +570,136 @@ class TestSpanEnrichmentEndToEnd:
             assert attrs["langfuse.session.id"] == "thread-1"
             assert attrs["langfuse.trace.name"] == "my_graph"
             assert attrs["langfuse.trace.metadata.run_id"] == "run-1"
+
+
+class TestSpanEnrichers:
+    """Enrichers registered on the processor reach every exporter."""
+
+    def _provider(self) -> tuple[TracerProvider, SpanEnrichmentProcessor, InMemorySpanExporter]:
+        processor = SpanEnrichmentProcessor()
+        exporter = InMemorySpanExporter()
+        provider = TracerProvider()
+        provider.add_span_processor(processor)
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        return provider, processor, exporter
+
+    def test_enricher_attributes_reach_the_exporter(self) -> None:
+        provider, processor, exporter = self._provider()
+        processor.add_enricher(lambda span: {"cost.usd": 0.42})
+
+        with provider.get_tracer("t").start_as_current_span("s") as span:
+            span.set_attribute("model", "gpt")
+
+        exported = exporter.get_finished_spans()[0]
+        assert exported.attributes["model"] == "gpt"
+        assert exported.attributes["cost.usd"] == 0.42
+
+    def test_enricher_sees_the_ended_span(self) -> None:
+        """Response-time data is the point: the enricher reads the finished span."""
+        provider, processor, exporter = self._provider()
+        processor.add_enricher(lambda span: {"derived.name": span.name})
+
+        with provider.get_tracer("t").start_as_current_span("llm-call"):
+            pass
+
+        assert exporter.get_finished_spans()[0].attributes["derived.name"] == "llm-call"
+
+    def test_every_enricher_runs_in_registration_order(self) -> None:
+        provider, processor, exporter = self._provider()
+        processor.add_enricher(lambda span: {"first": 1, "shared": "a"})
+        processor.add_enricher(lambda span: {"second": 2, "shared": "b"})
+
+        with provider.get_tracer("t").start_as_current_span("s"):
+            pass
+
+        attrs = exporter.get_finished_spans()[0].attributes
+        assert attrs["first"] == 1
+        assert attrs["second"] == 2
+        assert attrs["shared"] == "b"
+
+    def test_a_raising_enricher_does_not_block_the_others_or_the_export(self) -> None:
+        provider, processor, exporter = self._provider()
+
+        def boom(span: object) -> dict[str, int]:
+            raise RuntimeError("enricher is broken")
+
+        processor.add_enricher(boom)
+        processor.add_enricher(lambda span: {"survived": True})
+
+        with provider.get_tracer("t").start_as_current_span("s"):
+            pass
+
+        exported = exporter.get_finished_spans()
+        assert len(exported) == 1
+        assert exported[0].attributes["survived"] is True
+
+    def test_non_primitive_values_are_dropped_with_a_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        provider, processor, exporter = self._provider()
+        processor.add_enricher(lambda span: {"bad": {"nested": 1}, "good": "kept"})
+
+        with caplog.at_level(logging.WARNING), provider.get_tracer("t").start_as_current_span("s"):
+            pass
+
+        attrs = exporter.get_finished_spans()[0].attributes
+        assert "bad" not in attrs
+        assert attrs["good"] == "kept"
+        assert "non-primitive" in caplog.text
+
+    def test_enricher_returning_a_non_mapping_is_skipped_with_a_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        """A callback can return anything at runtime; .items() must not blow up on_end."""
+        provider, processor, exporter = self._provider()
+        processor.add_enricher(lambda span: "not-a-mapping")
+        processor.add_enricher(lambda span: {"survived": True})
+
+        with caplog.at_level(logging.WARNING), provider.get_tracer("t").start_as_current_span("s"):
+            pass
+
+        exported = exporter.get_finished_spans()
+        assert len(exported) == 1
+        assert exported[0].attributes["survived"] is True
+        assert "expected a mapping" in caplog.text
+
+    def test_enricher_returning_none_is_a_no_op(self) -> None:
+        provider, processor, exporter = self._provider()
+        processor.add_enricher(lambda span: None)
+
+        with provider.get_tracer("t").start_as_current_span("s") as span:
+            span.set_attribute("only", 1)
+
+        assert dict(exporter.get_finished_spans()[0].attributes) == {"only": 1}
+
+    def test_span_without_its_own_attributes_is_still_enriched(self) -> None:
+        provider, processor, exporter = self._provider()
+        processor.add_enricher(lambda span: {"added": 1})
+
+        with provider.get_tracer("t").start_as_current_span("bare"):
+            pass
+
+        assert exporter.get_finished_spans()[0].attributes["added"] == 1
+
+    def test_clear_enrichers_stops_enrichment(self) -> None:
+        provider, processor, exporter = self._provider()
+        processor.add_enricher(lambda span: {"gone": 1})
+        processor.clear_enrichers()
+
+        with provider.get_tracer("t").start_as_current_span("s"):
+            pass
+
+        assert "gone" not in exporter.get_finished_spans()[0].attributes
+
+    def test_sdk_still_hands_the_processor_the_span_own_attributes(self) -> None:
+        """Contract canary: on_end enrichment relies on the SDK not copying attributes.
+
+        If a future opentelemetry-sdk release passes a copy to on_end, enrichment
+        would silently stop reaching exporters. This test fails first.
+        """
+        provider, processor, exporter = self._provider()
+        seen: list[int] = []
+        processor.add_enricher(lambda span: seen.append(id(span._attributes)) or {"x": 1})
+
+        with provider.get_tracer("t").start_as_current_span("s"):
+            pass
+
+        exported = exporter.get_finished_spans()[0]
+        assert id(exported._attributes) == seen[0]
+        assert exported.attributes["x"] == 1

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.10.4"
+version = "0.10.5"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.10.4"
+version = "0.10.5"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -100,7 +100,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.10.4"
+version = "0.10.5"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
The span pipeline between instrumentation and export is wired privately in `OpenTelemetryProvider.setup()`, so an extension can add export destinations but cannot touch the spans themselves — and `SpanEnrichmentProcessor` only writes in `on_start`, which is too early for response-time values like LLM rate-limit headers, leaving exporter-wrapping plus an `OTEL_TARGETS` migration as the only way in. This adds `otel_provider.add_span_enricher(fn)`, where `fn` receives the ended span and returns extra attributes: enrichers run once per span ahead of the fan-out, so every target sees the same result, no configuration changes, and registration works both before and after `setup()`.

Enrichment happens in `on_end` by writing through the span's own attribute container, which the SDK passes to the processor rather than copying ([opentelemetry-python#4424](https://github.com/open-telemetry/opentelemetry-python/issues/4424) tracks the absence of a public hook for this). A contract test asserts the exported span shares that container, so a future SDK release that starts copying fails CI instead of silently dropping attributes.

Fixes #463

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for enriching completed observability spans with custom attributes.
  * Enrichers can add response-time metadata and run before span export.
  * Invalid attribute values are ignored, while callback errors are safely handled.
  * Enrichers can be registered before or after observability setup and cleared when needed.

* **Documentation**
  * Added guidance covering registration, supported values, execution timing, and error handling.

* **Chores**
  * Updated package versions to 0.10.5.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds hooks for enriching completed OpenTelemetry spans before exporter fan-out.
- Adds provider-level enricher registration before or after tracing setup.
- Applies and validates callback-produced attributes during span completion.
- Adds unit coverage and user-facing observability guidance.
- Synchronizes the API and CLI package versions at 0.10.5.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/observability/span_enrichment.py | Adds callback registration and guarded end-of-span attribute enrichment ahead of export. |
| libs/aegra-api/src/aegra_api/observability/otel.py | Makes the enrichment processor persistent and exposes provider-level callback registration. |
| docs/guides/observability.mdx | Documents the new enrichment API, callback contract, timing, and error handling. |
| libs/aegra-api/tests/unit/test_observability/test_span_enrichment.py | Adds coverage for enrichment order, validation, failures, clearing, and exporter propagation. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant App as Application extension
    participant Provider as OpenTelemetryProvider
    participant Processor as SpanEnrichmentProcessor
    participant Span as Ended span
    participant Exporters as Configured exporters
    App->>Provider: add_span_enricher(callback)
    Provider->>Processor: register callback
    Span->>Processor: on_end(span)
    Processor->>App: callback(span)
    App-->>Processor: extra attributes
    Processor->>Span: update attribute container
    Span->>Exporters: fan out enriched span
```
</details>

<sub>Reviews (2): Last reviewed commit: ["feat(observability): add span enrichment..."](https://github.com/aegra/aegra/commit/c751614b38404bbbd5412c3fca940600fbf088f0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55868157)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/aegra/aegra/blob/main/CLAUDE.md))
- Knowledge Base — [Observability and telemetry](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/observability.md)

<!-- /greptile_comment -->