### PR TITLE
fix(worker): fence expired worker attempts with per-acquisition claim tokens

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ aegra/
 **Key principle:** LangGraph handles ALL state persistence and graph execution. FastAPI provides only HTTP/Agent Protocol compliance.
 
 ### Run Execution Architecture
-- **Production mode** (`REDIS_BROKER_ENABLED=true`): Runs are dispatched via a Redis job queue (BLPOP). Workers run as concurrent asyncio tasks inside each instance (default: 3 workers x 10 jobs = 30 concurrent runs per instance). Lease-based crash recovery with heartbeat and reaper. Execution params stored in Postgres so workers can reconstruct jobs. OpenTelemetry trace context propagates across the Redis queue boundary.
+- **Production mode** (`REDIS_BROKER_ENABLED=true`): Runs are dispatched via a Redis job queue (BLPOP). Workers run as concurrent asyncio tasks inside each instance (default: 3 workers x 10 jobs = 30 concurrent runs per instance). Lease-based crash recovery with heartbeat, per-acquisition claim tokens (fencing), and reaper. Execution params stored in Postgres so workers can reconstruct jobs. OpenTelemetry trace context propagates across the Redis queue boundary.
 - **Dev mode** (`aegra dev`, `REDIS_BROKER_ENABLED=false`): Runs execute as in-process asyncio tasks via `LocalExecutor`. No Redis needed. SSE uses an in-memory broker.
 - Key files: `services/executor.py` (factory), `services/local_executor.py` (dev), `services/worker_executor.py` (prod), `services/lease_reaper.py` (crash recovery), `models/run_job.py` (serialized execution params).
 - See `docs/guides/worker-architecture.mdx` for the full architecture documentation.

--- a/docs/guides/worker-architecture.mdx
+++ b/docs/guides/worker-architecture.mdx
@@ -137,7 +137,7 @@ sequenceDiagram
 Key details:
 
 1. **Execution params** are stored in PostgreSQL alongside the run, so any worker can reconstruct the full job context (user identity, config, trace metadata, interrupt settings, etc.).
-2. **Lease acquisition** is atomic — `UPDATE ... WHERE claimed_by IS NULL` ensures only one worker wins the race.
+2. **Lease acquisition** is atomic — `UPDATE ... WHERE claimed_by IS NULL` ensures only one worker wins the race. Each acquisition also mints a fresh `claim_token` (see [Claim tokens](#claim-tokens)).
 3. **Heartbeats** extend the lease every 10 seconds. If a worker crashes, the lease expires and the run becomes eligible for recovery.
 4. **OpenTelemetry trace context** propagates across the Redis queue boundary, so traces span the full request lifecycle.
 
@@ -145,7 +145,7 @@ Key details:
 
 The full picture — a streaming run shows how the client SSE connection, worker execution, and reaper recovery all interact:
 
-<a href="https://mermaid.live/view#pako:eNqdVE1r4zAQ_SuDTw5tScPSi9kUksbQQEhN7NDLglHsaaNNLLmSvGm29L_vyHK-ncv6ZEYz8-a9edKXl8kcvQA8jR8VigxHnL0rVvwSQF_JlOEZL5kw8LTmKMxlfBCNL4MzzLm-DL9KtUJ1GR8N21qw0ua6E4d-9_hIcAFEL3ECXVUJ3dVG4W5cOqOM0TCA8TQOZwlQBvjaMFPpfoki5-L9FvATs8pwKVKCY4XuHBfXgwcwi-bxsy1PeQ5Gwm-5ANKnwkMuJbuhAojjENwc4G8YNwQDb1LBQkmiC_iHsiyMK3YiHLCGk-glOiCA_6DB8AJlZZrR6kQL6EqDZrCzdpb3PBoNkhDiMIGGNqWKmna2ZtQ0Txfb_qYuuYU1Mo0pfpZcoU6Z6Qu5uflxr-H1OZyFcCqcQxsNT-aQm0xWwvR74NfNgGUfFXXLOy3DxeEkfEou9D_L3PV2aZgSAZ_E6cANLJH8sUBm0rWUpauzf1ZhtYXefdPrmiznfKEPDWNXR0TbVxTNh5MxGcJt0hrCrjxbMiFwfbajY1O4_BYp3rhga_63Zrd3qK6yDLXucmFQqao0mHfpR6rO9U0fbXU6n0xadmrD7aysS3IpEFa4BT9JJtBb7l06lQZBkq7NRQx2Ij_oHWEbPl2tvZGn5mnsB4Pp6FL-n1b-Y1_toDLF9JJYOZ-3ATb0z-_2mRz_N8sJEBeZwoLWCKlCo7ZpbXgKX_HxvrjtJfEV3qFw19w-EExIsySJ3YXseLfgFagKxnN6kr88OivqxzlnauV9f_8DKe3lLA==" target="_blank" rel="noopener">View fullscreen ↗</a>
+<a href="https://mermaid.live/view#pako:eNqVVF1r4zAQ_CuLn2za0oajL6YJNI2hhZCa2KEvB0axt40useRK8qW50v9-K8tpE8flOD-Z1X7MzI707uWyQC8ET-NrjSLHCWcvipU_BdBXMWV4zismDNxtOApzGr-NH06Dcyy4Pg0_SbVGdRqfjPtasMrmuhM3_WI0onEhxI9JCpeqFvpSG4V7uHRGGZNxCA-zJJqnQBnga8NMrYcVioKLl3PAN8xrw6XIaBwrdXBY3AAPYR4vkntbnvECjIRfcgmkT41fuZTsQIWQJBE4HOBvGTc0Bp6lgqWSRBfwN2XZMa7YifA1azyNH-OvCeBfazC8RFmbFlqTaAe60rAF1mlneS_iyW0aQRKl0NKmVNHQzjeMmhbZcjfcNiVtKDMEUgxvBG6hrnkxOocNMo0ZvlVcoc6YGQq59YOzH1canu6jeQTHkjock_ERQrnNZS3McAB-0w5Y_lpTvyLogZ1E0-guPdlMJ3Pf26VhRtR8ki2AM1ghOWeJzGQbKStXZ_-s9moHg6u213eCdRnDELqcD8SCkpl8hW1PEqF_sfFiPH0gG7n9WxtZo-QrJgRuOps9tJLL75HpmQu24X8a5ntfE3kySlUb-smJhnJcgn-h7oK1limkQFjjDvw0ncJg9WnZmTQIkqRsb2W41_Va73nY8PE27fU89kvrRbidTU4Vv7GKH1ppPypXTK_IuM70fQPbJXYv-oHjZ4vp9NjvNvK_6PygZzgXucKSNgaZQqN2WeN7Cn9j58_ivqfGV3iBwr0D9gVhQpoVye5ubOCdg1eiKhkv6M1-9-isbF7vgqm19_HxF1iN79E=" target="_blank" rel="noopener">View fullscreen ↗</a>
 
 ```mermaid
 sequenceDiagram
@@ -163,26 +163,58 @@ sequenceDiagram
 
     Worker->>Redis: BLPOP job queue (5s timeout)
     Redis-->>Worker: run_id
-    Worker->>DB: UPDATE SET status=running, claimed_by=worker, lease_expires_at=now+30s WHERE status=pending
+    Worker->>DB: UPDATE SET status=running, claimed_by=worker, claim_token=<new uuid>, lease_expires_at=now()+30s WHERE status=pending
     DB-->>Worker: rowcount=1 (lease acquired)
     Worker->>DB: SELECT execution_params
     Worker->>Worker: execute_run(job) + heartbeat_loop
     loop every 10s
-        Worker->>DB: UPDATE lease_expires_at = now+30s
+        Worker->>DB: UPDATE lease_expires_at = now()+30s WHERE claim_token matches
     end
     Worker->>Redis: PUBLISH events to SSE channel
     Redis-->>Client: SSE events
-    Worker->>DB: finalize_run (status=success/interrupted/error)
-    Worker->>DB: UPDATE claimed_by=NULL, lease_expires_at=NULL
+    Worker->>DB: finalize_run (status + output + clear lease) WHERE claim_token matches
     Worker->>Redis: SET done key (TTL 1h)
 
     Note over Reaper: every 15s
     Reaper->>DB: SELECT runs WHERE status=running AND lease_expires_at < now
     DB-->>Reaper: crashed_run_ids
-    Reaper->>DB: UPDATE status=pending, claimed_by=NULL WHERE status=running AND lease_expires_at < now
+    Reaper->>DB: UPDATE status=pending, claimed_by=NULL, claim_token=NULL WHERE status=running AND lease_expires_at < now()
     Reaper->>DB: increment _retry_count in execution_params
     Reaper->>Redis: RPUSH run_id (re-enqueue for another worker)
 ```
+
+## Claim tokens
+
+A lease keeps a crashed worker from blocking a run forever, but on its own it does not stop a
+*stalled* one. A worker paused past its lease — long GC pause, saturated event loop, unreachable
+database — wakes up believing it still owns the run, while the reaper has already handed that run to
+somebody else.
+
+`claimed_by` cannot tell those two attempts apart: it is a stable worker name
+(`host-pid-worker-idx`), so the same worker re-acquiring the same run reproduces the identity its
+abandoned attempt is still writing with. Every acquisition therefore also mints a **`claim_token`**,
+a fresh UUID that identifies that attempt and nothing else.
+
+Every ownership-predicated write matches on the token:
+
+| Operation | Predicate |
+| --- | --- |
+| Heartbeat (extend lease) | `run_id + claim_token` |
+| Terminalize (status, output, clear lease) | `run_id + user_id + active status + claim_token` |
+| Release leftover lease | `run_id + claim_token + terminal status` |
+| Reaper reclaim | clears `claim_token`, retiring the expired attempt |
+
+Two consequences worth knowing:
+
+- **A stalled worker stops itself.** If the heartbeat cannot renew before the lease would expire —
+  including when the database is unreachable, since an unrenewed lease expires on its own — the
+  worker cancels the graph instead of running on unowned. A single failed renewal with time left on
+  the lease is retried, so a brief blip does not abort in-flight runs.
+- **Terminalizing clears the lease in the same statement.** A run can never be left terminal while
+  still advertising an owner, and a superseded attempt can never strip the lease off its replacement.
+
+Lease expiry is evaluated by PostgreSQL (`now()`), not by the worker or reaper process, so clock
+skew between hosts cannot expire a live lease.
 
 ## Crash recovery
 
@@ -192,7 +224,7 @@ The reaper resets the run to `pending` and re-enqueues it.
 The new worker resumes from the last checkpoint.
 Once retries are exhausted, the reaper marks the run `error`, clears ownership, and marks the thread `error` in the same transaction when no other run is active.
 
-<a href="https://mermaid.live/view#pako:eNptk09PwkAQxb_K2FOJiCbeGjVpocIBpRZJLyZm3Y6wge7W_aMkxO_uLK2CQE9N9r3fezPtbgKuSgwiCAx-OJQcB4LNNateJNBTM20FFzWTFooYmIFC6SVqiI_Ps6E_z5Sxc43Tp_GxIkdWk5dU7VuoJCSdE8JGUwpzokayVyN5kY2iiC_u7rJhBP0VExVoJyFcITN4K9XX-fWV6ezpijiCdI3cWQSatV70er0DzAgp8g2ZhRDXFmUJW1rnN-9RkVd9UgUP6-fxdAThZPJwuRSrVeeUZkc0VtXmGORjxz4EcF0LjQZIa333X22ztbbhNB2n_WcoRmmeEpJZZ25pbCnkHOLHQdMXboDmD9tC2ZC8DSSCe-Voqiaq9As7OxEyywbx8x--pj0Qvguc4LpJODDlEeTZjJZBwFdRQqjxAiX9WW63uyJphMk4m2St33-VJGpdezJfIuYfjkqCxK_9zO25N-VoXIXwrlUFfIF8WSsh7QHk_yTGcY7GBF0IKtQVEyVdgU1gF1htL0PJ9DL4_v4BvGz9cA==" target="_blank" rel="noopener">View fullscreen ↗</a>
+<a href="https://mermaid.live/view#pako:eNptk19Po0AUxb_KlSfIancT34iaQMu2D12LtIYXk2Z2uLYTygzOH21i_O7eKbiybXkimXN_59wD8x5wVWEQQ2DwxaHkOBFso1nzJIGelmkruGiZtFAmwAyUSteoITk9z6f-PFfGbjQuH-anigJZS7Ok6t9CJSGNzgg7TSXMmRjpIEb6JDtFmVzd3eXTGMY7JhrQTkK4Q2bwVqq3H9e_TDTQlUkM2R65swi0a7sdjUZHmBmS5V9kFkLcW5QVHGjRl9-9oln1ShE8bFwkyxmEi8Wfn7XY7aJzmm-isao1pyBvO_cmgPtWaDRAWuuzf2m71vqEy2yejVdQzrIiIySzztzS2lLIDST3ky7vuketCXUDVEXYZ8unhOl4MfxWjhbspJXv7uKM32M-SVb_nFqqhJwugZOP7syAEYUf-reqxuPQRQxF_kg9kcFaVBBqvEJJP537rrVMO2E6zxd5P-8_WBr3UwOZD5XwF0ehQeJbnyF8pnW3wxjRYMaDCjSuQXjWqgG-RV63Skh7BP5_W-M4R2OCSwga1A0TFd2Y98BusTncnYrpOvj4-AROFg68" target="_blank" rel="noopener">View fullscreen ↗</a>
 
 ```mermaid
 sequenceDiagram
@@ -211,19 +243,19 @@ sequenceDiagram
 
     Note over PG: Lease expires at t+30s
 
-    Reaper->>PG: SELECT WHERE status=running AND lease < now()
+    Reaper->>PG: SELECT WHERE status=running AND lease_expires_at < now()
     PG->>Reaper: Found expired run!
-    Reaper->>PG: UPDATE status=pending, clear lease
+    Reaper->>PG: UPDATE status=pending, clear lease and claim token
     Reaper->>R: RPUSH run_id (re-enqueue)
 
     WB->>R: BLPOP
     R->>WB: run_id
-    WB->>PG: Acquire new lease
+    WB->>PG: Acquire new lease (fresh claim token)
     WB->>WB: Resume from checkpoint
     WB->>PG: UPDATE status=success
 ```
 
-The reaper runs on every instance (default every 15 seconds). This is safe — the atomic lease acquisition prevents duplicate execution.
+The reaper runs on every instance (default every 15 seconds). This is safe — the atomic lease acquisition prevents duplicate execution, and claim tokens keep the reaped attempt from writing a result after Worker B takes over.
 
 ## Graceful shutdown
 

--- a/libs/aegra-api/alembic/versions/20260823000000_add_run_claim_token.py
+++ b/libs/aegra-api/alembic/versions/20260823000000_add_run_claim_token.py
@@ -1,0 +1,33 @@
+"""Add claim_token to runs for per-acquisition lease fencing
+
+``claimed_by`` is a stable worker name (hostname-pid-worker-idx), so it is
+reused across acquisitions. A worker that stalls past its lease, gets reaped,
+and then re-acquires the same run still matches its own ownership predicates
+and can extend, release, or terminalize the replacement attempt (#502).
+
+``claim_token`` is regenerated on every acquisition, giving each attempt an
+identity that a stale attempt cannot forge.
+
+Revision ID: c9d0e1f2a345
+Revises: b88bb61be638
+Create Date: 2026-08-23 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c9d0e1f2a345"
+down_revision = "b88bb61be638"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("runs", sa.Column("claim_token", sa.Text(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("runs", "claim_token")

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.10.4"
+version = "0.10.5"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-api/src/aegra_api/core/orm.py
+++ b/libs/aegra-api/src/aegra_api/core/orm.py
@@ -180,6 +180,11 @@ class Run(Base):
     claimed_by: Mapped[str | None] = mapped_column(Text, nullable=True)
     lease_expires_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True), nullable=True)
 
+    # Fencing token, regenerated on every acquisition. ``claimed_by`` is a
+    # reusable worker name, so it cannot distinguish two attempts by the same
+    # worker; every ownership-predicated write matches on this instead (#502).
+    claim_token: Mapped[str | None] = mapped_column(Text, nullable=True)
+
     # Indexes for performance
     __table_args__ = (
         Index("idx_runs_thread_id", "thread_id"),

--- a/libs/aegra-api/src/aegra_api/core/orm.py
+++ b/libs/aegra-api/src/aegra_api/core/orm.py
@@ -180,9 +180,8 @@ class Run(Base):
     claimed_by: Mapped[str | None] = mapped_column(Text, nullable=True)
     lease_expires_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True), nullable=True)
 
-    # Fencing token, regenerated on every acquisition. ``claimed_by`` is a
-    # reusable worker name, so it cannot distinguish two attempts by the same
-    # worker; every ownership-predicated write matches on this instead (#502).
+    # Regenerated on every acquisition because reusable worker names cannot
+    # distinguish attempts; ownership-predicated writes match this token (#502).
     claim_token: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     # Indexes for performance

--- a/libs/aegra-api/src/aegra_api/services/lease_reaper.py
+++ b/libs/aegra-api/src/aegra_api/services/lease_reaper.py
@@ -8,11 +8,11 @@ re-enqueues only retryable run IDs.
 
 import asyncio
 import contextlib
-from datetime import UTC, datetime, timedelta
+from datetime import timedelta
 
 import structlog
 from redis import RedisError
-from sqlalchemy import select, update
+from sqlalchemy import Interval, func, literal, select, update
 
 from aegra_api.core.orm import Run as RunORM
 from aegra_api.core.orm import _get_session_maker
@@ -93,15 +93,18 @@ class LeaseReaper:
 
         Returns (crashed_run_ids, stuck_pending_run_ids) separately so retry
         budget is only charged to crashed runs, not stuck pending ones.
+
+        Both cut-offs are evaluated by Postgres: leases are written by workers on
+        other hosts, so comparing them against this process's clock lets skew
+        reap a lease that is still live (#502).
         """
-        now = datetime.now(UTC)
         maker = _get_session_maker()
         async with maker() as session:
             crashed_result = await session.execute(
                 select(RunORM.run_id).where(
                     RunORM.status == "running",
                     RunORM.lease_expires_at.isnot(None),
-                    RunORM.lease_expires_at < now,
+                    RunORM.lease_expires_at < func.now(),
                 )
             )
             crashed = [row[0] for row in crashed_result.fetchall()]
@@ -110,7 +113,9 @@ class LeaseReaper:
                 select(RunORM.run_id).where(
                     RunORM.status == "pending",
                     RunORM.claimed_by.is_(None),
-                    RunORM.created_at < now - timedelta(seconds=settings.worker.STUCK_PENDING_THRESHOLD_SECONDS),
+                    RunORM.created_at
+                    < func.now()
+                    - literal(timedelta(seconds=settings.worker.STUCK_PENDING_THRESHOLD_SECONDS), Interval),
                 )
             )
             stuck_pending = [row[0] for row in stuck_result.fetchall()]
@@ -120,7 +125,6 @@ class LeaseReaper:
     @staticmethod
     async def _recover_crashed_runs(run_ids: list[str]) -> tuple[list[str], list[str]]:
         """Atomically classify expired runs and apply their next state."""
-        now = datetime.now(UTC)
         max_retries = settings.worker.BG_JOB_MAX_RETRIES
         retryable: list[str] = []
         exhausted: list[str] = []
@@ -138,7 +142,7 @@ class LeaseReaper:
                 .where(
                     RunORM.run_id.in_(run_ids),
                     RunORM.status == "running",
-                    RunORM.lease_expires_at < now,
+                    RunORM.lease_expires_at < func.now(),
                 )
                 .with_for_update(skip_locked=True)
             )
@@ -151,8 +155,11 @@ class LeaseReaper:
                 values: dict[str, object] = {
                     "execution_params": params,
                     "claimed_by": None,
+                    # Clearing the token retires the expired attempt: any write
+                    # it still has in flight can no longer match (#502).
+                    "claim_token": None,
                     "lease_expires_at": None,
-                    "updated_at": now,
+                    "updated_at": func.now(),
                 }
                 is_exhausted = retry_count > max_retries
                 if is_exhausted:
@@ -169,7 +176,7 @@ class LeaseReaper:
                         RunORM.run_id == run_id,
                         RunORM.user_id == user_id,
                         RunORM.status == "running",
-                        RunORM.lease_expires_at < now,
+                        RunORM.lease_expires_at < func.now(),
                     )
                     .values(**values)
                     .returning(RunORM.run_id)

--- a/libs/aegra-api/src/aegra_api/services/run_executor.py
+++ b/libs/aegra-api/src/aegra_api/services/run_executor.py
@@ -37,11 +37,14 @@ _TIMEOUT_ERROR = "Job exceeded maximum execution time"
 _TIMEOUT_SAFE_MESSAGE = "TimeoutError: execution failed"
 
 
-async def execute_run(job: RunJob) -> None:
+async def execute_run(job: RunJob, *, claim_token: str | None = None) -> None:
     """Execute a graph run, stream events to the broker, and update DB.
 
     Handles the full lifecycle: status transitions, event streaming,
     interrupt detection, cancellation, and error signaling.
+
+    ``claim_token`` fences every terminal write on the worker's acquisition of
+    this run; LocalExecutor holds no lease and passes none (#502).
     """
     run_id = job.identity.run_id
     thread_id = job.identity.thread_id
@@ -64,6 +67,7 @@ async def execute_run(job: RunJob) -> None:
                 status="interrupted",
                 thread_status="interrupted",
                 output=final_output.data,
+                claim_token=claim_token,
             )
         else:
             finalized = await finalize_run(
@@ -73,6 +77,7 @@ async def execute_run(job: RunJob) -> None:
                 status="success",
                 thread_status="idle",
                 output=final_output.data,
+                claim_token=claim_token,
             )
 
     except asyncio.CancelledError:
@@ -93,6 +98,7 @@ async def execute_run(job: RunJob) -> None:
                 thread_status="error",
                 output={},
                 error=_TIMEOUT_ERROR,
+                claim_token=claim_token,
             )
             if finalized:
                 await _best_effort_signal(
@@ -109,6 +115,7 @@ async def execute_run(job: RunJob) -> None:
                 status="interrupted",
                 thread_status="idle",
                 output={},
+                claim_token=claim_token,
             )
             if finalized:
                 await _best_effort_signal(streaming_service.signal_run_cancelled, run_id)
@@ -124,6 +131,7 @@ async def execute_run(job: RunJob) -> None:
             thread_status="error",
             output={},
             error=str(exc),
+            claim_token=claim_token,
         )
         if finalized:
             await _best_effort_signal(streaming_service.signal_run_error, run_id, safe_message, type(exc).__name__)
@@ -136,7 +144,9 @@ async def execute_run(job: RunJob) -> None:
         _shutdown_cancellations.discard(run_id)
         _timeout_cancellations.discard(run_id)
         active_runs.pop(run_id, None)
-        if not resumes_elsewhere:
+        # Only the attempt that won terminalization may tear the broker down:
+        # a rejected write means another attempt is still streaming (#502).
+        if not resumes_elsewhere and finalized:
             await streaming_service.cleanup_run(run_id)
             await _signal_run_done(run_id)
 

--- a/libs/aegra-api/src/aegra_api/services/run_status.py
+++ b/libs/aegra-api/src/aegra_api/services/run_status.py
@@ -134,6 +134,7 @@ async def interrupt_unowned_run(
             .values(
                 status="interrupted",
                 claimed_by=None,
+                claim_token=None,
                 lease_expires_at=None,
                 updated_at=now,
             )
@@ -158,11 +159,18 @@ async def finalize_run(
     thread_status: str,
     output: Any = None,
     error: str | None = None,
+    claim_token: str | None = None,
 ) -> bool:
     """Conditionally update run and thread status in one transaction.
 
-    Returns false when another actor has already made the run terminal. This
-    prevents an expired worker from overwriting a reconciled cancellation.
+    Returns false when another actor has already made the run terminal, or when
+    ``claim_token`` no longer matches the acquisition that owns the run — a
+    reaped worker must not overwrite the output of the attempt that replaced it
+    (#502). Callers with no lease (LocalExecutor, API-side cancellation) pass no
+    token and are guarded by the active-status predicate alone.
+
+    Terminalizing clears the lease in the same statement, so a run can never be
+    left terminal while still advertising an owner.
     """
     validated_run = validate_run_status(status)
     validated_thread = validate_thread_status(thread_status)
@@ -171,26 +179,28 @@ async def finalize_run(
     run_values: dict[str, Any] = {
         "status": validated_run,
         "updated_at": datetime.now(UTC),
+        "claimed_by": None,
+        "claim_token": None,
+        "lease_expires_at": None,
     }
     if output is not None:
         run_values["output"] = _safe_serialize(output, run_id)
     if error is not None:
         run_values["error_message"] = error
 
+    predicates = [
+        RunORM.run_id == run_id,
+        RunORM.user_id == user_id,
+        RunORM.status.in_(ACTIVE_RUN_STATES),
+    ]
+    if claim_token is not None:
+        predicates.append(RunORM.claim_token == claim_token)
+
     async with maker() as session:
-        result = await session.execute(
-            update(RunORM)
-            .where(
-                RunORM.run_id == run_id,
-                RunORM.user_id == user_id,
-                RunORM.status.in_(ACTIVE_RUN_STATES),
-            )
-            .values(**run_values)
-            .returning(RunORM.run_id)
-        )
+        result = await session.execute(update(RunORM).where(*predicates).values(**run_values).returning(RunORM.run_id))
         if result.scalar_one_or_none() is None:
             await session.rollback()
-            logger.info("Skipped finalizing terminal run", run_id=run_id, status=validated_run)
+            logger.info("Skipped finalizing run without ownership", run_id=run_id, status=validated_run)
             return False
 
         await set_thread_status_if_no_active_runs(

--- a/libs/aegra-api/src/aegra_api/services/worker_executor.py
+++ b/libs/aegra-api/src/aegra_api/services/worker_executor.py
@@ -674,8 +674,16 @@ async def _heartbeat_loop(
 
     while True:
         await asyncio.sleep(interval)
-        # Never spend more than the lease has left, so the checks below are always reached.
-        rowcount = await _renew_lease(run_id, claim_token, timeout=max(1.0, expires_at - loop.time()))
+
+        # Past expiry the reaper may already have handed this run to a replacement,
+        # so a renewal must never be allowed to run beyond what the lease has left.
+        budget = expires_at - loop.time()
+        if budget <= 0:
+            logger.warning("Lease ran out before the heartbeat woke, abandoning run", run_id=run_id, worker=worker_name)
+            _abandon_run(run_id, job_task)
+            return
+
+        rowcount = await _renew_lease(run_id, claim_token, timeout=budget)
 
         if rowcount is None:
             if loop.time() < expires_at - interval:

--- a/libs/aegra-api/src/aegra_api/services/worker_executor.py
+++ b/libs/aegra-api/src/aegra_api/services/worker_executor.py
@@ -627,7 +627,8 @@ async def _renew_lease(run_id: str, claim_token: str) -> int | None:
                 .values(lease_expires_at=_lease_deadline())
             )
             await session.commit()
-    except Exception:
+    except Exception as exc:
+        logger.warning("Lease renewal failed", run_id=run_id, error=str(exc), exc_info=True)
         return None
     return result.rowcount  # type: ignore[union-attr]
 

--- a/libs/aegra-api/src/aegra_api/services/worker_executor.py
+++ b/libs/aegra-api/src/aegra_api/services/worker_executor.py
@@ -14,13 +14,15 @@ import contextvars
 import os
 import re
 import socket
+import uuid
 from datetime import UTC, datetime, timedelta
+from typing import Any
 
 import structlog
 from asgi_correlation_id import correlation_id
 from redis import RedisError
 from redis import TimeoutError as RedisTimeoutError
-from sqlalchemy import select, update
+from sqlalchemy import Interval, func, literal, select, update
 
 from aegra_api.core.active_runs import active_runs, explicit_run_cancellations
 from aegra_api.core.orm import Run as RunORM
@@ -35,7 +37,7 @@ from aegra_api.services.run_executor import (
     _timeout_cancellations,
     execute_run,
 )
-from aegra_api.services.run_status import finalize_run
+from aegra_api.services.run_status import ACTIVE_RUN_STATES, finalize_run
 from aegra_api.settings import settings
 
 logger = structlog.getLogger(__name__)
@@ -50,13 +52,43 @@ def _is_valid_run_id(value: str) -> bool:
     return bool(_RUN_ID_PATTERN.match(value))
 
 
-async def _cleanup_cancelled_execution(run_id: str, execution_task: asyncio.Task[None]) -> None:
+class _ClaimSlot:
+    """Shares the token minted inside ``_execute_with_lease`` with its supervisor.
+
+    The timeout and explicit-cancel paths live one frame up, but must still
+    fence their writes on the acquisition that frame owns (#502).
+    """
+
+    __slots__ = ("token",)
+
+    def __init__(self) -> None:
+        self.token: str | None = None
+
+
+def _lease_deadline() -> Any:
+    """Lease expiry evaluated by Postgres.
+
+    Workers and the reaper run on different hosts; a Python-side deadline is
+    compared against another machine's clock, so skew can expire a live lease.
+    """
+    return func.now() + literal(timedelta(seconds=settings.worker.LEASE_DURATION_SECONDS), Interval)
+
+
+async def _cleanup_cancelled_execution(
+    run_id: str,
+    execution_task: asyncio.Task[None],
+    claim: _ClaimSlot,
+) -> None:
     """Stop execution and persist an explicit cancellation when applicable."""
     if not execution_task.done():
         execution_task.cancel()
     await asyncio.gather(execution_task, return_exceptions=True)
 
     if run_id not in explicit_run_cancellations:
+        return
+
+    if claim.token is None:
+        logger.info("Explicit cancel without a held claim, leaving finalization to the owner", run_id=run_id)
         return
 
     try:
@@ -72,6 +104,7 @@ async def _cleanup_cancelled_execution(run_id: str, execution_task: asyncio.Task
             status="interrupted",
             thread_status="idle",
             output={},
+            claim_token=claim.token,
         )
     except Exception:
         logger.exception("Failed to persist explicit run cancellation", run_id=run_id)
@@ -271,7 +304,8 @@ class WorkerExecutor(BaseExecutor):
         current_task = asyncio.current_task()
         if current_task is not None:
             active_runs[run_id] = current_task
-        execution_task = asyncio.create_task(self._execute_with_lease(run_id, worker_name))
+        claim = _ClaimSlot()
+        execution_task = asyncio.create_task(self._execute_with_lease(run_id, worker_name, claim))
         try:
             done, _ = await asyncio.wait(
                 {execution_task},
@@ -290,21 +324,10 @@ class WorkerExecutor(BaseExecutor):
                 execution_task.cancel()
                 await asyncio.gather(execution_task, return_exceptions=True)
 
-                identity = await _get_run_identity(run_id)
-                if identity is not None:
-                    thread_id, user_id = identity
-                    await finalize_run(
-                        run_id,
-                        thread_id,
-                        user_id=user_id,
-                        status="error",
-                        thread_status="error",
-                        error="Job exceeded maximum execution time",
-                    )
-                await _release_lease(run_id, worker_name)
+                await _finalize_timed_out_run(run_id, claim)
         except asyncio.CancelledError:
             logger.info("Job task cancelled", worker=worker_name, run_id=run_id)
-            cleanup_task = asyncio.create_task(_cleanup_cancelled_execution(run_id, execution_task))
+            cleanup_task = asyncio.create_task(_cleanup_cancelled_execution(run_id, execution_task, claim))
             await _await_cancellation_cleanup(cleanup_task)
             raise
         except Exception:
@@ -337,13 +360,14 @@ class WorkerExecutor(BaseExecutor):
             await asyncio.sleep(settings.worker.POSTGRES_POLL_INTERVAL_SECONDS)
             return await self._poll_postgres()
 
-    async def _execute_with_lease(self, run_id: str, worker_name: str) -> None:
+    async def _execute_with_lease(self, run_id: str, worker_name: str, claim: _ClaimSlot) -> None:
         """Acquire lease, load job from DB, execute with heartbeat."""
         lease_acquired_at = datetime.now(UTC)
         loaded = await _acquire_and_load(run_id, worker_name)
         if loaded is None:
             logger.debug("Lease not acquired or job missing, skipping", run_id=run_id, worker=worker_name)
             return
+        claim.token = loaded.claim_token
 
         _restore_trace_context(run_id, loaded.job, loaded.trace)
         logger.info(
@@ -354,9 +378,9 @@ class WorkerExecutor(BaseExecutor):
         )
         # Wrap execute_run in a task so the heartbeat can cancel it on
         # lease loss, preventing double execution by a second worker.
-        job_task = asyncio.create_task(execute_run(loaded.job))
+        job_task = asyncio.create_task(execute_run(loaded.job, claim_token=loaded.claim_token))
         heartbeat_task = asyncio.create_task(
-            _heartbeat_loop(run_id, worker_name, job_task=job_task),
+            _heartbeat_loop(run_id, worker_name, loaded.claim_token, job_task=job_task),
             context=contextvars.copy_context(),
         )
 
@@ -376,7 +400,7 @@ class WorkerExecutor(BaseExecutor):
             heartbeat_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await asyncio.gather(job_task, heartbeat_task, return_exceptions=True)
-            await _release_lease(run_id, worker_name)
+            await _release_lease(run_id, loaded.claim_token)
 
             elapsed = (datetime.now(UTC) - lease_acquired_at).total_seconds()
             logger.info(
@@ -416,29 +440,59 @@ async def _get_run_identity(run_id: str) -> tuple[str, str] | None:
         return row.thread_id, row.user_id
 
 
+async def _finalize_timed_out_run(run_id: str, claim: _ClaimSlot) -> None:
+    """Backstop terminalization for a job killed at BG_JOB_TIMEOUT_SECS.
+
+    ``execute_run`` normally finalizes on the timeout cancellation itself; this
+    covers the case where it never got that far. Without a held claim there is
+    nothing to fence the write with, so the reaper handles the row instead.
+    """
+    if claim.token is None:
+        return
+
+    identity = await _get_run_identity(run_id)
+    if identity is None:
+        return
+
+    thread_id, user_id = identity
+    await finalize_run(
+        run_id,
+        thread_id,
+        user_id=user_id,
+        status="error",
+        thread_status="error",
+        error="Job exceeded maximum execution time",
+        claim_token=claim.token,
+    )
+
+
 # ------------------------------------------------------------------
 # Lease operations (module-level for reuse by LeaseReaper)
 # ------------------------------------------------------------------
 
 
 class _LoadedRun:
-    """RunJob plus raw trace metadata from execution_params."""
+    """RunJob plus the acquisition's claim token and raw trace metadata."""
 
-    __slots__ = ("job", "trace")
+    __slots__ = ("claim_token", "job", "trace")
 
-    def __init__(self, job: RunJob, trace: dict[str, str]) -> None:
+    def __init__(self, job: RunJob, trace: dict[str, str], claim_token: str) -> None:
         self.job = job
         self.trace = trace
+        self.claim_token = claim_token
 
 
 async def _acquire_and_load(run_id: str, worker_name: str) -> _LoadedRun | None:
     """Acquire lease and load job in a single DB session.
 
-    Combines the lease UPDATE + job SELECT into one session. If the row
-    is missing execution_params (data corruption / pre-migration row),
-    releases the claim and marks the run as errored.
+    Combines the lease UPDATE + job SELECT into one session. Each acquisition
+    mints a fresh ``claim_token``: ``claimed_by`` is a stable worker name, so a
+    reaped attempt would otherwise still satisfy its own ownership predicates
+    after the same worker re-acquires the run (#502). If the row is missing
+    execution_params (data corruption / pre-migration row), releases the claim
+    and marks the run as errored.
     """
-    lease_until = datetime.now(UTC) + timedelta(seconds=settings.worker.LEASE_DURATION_SECONDS)
+    claim_token = str(uuid.uuid4())
     maker = _get_session_maker()
     async with maker() as session:
         result = await session.execute(
@@ -448,7 +502,12 @@ async def _acquire_and_load(run_id: str, worker_name: str) -> _LoadedRun | None:
                 RunORM.status == "pending",
                 RunORM.claimed_by.is_(None),
             )
-            .values(claimed_by=worker_name, lease_expires_at=lease_until, status="running")
+            .values(
+                claimed_by=worker_name,
+                claim_token=claim_token,
+                lease_expires_at=_lease_deadline(),
+                status="running",
+            )
         )
         if result.rowcount == 0:  # type: ignore[union-attr]
             await session.rollback()
@@ -465,9 +524,10 @@ async def _acquire_and_load(run_id: str, worker_name: str) -> _LoadedRun | None:
             )
             await session.execute(
                 update(RunORM)
-                .where(RunORM.run_id == run_id, RunORM.claimed_by == worker_name)
+                .where(RunORM.run_id == run_id, RunORM.claim_token == claim_token)
                 .values(
                     claimed_by=None,
+                    claim_token=None,
                     lease_expires_at=None,
                     status="error",
                     error_message="Run missing execution_params (data corruption or pre-migration row)",
@@ -478,7 +538,7 @@ async def _acquire_and_load(run_id: str, worker_name: str) -> _LoadedRun | None:
 
         job = RunJob.from_run_orm(run_orm)
         trace = run_orm.execution_params.get("trace", {})
-        return _LoadedRun(job=job, trace=trace)
+        return _LoadedRun(job=job, trace=trace, claim_token=claim_token)
 
 
 async def _push_back(run_id: str) -> None:
@@ -502,7 +562,7 @@ async def _requeue_drained_runs(run_ids: list[str]) -> None:
         result = await session.execute(
             update(RunORM)
             .where(RunORM.run_id.in_(run_ids), RunORM.status.in_(["running", "pending"]))
-            .values(status="pending", claimed_by=None, lease_expires_at=None)
+            .values(status="pending", claimed_by=None, claim_token=None, lease_expires_at=None)
             .returning(RunORM.run_id)
         )
         reset_ids = [row[0] for row in result.fetchall()]
@@ -527,57 +587,107 @@ async def _requeue_drained_runs(run_ids: list[str]) -> None:
         )
 
 
-async def _release_lease(run_id: str, worker_name: str) -> None:
-    """Clear lease fields after job completion, only if this worker still owns the lease."""
+async def _release_lease(run_id: str, claim_token: str) -> None:
+    """Clear a leftover lease once this attempt's run is terminal.
+
+    ``finalize_run`` already clears the lease in the same statement that
+    terminalizes, so this only mops up paths that ended without finalizing.
+    Both predicates matter: on the token, because a reaped attempt releasing on
+    its worker name would strip the lease off its own replacement; on terminal
+    status, because clearing a still-running row leaves it with neither an owner
+    nor an expiry, which no reaper query can see (#502).
+    """
     maker = _get_session_maker()
     async with maker() as session:
         await session.execute(
             update(RunORM)
-            .where(RunORM.run_id == run_id, RunORM.claimed_by == worker_name)
-            .values(claimed_by=None, lease_expires_at=None)
+            .where(
+                RunORM.run_id == run_id,
+                RunORM.claim_token == claim_token,
+                RunORM.status.not_in(ACTIVE_RUN_STATES),
+            )
+            .values(claimed_by=None, claim_token=None, lease_expires_at=None)
         )
         await session.commit()
+
+
+async def _renew_lease(run_id: str, claim_token: str) -> int | None:
+    """Extend one attempt's lease. Returns the matched row count, or None on failure.
+
+    The catch is deliberately broad: every failure mode here (driver error,
+    pool exhaustion, DNS, timeout) has the same consequence — the lease keeps
+    counting down unrenewed — so the caller treats them identically.
+    """
+    maker = _get_session_maker()
+    try:
+        async with maker() as session:
+            result = await session.execute(
+                update(RunORM)
+                .where(RunORM.run_id == run_id, RunORM.claim_token == claim_token)
+                .values(lease_expires_at=_lease_deadline())
+            )
+            await session.commit()
+    except Exception:
+        return None
+    return result.rowcount  # type: ignore[union-attr]
+
+
+def _abandon_run(run_id: str, job_task: asyncio.Task[None] | None) -> None:
+    """Stop executing without finalizing — the run is no longer ours to write."""
+    if job_task is None or job_task.done():
+        return
+    _lease_loss_cancellations.add(run_id)
+    job_task.cancel()
 
 
 async def _heartbeat_loop(
     run_id: str,
     worker_name: str,
+    claim_token: str,
     *,
     job_task: asyncio.Task[None] | None = None,
 ) -> None:
     """Extend lease periodically while the job is running.
 
-    If the lease is lost (another worker claimed the run), cancels
-    ``job_task`` to prevent double execution.
+    Cancels ``job_task`` when the run is claimed by another attempt, and also
+    when renewal keeps failing: an unreachable database means the lease expires
+    on its own while the graph runs on, so the worker must stop before the
+    reaper can hand the run to somebody else (#502).
     """
     interval = settings.worker.HEARTBEAT_INTERVAL_SECONDS
     duration = settings.worker.LEASE_DURATION_SECONDS
-    maker = _get_session_maker()
+    loop = asyncio.get_running_loop()
+    # Monotonic mirror of the lease the database holds, so a failing heartbeat
+    # can tell "transient blip, retry" from "out of runway, stop now".
+    expires_at = loop.time() + duration
 
     while True:
         await asyncio.sleep(interval)
-        try:
-            new_expiry = datetime.now(UTC) + timedelta(seconds=duration)
-            async with maker() as session:
-                result = await session.execute(
-                    update(RunORM)
-                    .where(RunORM.run_id == run_id, RunORM.claimed_by == worker_name)
-                    .values(lease_expires_at=new_expiry)
-                )
-                await session.commit()
-            if result.rowcount == 0:  # type: ignore[union-attr]
-                logger.warning(
-                    "Lease lost, cancelling job to prevent double execution",
-                    run_id=run_id,
-                    worker=worker_name,
-                )
-                if job_task is not None and not job_task.done():
-                    _lease_loss_cancellations.add(run_id)
-                    job_task.cancel()
-                return
-            logger.debug("Lease extended", run_id=run_id, worker=worker_name)
-        except Exception:
-            logger.warning("Heartbeat lease extension failed", run_id=run_id, worker=worker_name)
+        rowcount = await _renew_lease(run_id, claim_token)
+
+        if rowcount is None:
+            if loop.time() < expires_at - interval:
+                logger.warning("Heartbeat lease extension failed, retrying", run_id=run_id, worker=worker_name)
+                continue
+            logger.warning(
+                "Heartbeat cannot renew before lease expiry, abandoning run",
+                run_id=run_id,
+                worker=worker_name,
+            )
+            _abandon_run(run_id, job_task)
+            return
+
+        if rowcount == 0:
+            logger.warning(
+                "Lease lost, cancelling job to prevent double execution",
+                run_id=run_id,
+                worker=worker_name,
+            )
+            _abandon_run(run_id, job_task)
+            return
+
+        expires_at = loop.time() + duration
+        logger.debug("Lease extended", run_id=run_id, worker=worker_name)
 
 
 async def _is_run_terminal(run_id: str) -> bool:

--- a/libs/aegra-api/src/aegra_api/services/worker_executor.py
+++ b/libs/aegra-api/src/aegra_api/services/worker_executor.py
@@ -611,8 +611,12 @@ async def _release_lease(run_id: str, claim_token: str) -> None:
         await session.commit()
 
 
-async def _renew_lease(run_id: str, claim_token: str) -> int | None:
+async def _renew_lease(run_id: str, claim_token: str, *, timeout: float) -> int | None:
     """Extend one attempt's lease. Returns the matched row count, or None on failure.
+
+    ``timeout`` must not outlast the lease: a renewal that blocks on pool
+    acquisition or commit would otherwise keep the heartbeat parked inside this
+    call while the reaper hands the run to a replacement (#502).
 
     The catch is deliberately broad: every failure mode here (driver error,
     pool exhaustion, DNS, timeout) has the same consequence — the lease keeps
@@ -620,17 +624,23 @@ async def _renew_lease(run_id: str, claim_token: str) -> int | None:
     """
     maker = _get_session_maker()
     try:
-        async with maker() as session:
-            result = await session.execute(
-                update(RunORM)
-                .where(RunORM.run_id == run_id, RunORM.claim_token == claim_token)
-                .values(lease_expires_at=_lease_deadline())
-            )
-            await session.commit()
+        result = await asyncio.wait_for(_renew_lease_once(run_id, claim_token, maker), timeout=timeout)
     except Exception as exc:
         logger.warning("Lease renewal failed", run_id=run_id, error=str(exc), exc_info=True)
         return None
-    return result.rowcount  # type: ignore[union-attr]
+    return result
+
+
+async def _renew_lease_once(run_id: str, claim_token: str, maker: Any) -> int:
+    """Single fenced lease-extension round trip."""
+    async with maker() as session:
+        result = await session.execute(
+            update(RunORM)
+            .where(RunORM.run_id == run_id, RunORM.claim_token == claim_token)
+            .values(lease_expires_at=_lease_deadline())
+        )
+        await session.commit()
+    return result.rowcount
 
 
 def _abandon_run(run_id: str, job_task: asyncio.Task[None] | None) -> None:
@@ -664,7 +674,8 @@ async def _heartbeat_loop(
 
     while True:
         await asyncio.sleep(interval)
-        rowcount = await _renew_lease(run_id, claim_token)
+        # Never spend more than the lease has left, so the checks below are always reached.
+        rowcount = await _renew_lease(run_id, claim_token, timeout=max(1.0, expires_at - loop.time()))
 
         if rowcount is None:
             if loop.time() < expires_at - interval:

--- a/libs/aegra-api/tests/e2e/test_runs/test_run_reconciliation_e2e.py
+++ b/libs/aegra-api/tests/e2e/test_runs/test_run_reconciliation_e2e.py
@@ -30,6 +30,7 @@ async def _seed_run(
     run_status: str,
     thread_status: str,
     claimed_by: str | None = None,
+    claim_token: str | None = None,
     lease_expires_at: datetime | None = None,
     execution_params: dict[str, Any] | None = None,
     additional_run_status: str | None = None,
@@ -77,6 +78,7 @@ async def _seed_run(
                 user_id="anonymous",
                 execution_params=execution_params,
                 claimed_by=claimed_by,
+                claim_token=claim_token,
                 lease_expires_at=lease_expires_at,
                 created_at=now,
                 updated_at=now,
@@ -342,3 +344,48 @@ async def test_retry_exhaustion_marks_run_and_thread_error() -> None:
         assert run.claimed_by is None
         assert run.lease_expires_at is None
         assert thread.status == "error"
+
+
+@pytest.mark.e2e
+@pytest.mark.prod_only
+async def test_reaped_worker_cannot_terminalize_after_the_reaper_reclaims_its_run() -> None:
+    """Regression (#502): the reaper retires the expired attempt's claim token, so
+    a worker that comes back late can no longer write a result for the run."""
+    stale_token = str(uuid4())
+    expired = datetime.now(UTC) - timedelta(minutes=1)
+    async with _seed_run(
+        run_status="running",
+        thread_status="busy",
+        claimed_by="stalled-worker",
+        claim_token=stale_token,
+        lease_expires_at=expired,
+    ) as (thread_id, run_id):
+        deadline = asyncio.get_running_loop().time() + settings.worker.REAPER_INTERVAL_SECONDS * 2 + 5
+        while True:
+            run, _thread = await _read_state(thread_id, run_id)
+            if run.claim_token != stale_token or asyncio.get_running_loop().time() >= deadline:
+                break
+            await asyncio.sleep(0.5)
+
+        elog("Post-reap state", {"run_status": run.status, "claim_token": run.claim_token})
+        assert run.claim_token != stale_token, "reaper must retire the expired attempt's token"
+
+        engine = create_async_engine(settings.db.database_url)
+        maker = async_sessionmaker(engine, expire_on_commit=False)
+        try:
+            with patch("aegra_api.services.run_status._get_session_maker", return_value=maker):
+                finalized = await finalize_run(
+                    run_id,
+                    thread_id,
+                    user_id="anonymous",
+                    status="success",
+                    thread_status="idle",
+                    output={"from": "stalled-worker"},
+                    claim_token=stale_token,
+                )
+        finally:
+            await engine.dispose()
+
+        run, _thread = await _read_state(thread_id, run_id)
+        assert finalized is False
+        assert run.output != {"from": "stalled-worker"}

--- a/libs/aegra-api/tests/integration/test_lease_fencing_db.py
+++ b/libs/aegra-api/tests/integration/test_lease_fencing_db.py
@@ -163,7 +163,7 @@ async def test_reaped_attempt_cannot_renew_or_release_the_replacement_lease() ->
         live = await _acquire_and_load(run_id, _WORKER)
         assert live is not None
 
-        assert await _renew_lease(run_id, stale.claim_token) == 0
+        assert await _renew_lease(run_id, stale.claim_token, timeout=10) == 0
         await _release_lease(run_id, stale.claim_token)
 
         row = await _row(maker, run_id)

--- a/libs/aegra-api/tests/integration/test_lease_fencing_db.py
+++ b/libs/aegra-api/tests/integration/test_lease_fencing_db.py
@@ -7,13 +7,13 @@ against a real database and assert which attempt is allowed to win.
 
 from collections.abc import AsyncIterator
 from contextlib import ExitStack, asynccontextmanager
-from datetime import UTC, datetime, timedelta
+from datetime import timedelta
 from unittest.mock import patch
 from uuid import uuid4
 
 import asyncpg
 import pytest
-from sqlalchemy import delete, select, text, update
+from sqlalchemy import Interval, delete, func, literal, select, text, update
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker, create_async_engine
 
@@ -113,12 +113,16 @@ async def _pending_run() -> AsyncIterator[tuple[async_sessionmaker, str, str]]:
 
 
 async def _expire_lease(maker: async_sessionmaker, run_id: str) -> None:
-    """Backdate the lease so the reaper treats the holder as crashed."""
+    """Backdate the lease so the reaper treats the holder as crashed.
+
+    Uses the database clock: the reaper compares against ``now()``, so a value
+    written from the test runner's clock could still be in Postgres's future.
+    """
     async with maker() as session:
         await session.execute(
             update(RunORM)
             .where(RunORM.run_id == run_id)
-            .values(lease_expires_at=datetime.now(UTC) - timedelta(seconds=1))
+            .values(lease_expires_at=func.now() - literal(timedelta(minutes=1), Interval))
         )
         await session.commit()
 

--- a/libs/aegra-api/tests/integration/test_lease_fencing_db.py
+++ b/libs/aegra-api/tests/integration/test_lease_fencing_db.py
@@ -1,0 +1,246 @@
+"""Real-PostgreSQL regression tests for per-acquisition lease fencing (#502).
+
+The fence lives entirely in SQL predicates, so mocked sessions can only prove
+the statements are shaped right. These exercise the pause/reap/reclaim sequence
+against a real database and assert which attempt is allowed to win.
+"""
+
+from collections.abc import AsyncIterator
+from contextlib import ExitStack, asynccontextmanager
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
+from uuid import uuid4
+
+import asyncpg
+import pytest
+from sqlalchemy import delete, select, text, update
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncEngine, async_sessionmaker, create_async_engine
+
+from aegra_api.core.orm import Run as RunORM
+from aegra_api.core.orm import Thread as ThreadORM
+from aegra_api.services.lease_reaper import LeaseReaper
+from aegra_api.services.run_status import finalize_run
+from aegra_api.services.worker_executor import _acquire_and_load, _release_lease, _renew_lease
+from aegra_api.settings import settings
+
+_USER_ID = "lease-fencing-test-user"
+_WORKER = "test-host-1234-worker-0"
+
+_EXECUTION_PARAMS = {
+    "graph_id": "test-graph",
+    "user": {"identity": _USER_ID, "is_authenticated": True, "permissions": []},
+    "execution": {
+        "input_data": {},
+        "config": {},
+        "context": {},
+        "stream_mode": None,
+        "checkpoint": None,
+        "command": None,
+        "event_streaming_v2": False,
+    },
+    "behavior": {
+        "interrupt_before": None,
+        "interrupt_after": None,
+        "multitask_strategy": None,
+        "subgraphs": False,
+    },
+    "run_metadata": {},
+}
+
+
+async def _skip_unless_schema_ready(engine: AsyncEngine) -> None:
+    """Skip when the test database is unreachable or unmigrated."""
+    claim_token_column = None
+    try:
+        async with engine.begin() as conn:
+            claim_token_column = await conn.scalar(
+                text(
+                    "SELECT column_name FROM information_schema.columns "
+                    "WHERE table_name = 'runs' AND column_name = 'claim_token'"
+                )
+            )
+    except (SQLAlchemyError, asyncpg.PostgresError, OSError) as exc:
+        pytest.skip(f"PostgreSQL test database is unavailable: {exc}")
+    if claim_token_column is None:
+        pytest.skip("runs.claim_token is missing; run Alembic migrations before this DB regression test")
+
+
+# The services under test resolve their sessions through the app-wide manager,
+# which only exists inside a running server; point all three at the test engine.
+_SESSION_MAKER_TARGETS = (
+    "aegra_api.services.worker_executor._get_session_maker",
+    "aegra_api.services.lease_reaper._get_session_maker",
+    "aegra_api.services.run_status._get_session_maker",
+)
+
+
+@asynccontextmanager
+async def _pending_run() -> AsyncIterator[tuple[async_sessionmaker, str, str]]:
+    """Seed a busy thread with one pending run; always clean up and dispose."""
+    engine = create_async_engine(settings.db.database_url)
+    await _skip_unless_schema_ready(engine)
+
+    maker = async_sessionmaker(engine, expire_on_commit=False)
+    thread_id = f"fencing-thread-{uuid4()}"
+    run_id = str(uuid4())
+
+    async with maker() as session:
+        session.add(ThreadORM(thread_id=thread_id, status="busy", user_id=_USER_ID))
+        await session.flush()
+        session.add(
+            RunORM(
+                run_id=run_id,
+                thread_id=thread_id,
+                status="pending",
+                user_id=_USER_ID,
+                execution_params=_EXECUTION_PARAMS,
+            )
+        )
+        await session.commit()
+
+    try:
+        with ExitStack() as stack:
+            for target in _SESSION_MAKER_TARGETS:
+                stack.enter_context(patch(target, return_value=maker))
+            yield maker, thread_id, run_id
+    finally:
+        async with maker() as session:
+            await session.execute(delete(RunORM).where(RunORM.thread_id == thread_id))
+            await session.execute(delete(ThreadORM).where(ThreadORM.thread_id == thread_id))
+            await session.commit()
+        await engine.dispose()
+
+
+async def _expire_lease(maker: async_sessionmaker, run_id: str) -> None:
+    """Backdate the lease so the reaper treats the holder as crashed."""
+    async with maker() as session:
+        await session.execute(
+            update(RunORM)
+            .where(RunORM.run_id == run_id)
+            .values(lease_expires_at=datetime.now(UTC) - timedelta(seconds=1))
+        )
+        await session.commit()
+
+
+async def _row(maker: async_sessionmaker, run_id: str) -> RunORM:
+    async with maker() as session:
+        run = await session.scalar(select(RunORM).where(RunORM.run_id == run_id))
+        assert run is not None
+        return run
+
+
+@pytest.mark.asyncio
+async def test_same_worker_reclaiming_a_reaped_run_gets_a_new_token() -> None:
+    async with _pending_run() as (maker, _thread_id, run_id):
+        first = await _acquire_and_load(run_id, _WORKER)
+        assert first is not None
+
+        await _expire_lease(maker, run_id)
+        retryable, exhausted = await LeaseReaper._recover_crashed_runs([run_id])
+        assert retryable == [run_id]
+        assert exhausted == []
+        assert (await _row(maker, run_id)).claim_token is None
+
+        second = await _acquire_and_load(run_id, _WORKER)
+        assert second is not None
+        assert second.claim_token != first.claim_token
+
+
+@pytest.mark.asyncio
+async def test_reaped_attempt_cannot_renew_or_release_the_replacement_lease() -> None:
+    """Regression: releasing on the reusable worker name stripped the lease off
+    the replacement, leaving a running row no reaper query can see."""
+    async with _pending_run() as (maker, _thread_id, run_id):
+        stale = await _acquire_and_load(run_id, _WORKER)
+        assert stale is not None
+        await _expire_lease(maker, run_id)
+        await LeaseReaper._recover_crashed_runs([run_id])
+        live = await _acquire_and_load(run_id, _WORKER)
+        assert live is not None
+
+        assert await _renew_lease(run_id, stale.claim_token) == 0
+        await _release_lease(run_id, stale.claim_token)
+
+        row = await _row(maker, run_id)
+        assert row.status == "running"
+        assert row.claim_token == live.claim_token
+        assert row.lease_expires_at is not None, "the replacement must stay visible to the reaper"
+
+
+@pytest.mark.asyncio
+async def test_only_the_live_attempt_can_terminalize_the_run() -> None:
+    """Regression: a late finish from a reaped worker overwrote the replacement's
+    output, making the surviving result non-deterministic."""
+    async with _pending_run() as (maker, thread_id, run_id):
+        stale = await _acquire_and_load(run_id, _WORKER)
+        assert stale is not None
+        await _expire_lease(maker, run_id)
+        await LeaseReaper._recover_crashed_runs([run_id])
+        live = await _acquire_and_load(run_id, _WORKER)
+        assert live is not None
+
+        stale_won = await finalize_run(
+            run_id,
+            thread_id,
+            user_id=_USER_ID,
+            status="success",
+            thread_status="idle",
+            output={"from": "stale"},
+            claim_token=stale.claim_token,
+        )
+        assert stale_won is False
+
+        live_won = await finalize_run(
+            run_id,
+            thread_id,
+            user_id=_USER_ID,
+            status="success",
+            thread_status="idle",
+            output={"from": "live"},
+            claim_token=live.claim_token,
+        )
+        assert live_won is True
+
+        row = await _row(maker, run_id)
+        assert row.output == {"from": "live"}
+        assert row.status == "success"
+        assert row.claimed_by is None
+        assert row.claim_token is None
+        assert row.lease_expires_at is None
+
+
+@pytest.mark.asyncio
+async def test_stale_attempt_cannot_reopen_a_run_it_no_longer_owns() -> None:
+    async with _pending_run() as (maker, thread_id, run_id):
+        stale = await _acquire_and_load(run_id, _WORKER)
+        assert stale is not None
+        await _expire_lease(maker, run_id)
+        await LeaseReaper._recover_crashed_runs([run_id])
+        live = await _acquire_and_load(run_id, _WORKER)
+        assert live is not None
+
+        await finalize_run(
+            run_id,
+            thread_id,
+            user_id=_USER_ID,
+            status="error",
+            thread_status="error",
+            error="genuine failure",
+            claim_token=live.claim_token,
+        )
+
+        reopened = await finalize_run(
+            run_id,
+            thread_id,
+            user_id=_USER_ID,
+            status="success",
+            thread_status="idle",
+            output={"from": "stale"},
+            claim_token=stale.claim_token,
+        )
+
+        assert reopened is False
+        row = await _row(maker, run_id)
+        assert row.status == "error"
+        assert row.error_message == "genuine failure"

--- a/libs/aegra-api/tests/unit/test_services/test_run_executor.py
+++ b/libs/aegra-api/tests/unit/test_services/test_run_executor.py
@@ -141,6 +141,7 @@ class TestExecuteRunCancelledError:
             thread_status="error",
             output={},
             error="Job exceeded maximum execution time",
+            claim_token=None,
         )
         mock_streaming.signal_run_error.assert_awaited_once_with(
             "run-1",

--- a/libs/aegra-api/tests/unit/test_services/test_run_status.py
+++ b/libs/aegra-api/tests/unit/test_services/test_run_status.py
@@ -378,6 +378,6 @@ class TestFinalizeRunClaimFencing:
                 claim_token="token-a",
             )
 
-        statement = session.execute.await_args_list[0].args[0]
-        cleared = {column.name for column, value in statement._values.items() if value.value is None}
+        compiled = session.execute.await_args_list[0].args[0].compile()
+        cleared = {name for name, value in compiled.params.items() if value is None}
         assert {"claimed_by", "claim_token", "lease_expires_at"} <= cleared

--- a/libs/aegra-api/tests/unit/test_services/test_run_status.py
+++ b/libs/aegra-api/tests/unit/test_services/test_run_status.py
@@ -291,3 +291,93 @@ class TestSafeSerialize:
 
         assert result["error"] == "Output serialization failed"
         assert "original_type" in result
+
+
+class TestFinalizeRunClaimFencing:
+    """Terminal writes must belong to the acquisition that still owns the run (#502)."""
+
+    @staticmethod
+    def _session_returning(run_id: str | None) -> AsyncMock:
+        session = _make_mock_session()
+        result = MagicMock()
+        result.scalar_one_or_none.return_value = run_id
+        session.execute = AsyncMock(return_value=result)
+        return session
+
+    @pytest.mark.asyncio
+    async def test_adds_claim_token_predicate_when_token_supplied(self) -> None:
+        session = self._session_returning("run-1")
+
+        with patch("aegra_api.services.run_status._get_session_maker", return_value=_make_mock_session_maker(session)):
+            await finalize_run(
+                "run-1",
+                "thread-1",
+                user_id="user-1",
+                status="success",
+                thread_status="idle",
+                output={"ok": True},
+                claim_token="token-a",
+            )
+
+        compiled = session.execute.await_args_list[0].args[0].compile()
+        assert "claim_token = " in str(compiled)
+        assert "token-a" in compiled.params.values()
+
+    @pytest.mark.asyncio
+    async def test_omits_claim_token_predicate_for_unleased_callers(self) -> None:
+        """LocalExecutor and API-side cancellation hold no lease to fence on."""
+        session = self._session_returning("run-1")
+
+        with patch("aegra_api.services.run_status._get_session_maker", return_value=_make_mock_session_maker(session)):
+            await finalize_run(
+                "run-1",
+                "thread-1",
+                user_id="user-1",
+                status="success",
+                thread_status="idle",
+                output={"ok": True},
+            )
+
+        compiled = session.execute.await_args_list[0].args[0].compile()
+        assert "claim_token = " not in str(compiled)
+
+    @pytest.mark.asyncio
+    async def test_rejects_write_from_a_superseded_attempt(self) -> None:
+        """Regression: a reaped worker finishing late used to overwrite the
+        output of the attempt that replaced it."""
+        session = self._session_returning(None)
+
+        with patch("aegra_api.services.run_status._get_session_maker", return_value=_make_mock_session_maker(session)):
+            finalized = await finalize_run(
+                "run-1",
+                "thread-1",
+                user_id="user-1",
+                status="success",
+                thread_status="idle",
+                output={"stale": True},
+                claim_token="retired-token",
+            )
+
+        assert finalized is False
+        session.commit.assert_not_awaited()
+        session.rollback.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_terminalizing_clears_the_lease_in_the_same_statement(self) -> None:
+        """A terminal run must never be left advertising an owner."""
+        session = self._session_returning("run-1")
+
+        with patch("aegra_api.services.run_status._get_session_maker", return_value=_make_mock_session_maker(session)):
+            await finalize_run(
+                "run-1",
+                "thread-1",
+                user_id="user-1",
+                status="error",
+                thread_status="error",
+                error="boom",
+                claim_token="token-a",
+            )
+
+        statement = session.execute.await_args_list[0].args[0]
+        cleared = {column.name for column, value in statement._values.items() if value.value is None}
+        assert {"claimed_by", "claim_token", "lease_expires_at"} <= cleared

--- a/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
+++ b/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
@@ -759,6 +759,31 @@ class TestExecuteAndRelease:
         assert not semaphore.locked()
 
     @pytest.mark.asyncio
+    async def test_timeout_skips_finalize_when_the_run_row_is_gone(self) -> None:
+        """A deleted thread cascades the run away; there is nothing left to mark."""
+        run_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        semaphore = asyncio.Semaphore(1)
+        await semaphore.acquire()
+        executor = WorkerExecutor()
+
+        async def slow_claimed(rid: str, wn: str, claim: _ClaimSlot) -> None:
+            claim.token = TOKEN
+            await asyncio.sleep(9999)
+
+        executor._execute_with_lease = AsyncMock(side_effect=slow_claimed)  # type: ignore[method-assign]
+
+        with (
+            patch(f"{MODULE}.settings") as mock_settings,
+            patch(f"{MODULE}._get_run_identity", new_callable=AsyncMock, return_value=None),
+            patch(f"{MODULE}.finalize_run", new_callable=AsyncMock) as mock_finalize,
+        ):
+            mock_settings.worker.BG_JOB_TIMEOUT_SECS = 0.01
+            await executor._execute_and_release(run_id, "worker-0", semaphore)
+
+        mock_finalize.assert_not_awaited()
+        assert not semaphore.locked()
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize("failure_source", ["identity", "finalize"])
     async def test_cleanup_failure_preserves_cancellation(self, failure_source: str) -> None:
         run_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
@@ -1414,7 +1439,7 @@ class TestHeartbeatAuthorityLoss:
     async def test_abandon_run_is_a_noop_for_a_finished_job(self) -> None:
         run_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
         done: asyncio.Task[None] = asyncio.create_task(asyncio.sleep(0))
-        await done
+        await asyncio.wait_for(done, timeout=1)
 
         _abandon_run(run_id, done)
 

--- a/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
+++ b/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
@@ -709,6 +709,56 @@ class TestExecuteAndRelease:
         assert not semaphore.locked()
 
     @pytest.mark.asyncio
+    async def test_explicit_cancel_without_a_claim_leaves_the_write_to_the_owner(self) -> None:
+        """Cancelled before the lease was acquired, this task owns nothing: writing
+        anyway would let it stomp on whoever does hold the run (#502). The API-side
+        unowned-interrupt path and the reaper cover the row instead."""
+        run_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        semaphore = asyncio.Semaphore(1)
+        await semaphore.acquire()
+        executor = WorkerExecutor()
+        executor._execute_with_lease = AsyncMock(side_effect=asyncio.CancelledError)  # type: ignore[method-assign]
+        explicit_run_cancellations.add(run_id)
+
+        with (
+            patch(f"{MODULE}.settings") as mock_settings,
+            patch(f"{MODULE}._get_run_identity", new_callable=AsyncMock) as mock_identity,
+            patch(f"{MODULE}.finalize_run", new_callable=AsyncMock) as mock_finalize,
+        ):
+            mock_settings.worker.BG_JOB_TIMEOUT_SECS = 60
+            with pytest.raises(asyncio.CancelledError):
+                await executor._execute_and_release(run_id, "worker-0", semaphore)
+
+        mock_finalize.assert_not_awaited()
+        mock_identity.assert_not_awaited()
+        assert run_id not in explicit_run_cancellations
+        assert run_id not in active_runs
+        assert not semaphore.locked()
+
+    @pytest.mark.asyncio
+    async def test_timeout_without_a_claim_leaves_recovery_to_the_reaper(self) -> None:
+        """No claim means no token to fence the write with, so the backstop stays out."""
+        run_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        semaphore = asyncio.Semaphore(1)
+        await semaphore.acquire()
+        executor = WorkerExecutor()
+
+        async def slow_unclaimed(rid: str, wn: str, claim: _ClaimSlot) -> None:
+            await asyncio.sleep(9999)
+
+        executor._execute_with_lease = AsyncMock(side_effect=slow_unclaimed)  # type: ignore[method-assign]
+
+        with (
+            patch(f"{MODULE}.settings") as mock_settings,
+            patch(f"{MODULE}.finalize_run", new_callable=AsyncMock) as mock_finalize,
+        ):
+            mock_settings.worker.BG_JOB_TIMEOUT_SECS = 0.01
+            await executor._execute_and_release(run_id, "worker-0", semaphore)
+
+        mock_finalize.assert_not_awaited()
+        assert not semaphore.locked()
+
+    @pytest.mark.asyncio
     @pytest.mark.parametrize("failure_source", ["identity", "finalize"])
     async def test_cleanup_failure_preserves_cancellation(self, failure_source: str) -> None:
         run_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"

--- a/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
+++ b/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
@@ -7,24 +7,33 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from redis import ConnectionError as RedisConnectionError
 from redis import TimeoutError as RedisTimeoutError
+from sqlalchemy.dialects import postgresql
 
 from aegra_api.core.active_runs import active_runs, explicit_run_cancellations
 from aegra_api.models.auth import User
 from aegra_api.models.run_job import RunBehavior, RunExecution, RunIdentity, RunJob
-from aegra_api.services.run_executor import _shutdown_cancellations, _timeout_cancellations
+from aegra_api.services.run_executor import (
+    _lease_loss_cancellations,
+    _shutdown_cancellations,
+    _timeout_cancellations,
+)
 from aegra_api.services.worker_executor import (
     WorkerExecutor,
+    _abandon_run,
     _acquire_and_load,
+    _ClaimSlot,
     _heartbeat_loop,
     _is_run_terminal,
     _is_valid_run_id,
     _LoadedRun,
     _release_lease,
+    _renew_lease,
     _requeue_drained_runs,
     _restore_trace_context,
 )
 
 MODULE = "aegra_api.services.worker_executor"
+TOKEN = "99999999-9999-9999-9999-999999999999"
 
 
 def _make_session_maker(session: AsyncMock) -> MagicMock:
@@ -184,7 +193,7 @@ class TestReleaseLease:
         maker = _make_session_maker(session)
 
         with patch(f"{MODULE}._get_session_maker", return_value=maker):
-            await _release_lease("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", "test-worker")
+            await _release_lease("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", TOKEN)
 
         session.execute.assert_awaited_once()
         session.commit.assert_awaited_once()
@@ -221,7 +230,7 @@ class TestHeartbeatLoop:
             mock_settings.worker.LEASE_DURATION_SECONDS = 30
 
             with pytest.raises(asyncio.CancelledError):
-                await _heartbeat_loop("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", "worker-0")
+                await _heartbeat_loop("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", "worker-0", TOKEN)
 
         # One iteration completed before cancellation on second sleep
         assert session.execute.await_count == 1
@@ -250,7 +259,7 @@ class TestHeartbeatLoop:
             mock_settings.worker.LEASE_DURATION_SECONDS = 30
 
             with pytest.raises(asyncio.CancelledError):
-                await _heartbeat_loop("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", "worker-0")
+                await _heartbeat_loop("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", "worker-0", TOKEN)
 
         # Loop continued despite DB errors (2 iterations before cancel on 3rd sleep)
         assert session.execute.await_count == 2
@@ -589,7 +598,7 @@ class TestExecuteAndRelease:
 
         registered_in_active: bool = False
 
-        async def mock_execute_with_lease(rid: str, wn: str) -> None:
+        async def mock_execute_with_lease(rid: str, wn: str, claim: _ClaimSlot) -> None:
             nonlocal registered_in_active
             registered_in_active = run_id in active_runs
 
@@ -616,8 +625,9 @@ class TestExecuteAndRelease:
         executor = WorkerExecutor()
         timeout_marker_seen = False
 
-        async def slow_execute(rid: str, wn: str) -> None:
+        async def slow_execute(rid: str, wn: str, claim: _ClaimSlot) -> None:
             nonlocal timeout_marker_seen
+            claim.token = TOKEN
             try:
                 await asyncio.sleep(9999)
             except asyncio.CancelledError:
@@ -636,10 +646,8 @@ class TestExecuteAndRelease:
                 return_value=(thread_id, "user-1"),
             ),
             patch(f"{MODULE}.finalize_run", new_callable=AsyncMock) as mock_finalize,
-            patch(f"{MODULE}._release_lease") as mock_release,
         ):
             mock_settings.worker.BG_JOB_TIMEOUT_SECS = 0.01  # Very short timeout
-            mock_release.return_value = None
 
             await executor._execute_and_release(run_id, "worker-0", semaphore)
 
@@ -650,8 +658,8 @@ class TestExecuteAndRelease:
             status="error",
             thread_status="error",
             error="Job exceeded maximum execution time",
+            claim_token=TOKEN,
         )
-        mock_release.assert_awaited_once_with(run_id, "worker-0")
         assert timeout_marker_seen is True
         # Semaphore released even on timeout
         assert not semaphore.locked()
@@ -666,7 +674,12 @@ class TestExecuteAndRelease:
         semaphore = asyncio.Semaphore(1)
         await semaphore.acquire()
         executor = WorkerExecutor()
-        executor._execute_with_lease = AsyncMock(side_effect=asyncio.CancelledError)  # type: ignore[method-assign]
+
+        async def claim_then_cancel(rid: str, wn: str, claim: _ClaimSlot) -> None:
+            claim.token = TOKEN
+            raise asyncio.CancelledError
+
+        executor._execute_with_lease = AsyncMock(side_effect=claim_then_cancel)  # type: ignore[method-assign]
         explicit_run_cancellations.add(run_id)
 
         with (
@@ -689,6 +702,7 @@ class TestExecuteAndRelease:
             status="interrupted",
             thread_status="idle",
             output={},
+            claim_token=TOKEN,
         )
         assert run_id not in explicit_run_cancellations
         assert run_id not in active_runs
@@ -702,7 +716,12 @@ class TestExecuteAndRelease:
         semaphore = asyncio.Semaphore(1)
         await semaphore.acquire()
         executor = WorkerExecutor()
-        executor._execute_with_lease = AsyncMock(side_effect=asyncio.CancelledError)  # type: ignore[method-assign]
+
+        async def claim_then_cancel(rid: str, wn: str, claim: _ClaimSlot) -> None:
+            claim.token = TOKEN
+            raise asyncio.CancelledError
+
+        executor._execute_with_lease = AsyncMock(side_effect=claim_then_cancel)  # type: ignore[method-assign]
         explicit_run_cancellations.add(run_id)
 
         with (
@@ -744,8 +763,9 @@ class TestExecuteAndRelease:
         allow_finalize = asyncio.Event()
         inner_cancelled = False
 
-        async def long_running(rid: str, worker_name: str) -> None:
+        async def long_running(rid: str, worker_name: str, claim: _ClaimSlot) -> None:
             nonlocal inner_cancelled
+            claim.token = TOKEN
             execution_started.set()
             try:
                 await asyncio.sleep(9999)
@@ -796,6 +816,7 @@ class TestExecuteAndRelease:
             status="interrupted",
             thread_status="idle",
             output={},
+            claim_token=TOKEN,
         )
         assert run_id not in explicit_run_cancellations
         assert run_id not in active_runs
@@ -813,7 +834,7 @@ class TestExecuteWithLease:
 
         job_task_was_cancelled = False
 
-        async def long_running_job(job: object) -> None:
+        async def long_running_job(job: object, *, claim_token: str | None = None) -> None:
             nonlocal job_task_was_cancelled
             try:
                 await asyncio.sleep(9999)
@@ -824,6 +845,7 @@ class TestExecuteWithLease:
         mock_loaded = MagicMock(spec=_LoadedRun)
         mock_loaded.job = _make_run_job()
         mock_loaded.trace = {}
+        mock_loaded.claim_token = TOKEN
 
         with (
             patch(f"{MODULE}._acquire_and_load", new_callable=AsyncMock, return_value=mock_loaded),
@@ -836,7 +858,7 @@ class TestExecuteWithLease:
             # The CancelledError is caught internally by _execute_with_lease's
             # except block, so the task completes normally — but the inner
             # job_task must still have been cancelled.
-            task = asyncio.create_task(executor._execute_with_lease(run_id, "worker-0"))
+            task = asyncio.create_task(executor._execute_with_lease(run_id, "worker-0", _ClaimSlot()))
             await asyncio.sleep(0.05)  # Let it start
             task.cancel()
             await task  # Completes normally (CancelledError is handled internally)
@@ -1135,3 +1157,215 @@ class TestStopRequeuesDrainedRuns:
 
         mock_push_back.assert_awaited_once_with(run_id)
         assert not executor._job_tasks
+
+
+# ------------------------------------------------------------------
+# Claim-token fencing (#502)
+# ------------------------------------------------------------------
+
+
+def _compiled(statement: object) -> tuple[str, dict]:
+    """Render a SQLAlchemy statement plus its bound parameters for assertions."""
+    compiled = statement.compile(dialect=postgresql.dialect())  # type: ignore[attr-defined]
+    return str(compiled), dict(compiled.params)
+
+
+class TestClaimTokenFencing:
+    """``claimed_by`` is reusable, so ownership must key on a per-acquisition token."""
+
+    @pytest.mark.asyncio
+    async def test_repeated_acquisition_by_same_worker_mints_distinct_tokens(self) -> None:
+        """Regression: the same worker re-claiming a reaped run must not inherit
+        the identity its abandoned attempt is still writing with."""
+        statements: list[object] = []
+
+        def _make_maker() -> MagicMock:
+            session = AsyncMock()
+            update_result = MagicMock()
+            update_result.rowcount = 1
+
+            async def capture(statement: object) -> MagicMock:
+                statements.append(statement)
+                return update_result
+
+            session.execute = AsyncMock(side_effect=capture)
+            session.scalar = AsyncMock(return_value=_make_run_orm())
+            session.commit = AsyncMock()
+            return _make_session_maker(session)
+
+        run_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        with patch(f"{MODULE}._get_session_maker", side_effect=_make_maker):
+            first = await _acquire_and_load(run_id, "worker-0")
+            second = await _acquire_and_load(run_id, "worker-0")
+
+        assert first is not None
+        assert second is not None
+        assert first.claim_token != second.claim_token
+
+        for statement, loaded in zip(statements, [first, second], strict=True):
+            sql, params = _compiled(statement)
+            assert "claim_token" in sql
+            assert loaded.claim_token in params.values()
+
+    @pytest.mark.asyncio
+    async def test_acquire_sets_lease_expiry_from_postgres_clock(self) -> None:
+        """Workers and the reaper compare leases across hosts, so the deadline
+        must come from the database rather than the claiming process."""
+        session = AsyncMock()
+        update_result = MagicMock()
+        update_result.rowcount = 1
+        captured: list[object] = []
+
+        async def capture(statement: object) -> MagicMock:
+            captured.append(statement)
+            return update_result
+
+        session.execute = AsyncMock(side_effect=capture)
+        session.scalar = AsyncMock(return_value=_make_run_orm())
+        session.commit = AsyncMock()
+
+        with patch(f"{MODULE}._get_session_maker", return_value=_make_session_maker(session)):
+            await _acquire_and_load("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", "worker-0")
+
+        sql, _ = _compiled(captured[0])
+        assert "now()" in sql
+
+    @pytest.mark.asyncio
+    async def test_release_lease_requires_token_and_terminal_status(self) -> None:
+        """Releasing a still-running row would leave it with no owner and no
+        expiry — a state neither reaper query can find."""
+        session = AsyncMock()
+        captured: list[object] = []
+
+        async def capture(statement: object) -> MagicMock:
+            captured.append(statement)
+            return MagicMock()
+
+        session.execute = AsyncMock(side_effect=capture)
+        session.commit = AsyncMock()
+
+        with patch(f"{MODULE}._get_session_maker", return_value=_make_session_maker(session)):
+            await _release_lease("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", TOKEN)
+
+        sql, params = _compiled(captured[0])
+        assert "claim_token = " in sql
+        assert "status NOT IN" in sql
+        assert TOKEN in params.values()
+
+    @pytest.mark.asyncio
+    async def test_renew_lease_predicates_on_token_not_worker_name(self) -> None:
+        session = AsyncMock()
+        result = MagicMock()
+        result.rowcount = 1
+        captured: list[object] = []
+
+        async def capture(statement: object) -> MagicMock:
+            captured.append(statement)
+            return result
+
+        session.execute = AsyncMock(side_effect=capture)
+        session.commit = AsyncMock()
+
+        with patch(f"{MODULE}._get_session_maker", return_value=_make_session_maker(session)):
+            rowcount = await _renew_lease("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", TOKEN)
+
+        assert rowcount == 1
+        sql, params = _compiled(captured[0])
+        assert "claim_token = " in sql
+        assert "claimed_by = " not in sql
+        assert TOKEN in params.values()
+
+    @pytest.mark.asyncio
+    async def test_renew_lease_returns_none_on_database_failure(self) -> None:
+        session = AsyncMock()
+        session.execute = AsyncMock(side_effect=RuntimeError("connection reset"))
+        maker = _make_session_maker(session)
+
+        with patch(f"{MODULE}._get_session_maker", return_value=maker):
+            assert await _renew_lease("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", TOKEN) is None
+
+
+class TestHeartbeatAuthorityLoss:
+    """A worker that cannot prove it still owns the run must stop executing."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_cancellation_state(self) -> Iterator[None]:
+        _lease_loss_cancellations.clear()
+        yield
+        _lease_loss_cancellations.clear()
+
+    @staticmethod
+    async def _never_finishes() -> None:
+        await asyncio.sleep(9999)
+
+    @pytest.mark.asyncio
+    async def test_cancels_job_when_token_no_longer_matches(self) -> None:
+        run_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        job_task = asyncio.create_task(self._never_finishes())
+
+        with (
+            patch(f"{MODULE}.asyncio.sleep", new_callable=AsyncMock),
+            patch(f"{MODULE}._renew_lease", new_callable=AsyncMock, return_value=0),
+        ):
+            await _heartbeat_loop(run_id, "worker-0", TOKEN, job_task=job_task)
+
+        assert job_task.cancelled() or job_task.cancelling()
+        assert run_id in _lease_loss_cancellations
+        job_task.cancel()
+        await asyncio.gather(job_task, return_exceptions=True)
+
+    @pytest.mark.asyncio
+    async def test_retries_transient_failure_while_lease_has_runway(self) -> None:
+        """A single failed renewal is not authority loss: the lease still has
+        time on it, so aborting every in-flight run on a blip would be worse."""
+        run_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        job_task = asyncio.create_task(self._never_finishes())
+        renewals = [None, 1, 0]
+
+        with (
+            patch(f"{MODULE}.asyncio.sleep", new_callable=AsyncMock),
+            patch(f"{MODULE}._renew_lease", new_callable=AsyncMock, side_effect=renewals) as mock_renew,
+            patch(f"{MODULE}.settings") as mock_settings,
+        ):
+            mock_settings.worker.HEARTBEAT_INTERVAL_SECONDS = 10
+            mock_settings.worker.LEASE_DURATION_SECONDS = 30
+            await _heartbeat_loop(run_id, "worker-0", TOKEN, job_task=job_task)
+
+        # Kept going through the failure, stopped only on the rejected renewal.
+        assert mock_renew.await_count == 3
+        assert run_id in _lease_loss_cancellations
+        job_task.cancel()
+        await asyncio.gather(job_task, return_exceptions=True)
+
+    @pytest.mark.asyncio
+    async def test_abandons_run_when_renewal_cannot_beat_lease_expiry(self) -> None:
+        """Regression: an unreachable database used to be logged and ignored, so
+        the graph kept running while the reaper handed the run to someone else."""
+        run_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        job_task = asyncio.create_task(self._never_finishes())
+
+        with (
+            patch(f"{MODULE}.asyncio.sleep", new_callable=AsyncMock),
+            patch(f"{MODULE}._renew_lease", new_callable=AsyncMock, return_value=None) as mock_renew,
+            patch(f"{MODULE}.settings") as mock_settings,
+        ):
+            # Zero runway: the first failure already reaches the expiry guard.
+            mock_settings.worker.HEARTBEAT_INTERVAL_SECONDS = 10
+            mock_settings.worker.LEASE_DURATION_SECONDS = 10
+            await _heartbeat_loop(run_id, "worker-0", TOKEN, job_task=job_task)
+
+        assert mock_renew.await_count == 1
+        assert job_task.cancelled() or job_task.cancelling()
+        assert run_id in _lease_loss_cancellations
+        job_task.cancel()
+        await asyncio.gather(job_task, return_exceptions=True)
+
+    @pytest.mark.asyncio
+    async def test_abandon_run_is_a_noop_for_a_finished_job(self) -> None:
+        run_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        done: asyncio.Task[None] = asyncio.create_task(asyncio.sleep(0))
+        await done
+
+        _abandon_run(run_id, done)
+
+        assert run_id not in _lease_loss_cancellations

--- a/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
+++ b/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
@@ -774,12 +774,14 @@ class TestExecuteAndRelease:
 
         with (
             patch(f"{MODULE}.settings") as mock_settings,
-            patch(f"{MODULE}._get_run_identity", new_callable=AsyncMock, return_value=None),
+            patch(f"{MODULE}._get_run_identity", new_callable=AsyncMock, return_value=None) as mock_identity,
             patch(f"{MODULE}.finalize_run", new_callable=AsyncMock) as mock_finalize,
         ):
             mock_settings.worker.BG_JOB_TIMEOUT_SECS = 0.01
             await executor._execute_and_release(run_id, "worker-0", semaphore)
 
+        # Asserting the lookup ran is what distinguishes this from the no-claim skip.
+        mock_identity.assert_awaited_once_with(run_id)
         mock_finalize.assert_not_awaited()
         assert not semaphore.locked()
 
@@ -1342,7 +1344,7 @@ class TestClaimTokenFencing:
         session.commit = AsyncMock()
 
         with patch(f"{MODULE}._get_session_maker", return_value=_make_session_maker(session)):
-            rowcount = await _renew_lease("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", TOKEN)
+            rowcount = await _renew_lease("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", TOKEN, timeout=5)
 
         assert rowcount == 1
         sql, params = _compiled(captured[0])
@@ -1351,13 +1353,28 @@ class TestClaimTokenFencing:
         assert TOKEN in params.values()
 
     @pytest.mark.asyncio
+    async def test_renew_lease_gives_up_when_the_round_trip_outlasts_its_budget(self) -> None:
+        """Regression: a renewal blocked on pool acquisition or commit used to park
+        the heartbeat, so it could not abandon the run before the reaper replaced it."""
+        session = AsyncMock()
+
+        async def never_returns(_statement: object) -> None:
+            await asyncio.sleep(9999)
+
+        session.execute = AsyncMock(side_effect=never_returns)
+        maker = _make_session_maker(session)
+
+        with patch(f"{MODULE}._get_session_maker", return_value=maker):
+            assert await _renew_lease("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", TOKEN, timeout=0.01) is None
+
+    @pytest.mark.asyncio
     async def test_renew_lease_returns_none_on_database_failure(self) -> None:
         session = AsyncMock()
         session.execute = AsyncMock(side_effect=RuntimeError("connection reset"))
         maker = _make_session_maker(session)
 
         with patch(f"{MODULE}._get_session_maker", return_value=maker):
-            assert await _renew_lease("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", TOKEN) is None
+            assert await _renew_lease("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", TOKEN, timeout=5) is None
 
 
 class TestHeartbeatAuthorityLoss:
@@ -1409,6 +1426,30 @@ class TestHeartbeatAuthorityLoss:
         # Kept going through the failure, stopped only on the rejected renewal.
         assert mock_renew.await_count == 3
         assert run_id in _lease_loss_cancellations
+        job_task.cancel()
+        await asyncio.gather(job_task, return_exceptions=True)
+
+    @pytest.mark.asyncio
+    async def test_budgets_each_renewal_against_the_remaining_lease(self) -> None:
+        """The renewal must never be allowed to outlast the lease it is extending."""
+        run_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        job_task = asyncio.create_task(self._never_finishes())
+        budgets: list[float] = []
+
+        async def record_budget(_run_id: str, _token: str, *, timeout: float) -> int:
+            budgets.append(timeout)
+            return 0
+
+        with (
+            patch(f"{MODULE}.asyncio.sleep", new_callable=AsyncMock),
+            patch(f"{MODULE}._renew_lease", side_effect=record_budget),
+            patch(f"{MODULE}.settings") as mock_settings,
+        ):
+            mock_settings.worker.HEARTBEAT_INTERVAL_SECONDS = 10
+            mock_settings.worker.LEASE_DURATION_SECONDS = 30
+            await _heartbeat_loop(run_id, "worker-0", TOKEN, job_task=job_task)
+
+        assert budgets and all(0 < b <= 30 for b in budgets)
         job_task.cancel()
         await asyncio.gather(job_task, return_exceptions=True)
 

--- a/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
+++ b/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
@@ -1454,6 +1454,30 @@ class TestHeartbeatAuthorityLoss:
         await asyncio.gather(job_task, return_exceptions=True)
 
     @pytest.mark.asyncio
+    async def test_abandons_without_attempting_renewal_once_the_lease_is_gone(self) -> None:
+        """Regression: a floor on the renewal budget let the call run past expiry,
+        so the reaper could start a replacement while this graph was still live."""
+        run_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        job_task = asyncio.create_task(self._never_finishes())
+
+        with (
+            patch(f"{MODULE}._renew_lease", new_callable=AsyncMock) as mock_renew,
+            patch(f"{MODULE}.settings") as mock_settings,
+        ):
+            # Real timings, no patched clock: sleeping a whole interval past a lease
+            # this short is what a stalled event loop looks like, and scheduling jitter
+            # can only push the wake-up later.
+            mock_settings.worker.HEARTBEAT_INTERVAL_SECONDS = 0.02
+            mock_settings.worker.LEASE_DURATION_SECONDS = 0.001
+            await _heartbeat_loop(run_id, "worker-0", TOKEN, job_task=job_task)
+
+        mock_renew.assert_not_awaited()
+        assert job_task.cancelled() or job_task.cancelling()
+        assert run_id in _lease_loss_cancellations
+        job_task.cancel()
+        await asyncio.gather(job_task, return_exceptions=True)
+
+    @pytest.mark.asyncio
     async def test_abandons_run_when_renewal_cannot_beat_lease_expiry(self) -> None:
         """Regression: an unreachable database used to be logged and ignored, so
         the graph kept running while the reaper handed the run to someone else."""

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.10.4"
+version = "0.10.5"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.10.4"
+version = "0.10.5"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -100,7 +100,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.10.4"
+version = "0.10.5"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
## Problem

The worker recovery path has leases but no fencing. `claimed_by` is a stable worker name (`hostname-pid-worker-idx`), so it cannot distinguish two attempts by the same worker — and every ownership check in the lease path compares exactly that string.

A worker that stalls past its lease (GC pause, saturated event loop, Postgres failover, connection-pool exhaustion) gets reaped, the run goes back to `pending`, and the same worker index can pick it up again. From that moment the abandoned attempt satisfies its own ownership predicates against the *replacement's* row:

1. **Its heartbeat succeeds.** `UPDATE ... WHERE claimed_by = 'host-1-worker-0'` matches, `rowcount = 1`, so the stalled worker never learns it lost authority and keeps extending the replacement's lease.
2. **Its release strips the replacement's lease.** `_release_lease` clears `claimed_by` and `lease_expires_at` on a row that is still `running`. That state is invisible to both reaper queries — the crashed query requires `lease_expires_at IS NOT NULL`, the stuck-pending query requires `status = 'pending'` — so the run hangs in `running` forever.
3. **Its result overwrites the live one.** `finalize_run` predicated only on `run_id + user_id + active status`. A late finish from the reaped attempt commits stale output over a run another worker is still executing; the live attempt's `finalize_run` then returns `False` and its real result is discarded. Which result survives is non-deterministic.

Separately, a heartbeat exception was logged and ignored. If the database is unreachable for longer than `LEASE_DURATION_SECONDS` (default 30s, three heartbeat attempts), the lease expires unrenewed, the reaper hands the run to a second worker, and the first keeps executing the graph — the failure window where fencing matters most was the one window with no ownership check at all.

## Fix

Each acquisition mints a fresh `claim_token` (UUID). `claimed_by` stays as the human-readable label for logs; the token is what every ownership-predicated write matches on.

| Operation | Predicate |
| --- | --- |
| Heartbeat renewal | `run_id + claim_token` |
| Terminalization | `run_id + user_id + active status + claim_token` |
| Lease release | `run_id + claim_token + terminal status` |
| Reaper reclaim | clears `claim_token`, retiring the expired attempt |

- **Terminalization is atomic.** `finalize_run` now clears `claimed_by`, `claim_token`, and `lease_expires_at` in the same statement that writes status and output, so a run can never be left terminal while still advertising an owner. Callers with no lease (LocalExecutor, API-side cancellation) pass no token and are guarded by the active-status predicate as before.
- **Release can no longer orphan a row.** It is additionally gated on terminal status, so clearing a still-running row — the state no reaper query can find — is not expressible.
- **Sustained heartbeat failure is authority loss.** The loop keeps a monotonic mirror of the lease: a single failed renewal with runway left is retried (a brief blip must not abort all 30 in-flight runs on an instance), but once renewal can no longer beat the expiry the worker cancels the graph rather than run on unowned.
- **Timestamps come from Postgres.** Lease deadlines and expiry comparisons use `now()` instead of each process's clock — workers and the reaper run on different hosts, and skew could expire a live lease.

## Migration

One additive, nullable column (`runs.claim_token`). Existing rows read as `NULL`; runs claimed before the upgrade simply fall back to the previous status-only guard until they finish.

## Tests

Covers the verification list from the issue.

**Unit** (`test_worker_executor.py`, `test_run_status.py`)
- repeated acquisition by the same worker mints distinct tokens
- renewal / release / finalize predicate on the token, not the worker name
- release requires terminal status
- lease expiry is written by Postgres
- heartbeat retries a transient failure while the lease has runway, and abandons the run when renewal can no longer beat expiry
- heartbeat abandons on a rejected renewal (token retired)
- `finalize_run` rejects a superseded attempt, clears the lease when it wins, and omits the token predicate for unleased callers

**Integration** (`test_lease_fencing_db.py`, real PostgreSQL — the fence lives in SQL predicates, mocks can only prove statement shape)
- full pause → reap → reclaim sequence: the stale attempt cannot renew, cannot release the replacement's lease, cannot terminalize, and cannot reopen a run that already ended
- asserts the replacement stays visible to the reaper (this test fails against the old release predicate)

**E2E** (`test_run_reconciliation_e2e.py`, `prod_only`)
- with the real server and reaper running, a worker that comes back after its run was reclaimed cannot write a result for it

Verified against a live stack (Postgres + Redis + workers, `REDIS_BROKER_ENABLED=true`): 1909 unit/integration tests pass, and all 11 reconciliation E2E tests pass including the new one. The migration applies cleanly on top of `b88bb61be638`.

Closes #502


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Reliability Improvements**
  * Improved recovery when workers crash, stall, or lose lease ownership.
  * Prevented outdated workers from overwriting results or disrupting newer attempts.
  * Improved lease-expiry accuracy using database time.
  * Prevented rejected cleanup or finalization attempts from interrupting active streaming.
  * Improved cancellation, renewal, and shutdown handling for abandoned work.

* **Documentation**
  * Updated recovery documentation with enhanced lease ownership safeguards.

* **Tests**
  * Added coverage for stale-worker protection, lease recovery, cancellation, renewal, and shutdown behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->









<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds per-acquisition claim tokens to fence stale workers, moves lease timing to PostgreSQL, and updates terminalization, cancellation, recovery, documentation, migrations, and tests.
- Adds a nullable `runs.claim_token` migration and ORM field.
- Predicates renewal, release, and worker finalization on the acquisition token.
- Clears ownership atomically during terminalization and reaper recovery.
- Adds unit, PostgreSQL integration, and production-mode reconciliation coverage.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until renewal is guaranteed to stop the old graph before its lease expires and recovery can begin.

The new timeout bounds when renewal cancellation starts, but the heartbeat waits for the cancelled database operation to unwind before abandoning the graph; during that interval PostgreSQL may consider the lease expired and the reaper may start a replacement.

**Files Needing Attention:** libs/aegra-api/src/aegra_api/services/worker_executor.py

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/services/worker_executor.py | Adds token-fenced acquisition, renewal, release, timeout, and cancellation handling, but renewal cancellation can still finish after the lease deadline. |
| libs/aegra-api/src/aegra_api/services/run_status.py | Adds optional claim-token fencing and atomically clears ownership during terminalization. |
| libs/aegra-api/src/aegra_api/services/lease_reaper.py | Uses PostgreSQL time for recovery decisions and retires expired attempts by clearing their tokens. |
| libs/aegra-api/src/aegra_api/core/orm.py | Adds the nullable claim-token field, and the previously reported comment-length violation is fixed. |
| libs/aegra-api/alembic/versions/20260823000000_add_run_claim_token.py | Adds and removes the nullable claim-token column through a linear Alembic revision. |
| libs/aegra-api/tests/integration/test_lease_fencing_db.py | Exercises stale-token fencing and reclaim behavior against PostgreSQL. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant W as Worker attempt
  participant DB as PostgreSQL
  participant R as Lease reaper
  participant N as Replacement worker
  W->>DB: Claim pending run with fresh token
  loop Heartbeats
    W->>DB: Renew where claim_token matches
  end
  alt Lease expires
    R->>DB: Reset run and clear claim token
    N->>DB: Claim with a new token
    W->>DB: Late renew/finalize with stale token
    DB-->>W: No matching row
  else Worker completes while owned
    W->>DB: Finalize and clear lease atomically
  end
```
</details>

<sub>Reviews (5): Last reviewed commit: ["fix(worker): abandon the run when the he..."](https://github.com/aegra/aegra/commit/977276f091c70c4a34f1ad22eeaa2d9150f8411d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56001187)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Run execution lifecycle](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/run-execution.md)
- Knowledge Base — [Broker and worker coordination](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/broker-and-worker-coordination.md)
- Knowledge Base — [Data persistence and migrations](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/data-persistence.md)
</details>


<!-- /greptile_comment -->