### PR TITLE
fix(api): preserve @auth.authenticate HTTPException status codes

### DIFF
--- a/docs/guides/authentication.mdx
+++ b/docs/guides/authentication.mdx
@@ -74,18 +74,36 @@ Any additional fields you return (like `role`, `team_id`, etc.) are preserved an
 
 ### Denying access
 
-Raise any exception to deny authentication:
+Raise `Auth.exceptions.HTTPException` to deny authentication. Aegra forwards the handler's `status_code`, `detail`, and `headers` to the client. Status codes that the handler does not set default to 401.
 
 ```python
+from langgraph_sdk import Auth
+
+auth = Auth()
+
 @auth.authenticate
 async def authenticate(headers: dict) -> dict:
     token = headers.get("Authorization", "").replace("Bearer ", "")
     if not token:
-        raise Exception("Authentication required")
+        raise Auth.exceptions.HTTPException(status_code=401, detail="Authentication required")
+    if is_rate_limited(token):
+        raise Auth.exceptions.HTTPException(status_code=429, detail="Too many attempts")
+    if is_account_disabled(token):
+        raise Auth.exceptions.HTTPException(status_code=403, detail="Account disabled")
+    if idp_unreachable():
+        raise Auth.exceptions.HTTPException(status_code=503, detail="Identity provider unreachable")
     if not is_valid_token(token):
-        raise Exception("Invalid token")
+        raise Auth.exceptions.HTTPException(status_code=401, detail="Invalid token")
     return user_data
 ```
+
+| Status | Meaning |
+|---|---|
+| `401` | Not authenticated (missing or invalid credentials). Also the default when the handler raises a non-HTTP exception. |
+| `403` | The identity is known but access is refused (disabled account, forbidden). Authorization denials from `@auth.on` are also 403. |
+| Other | Passed through as raised (`429` rate limit, `503` identity provider down, …). |
+
+Any other exception still becomes `401` and does not leak the exception text. Do not raise a generic `Exception` if you need a status other than 401.
 
 ## Authorization handlers
 

--- a/examples/jwt_mock_auth_example.py
+++ b/examples/jwt_mock_auth_example.py
@@ -73,6 +73,11 @@ async def authenticate(headers: dict[str, str]) -> dict[str, str | bool | list[s
 
     user_id = parts[0]
     role = parts[1]
+    # Special identities for auth E2E: handler-chosen status must survive dispatch.
+    if user_id == "disabled":
+        raise Auth.exceptions.HTTPException(status_code=403, detail="account disabled")
+    if user_id == "ratelimited":
+        raise Auth.exceptions.HTTPException(status_code=429, detail="too many attempts")
     has_team = len(parts) > 2
     team_id = parts[2] if has_team else "team_default"
 

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.10.4"
+version = "0.10.5"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-api/src/aegra_api/core/auth_deps.py
+++ b/libs/aegra-api/src/aegra_api/core/auth_deps.py
@@ -3,6 +3,7 @@
 from typing import Annotated, Any
 
 from fastapi import Depends, HTTPException, Request
+from langgraph_sdk import Auth
 
 from aegra_api.core.auth_middleware import get_auth_backend
 from aegra_api.models.auth import User
@@ -68,12 +69,21 @@ async def require_auth(request: Request) -> User:
         User object with authentication context including any extra fields
 
     Raises:
-        HTTPException: If user is not authenticated
+        HTTPException: If authentication fails. Status/detail/headers from
+            ``Auth.exceptions.HTTPException`` are preserved; other failures are 401.
     """
     backend = get_auth_backend()
 
     try:
         result = await backend.authenticate(request)
+    except HTTPException:
+        raise
+    except Auth.exceptions.HTTPException as e:
+        raise HTTPException(
+            status_code=e.status_code,
+            detail=e.detail,
+            headers=dict(e.headers) if hasattr(e, "headers") and e.headers else None,
+        ) from e
     except Exception as e:
         raise HTTPException(status_code=401, detail=str(e)) from e
 

--- a/libs/aegra-api/src/aegra_api/core/auth_middleware.py
+++ b/libs/aegra-api/src/aegra_api/core/auth_middleware.py
@@ -225,7 +225,8 @@ class LangGraphAuthBackend(AuthenticationBackend):
             Tuple of (credentials, user) if authenticated, None otherwise
 
         Raises:
-            AuthenticationError: If authentication fails
+            Auth.exceptions.HTTPException: Handler denied with an explicit status
+            AuthenticationError: Authentication failed without an HTTPException
         """
         # Handle noop auth when no auth instance is configured
         # Default to noop (anonymous) authentication when no auth file is found,
@@ -278,8 +279,9 @@ class LangGraphAuthBackend(AuthenticationBackend):
             return credentials, user
 
         except Auth.exceptions.HTTPException as e:
+            # Keep handler status codes; AuthenticationError can only become 401.
             logger.warning(f"Authentication failed: {e.detail}")
-            raise AuthenticationError(e.detail) from e
+            raise
 
         except Exception as e:
             logger.error(f"Unexpected error during authentication: {e}", exc_info=True)

--- a/libs/aegra-api/src/aegra_api/main.py
+++ b/libs/aegra-api/src/aegra_api/main.py
@@ -166,6 +166,7 @@ async def agent_protocol_exception_handler(_request: Request, exc: HTTPException
             message=exc.detail,
             details=getattr(exc, "details", None),
         ).model_dump(),
+        headers=exc.headers,
     )
 
 

--- a/libs/aegra-api/tests/e2e/manual_auth_tests/test_auth_e2e.py
+++ b/libs/aegra-api/tests/e2e/manual_auth_tests/test_auth_e2e.py
@@ -86,6 +86,30 @@ class TestCoreRoutesAuth:
             {"url": url, "status": response.status_code},
         )
 
+    def test_disabled_account_returns_403(self) -> None:
+        """Handler HTTPException(403) must not be rewritten as 401."""
+        url = f"{get_server_url()}/assistants"
+        headers = get_auth_headers("mock-jwt-disabled-user-team123")
+
+        response = httpx.get(url, headers=headers, timeout=10.0)
+
+        assert response.status_code == 403, f"Expected 403, got {response.status_code}: {response.text}"
+        assert "account disabled" in response.text
+
+        elog("Disabled account", {"url": url, "status": response.status_code})
+
+    def test_rate_limited_identity_returns_429(self) -> None:
+        """Handler HTTPException(429) must not be rewritten as 401."""
+        url = f"{get_server_url()}/assistants"
+        headers = get_auth_headers("mock-jwt-ratelimited-user-team123")
+
+        response = httpx.get(url, headers=headers, timeout=10.0)
+
+        assert response.status_code == 429, f"Expected 429, got {response.status_code}: {response.text}"
+        assert "too many attempts" in response.text
+
+        elog("Rate limited identity", {"url": url, "status": response.status_code})
+
 
 @pytest.mark.e2e
 @pytest.mark.auth_only

--- a/libs/aegra-api/tests/integration/test_auth_flow.py
+++ b/libs/aegra-api/tests/integration/test_auth_flow.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
-from fastapi import Depends, FastAPI, Request
+from fastapi import Depends, FastAPI, HTTPException, Request
 from fastapi.testclient import TestClient
 from langgraph_sdk import Auth
 from starlette.authentication import AuthCredentials
@@ -20,6 +20,7 @@ from starlette.requests import HTTPConnection
 
 from aegra_api.core.auth_deps import require_auth
 from aegra_api.core.auth_middleware import LangGraphAuthBackend, LangGraphUser
+from aegra_api.main import agent_protocol_exception_handler
 from aegra_api.models.auth import User
 
 
@@ -383,13 +384,15 @@ def _auth_succeeding() -> Auth:
 
 
 class TestAuthenticateHttpStatusPassthrough:
-    """HTTP-level: handler status codes must reach the response, not collapse to 401."""
+    """HTTP-level: handler status/headers reach the Agent Protocol response, not collapse to 401."""
 
     def _get(self, auth_instance: Auth | None) -> tuple[int, dict[str, object], dict[str, str]]:
         backend = LangGraphAuthBackend()
         backend.auth_instance = auth_instance
 
         app = FastAPI()
+        # Exercise production JSON + header forwarding, not FastAPI's default handler.
+        app.add_exception_handler(HTTPException, agent_protocol_exception_handler)
 
         @app.get("/protected")
         async def protected(user: User = Depends(require_auth)) -> dict[str, str]:
@@ -414,16 +417,18 @@ class TestAuthenticateHttpStatusPassthrough:
         code, body, _headers = self._get(_auth_raising(status_code=status_code, detail=detail))
 
         assert code == status_code
-        assert body["detail"] == detail
+        assert body["message"] == detail
 
     def test_handler_http_exception_headers_reach_client(self) -> None:
-        _code, _body, headers = self._get(
+        code, body, headers = self._get(
             _auth_raising(
                 status_code=401,
                 detail="invalid token",
                 headers={"WWW-Authenticate": "Bearer"},
             )
         )
+        assert code == 401
+        assert body["message"] == "invalid token"
         assert headers.get("www-authenticate") == "Bearer"
 
     def test_non_http_exception_stays_401_without_leaking(self) -> None:
@@ -437,7 +442,7 @@ class TestAuthenticateHttpStatusPassthrough:
 
         assert code == 401
         assert "secret" not in str(body)
-        assert "Authentication system error" in str(body["detail"])
+        assert "Authentication system error" in str(body["message"])
 
     def test_successful_auth_unchanged(self) -> None:
         code, body, _headers = self._get(_auth_succeeding())

--- a/libs/aegra-api/tests/integration/test_auth_flow.py
+++ b/libs/aegra-api/tests/integration/test_auth_flow.py
@@ -12,8 +12,10 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
-from fastapi import Request
-from starlette.authentication import AuthCredentials, AuthenticationError
+from fastapi import Depends, FastAPI, Request
+from fastapi.testclient import TestClient
+from langgraph_sdk import Auth
+from starlette.authentication import AuthCredentials
 from starlette.requests import HTTPConnection
 
 from aegra_api.core.auth_deps import require_auth
@@ -182,8 +184,10 @@ class TestMockJWTAuth:
         mock_conn = Mock(spec=HTTPConnection)
         mock_conn.headers = {"authorization": "Bearer invalid-token"}
 
-        with pytest.raises(AuthenticationError):
+        with pytest.raises(Auth.exceptions.HTTPException) as exc_info:
             await mock_jwt_auth_backend.authenticate(mock_conn)
+
+        assert exc_info.value.status_code == 401
 
     @pytest.mark.asyncio
     async def test_mock_jwt_missing_token(self, mock_jwt_auth_backend):
@@ -191,10 +195,11 @@ class TestMockJWTAuth:
         mock_conn = Mock(spec=HTTPConnection)
         mock_conn.headers = {}
 
-        with pytest.raises(AuthenticationError) as exc_info:
+        with pytest.raises(Auth.exceptions.HTTPException) as exc_info:
             await mock_jwt_auth_backend.authenticate(mock_conn)
 
-        assert "Missing or invalid" in str(exc_info.value)
+        assert exc_info.value.status_code == 401
+        assert "Missing or invalid" in str(exc_info.value.detail)
 
     @pytest.mark.asyncio
     async def test_mock_jwt_malformed_token(self, mock_jwt_auth_backend):
@@ -202,10 +207,11 @@ class TestMockJWTAuth:
         mock_conn = Mock(spec=HTTPConnection)
         mock_conn.headers = {"authorization": "Bearer mock-jwt-incomplete"}
 
-        with pytest.raises(AuthenticationError) as exc_info:
+        with pytest.raises(Auth.exceptions.HTTPException) as exc_info:
             await mock_jwt_auth_backend.authenticate(mock_conn)
 
-        assert "missing required fields" in str(exc_info.value).lower()
+        assert exc_info.value.status_code == 401
+        assert "missing required fields" in str(exc_info.value.detail).lower()
 
     @pytest.mark.asyncio
     async def test_mock_jwt_premium_role(self, mock_jwt_auth_backend):
@@ -348,3 +354,99 @@ class TestUserModelCustomFields:
             # Verify request scope was set
             assert mock_request.scope["user"] is not None
             assert mock_request.scope["auth"] is not None
+
+
+def _auth_raising(*, status_code: int, detail: str, headers: dict[str, str] | None = None) -> Auth:
+    """Auth whose @authenticate handler raises a fixed HTTPException."""
+    auth = Auth()
+
+    @auth.authenticate
+    async def authenticate(_headers: dict[str, str]) -> dict[str, str]:
+        raise Auth.exceptions.HTTPException(status_code=status_code, detail=detail, headers=headers)
+
+    return auth
+
+
+def _auth_succeeding() -> Auth:
+    """Auth whose @authenticate handler always returns a user."""
+    auth = Auth()
+
+    @auth.authenticate
+    async def authenticate(_headers: dict[str, str]) -> dict[str, str | bool]:
+        return {
+            "identity": "ok-user",
+            "display_name": "OK User",
+            "is_authenticated": True,
+        }
+
+    return auth
+
+
+class TestAuthenticateHttpStatusPassthrough:
+    """HTTP-level: handler status codes must reach the response, not collapse to 401."""
+
+    def _get(self, auth_instance: Auth | None) -> tuple[int, dict[str, object], dict[str, str]]:
+        backend = LangGraphAuthBackend()
+        backend.auth_instance = auth_instance
+
+        app = FastAPI()
+
+        @app.get("/protected")
+        async def protected(user: User = Depends(require_auth)) -> dict[str, str]:
+            return {"identity": user.identity}
+
+        with (
+            patch("aegra_api.core.auth_deps.get_auth_backend", return_value=backend),
+            TestClient(app, raise_server_exceptions=False) as client,
+        ):
+            response = client.get("/protected")
+            return response.status_code, response.json(), dict(response.headers)
+
+    @pytest.mark.parametrize(
+        ("status_code", "detail"),
+        [
+            (403, "account disabled"),
+            (429, "too many attempts"),
+            (503, "identity provider unreachable"),
+        ],
+    )
+    def test_handler_http_exception_status_reaches_client(self, status_code: int, detail: str) -> None:
+        code, body, _headers = self._get(_auth_raising(status_code=status_code, detail=detail))
+
+        assert code == status_code
+        assert body["detail"] == detail
+
+    def test_handler_http_exception_headers_reach_client(self) -> None:
+        _code, _body, headers = self._get(
+            _auth_raising(
+                status_code=401,
+                detail="invalid token",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+        )
+        assert headers.get("www-authenticate") == "Bearer"
+
+    def test_non_http_exception_stays_401_without_leaking(self) -> None:
+        auth = Auth()
+
+        @auth.authenticate
+        async def authenticate(_headers: dict[str, str]) -> dict[str, str]:
+            raise RuntimeError("postgres://secret@internal/db")
+
+        code, body, _headers = self._get(auth)
+
+        assert code == 401
+        assert "secret" not in str(body)
+        assert "Authentication system error" in str(body["detail"])
+
+    def test_successful_auth_unchanged(self) -> None:
+        code, body, _headers = self._get(_auth_succeeding())
+
+        assert code == 200
+        assert body == {"identity": "ok-user"}
+
+    def test_unconfigured_auth_still_anonymous(self) -> None:
+        code, body, _headers = self._get(None)
+
+        assert code == 200
+        assert body == {"identity": "anonymous"}

--- a/libs/aegra-api/tests/unit/test_core/test_auth_deps.py
+++ b/libs/aegra-api/tests/unit/test_core/test_auth_deps.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from fastapi import HTTPException, Request
+from langgraph_sdk import Auth
 from starlette.authentication import AuthCredentials
 
 from aegra_api.core.auth_deps import (
@@ -80,6 +81,77 @@ class TestRequireAuth:
 
             assert exc_info.value.status_code == 401
             assert "Auth error" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("status_code", "detail"),
+        [
+            (403, "account disabled"),
+            (429, "too many attempts"),
+            (503, "identity provider unreachable"),
+        ],
+    )
+    async def test_require_auth_preserves_handler_http_status(self, status_code: int, detail: str) -> None:
+        """@auth.authenticate HTTPException status and detail must reach the client."""
+        mock_backend = Mock()
+        mock_backend.authenticate = AsyncMock(
+            side_effect=Auth.exceptions.HTTPException(status_code=status_code, detail=detail)
+        )
+
+        mock_request = Mock(spec=Request)
+        mock_request.scope = {}
+
+        with (
+            patch("aegra_api.core.auth_deps.get_auth_backend", return_value=mock_backend),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await require_auth(mock_request)
+
+        assert exc_info.value.status_code == status_code
+        assert exc_info.value.detail == detail
+
+    @pytest.mark.asyncio
+    async def test_require_auth_preserves_handler_http_headers(self) -> None:
+        """Headers from Auth.exceptions.HTTPException are forwarded to FastAPI."""
+        mock_backend = Mock()
+        mock_backend.authenticate = AsyncMock(
+            side_effect=Auth.exceptions.HTTPException(
+                status_code=401,
+                detail="invalid token",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+        )
+
+        mock_request = Mock(spec=Request)
+        mock_request.scope = {}
+
+        with (
+            patch("aegra_api.core.auth_deps.get_auth_backend", return_value=mock_backend),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await require_auth(mock_request)
+
+        assert exc_info.value.status_code == 401
+        assert exc_info.value.detail == "invalid token"
+        assert exc_info.value.headers == {"WWW-Authenticate": "Bearer"}
+
+    @pytest.mark.asyncio
+    async def test_require_auth_reraises_fastapi_http_exception(self) -> None:
+        """A FastAPI HTTPException from the backend is not rewritten to 401."""
+        mock_backend = Mock()
+        mock_backend.authenticate = AsyncMock(side_effect=HTTPException(status_code=403, detail="forbidden"))
+
+        mock_request = Mock(spec=Request)
+        mock_request.scope = {}
+
+        with (
+            patch("aegra_api.core.auth_deps.get_auth_backend", return_value=mock_backend),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await require_auth(mock_request)
+
+        assert exc_info.value.status_code == 403
+        assert exc_info.value.detail == "forbidden"
 
     @pytest.mark.asyncio
     async def test_require_auth_preserves_custom_fields(self):

--- a/libs/aegra-api/tests/unit/test_core/test_auth_middleware.py
+++ b/libs/aegra-api/tests/unit/test_core/test_auth_middleware.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from langgraph_sdk import Auth
 from starlette.authentication import AuthCredentials, AuthenticationError
 from starlette.requests import HTTPConnection
 from starlette.responses import JSONResponse
@@ -360,27 +361,49 @@ class TestLangGraphAuthBackend:
             await backend.authenticate(mock_conn)
 
     @pytest.mark.asyncio
-    async def test_authenticate_http_exception(self):
-        """Test authentication with HTTP exception"""
+    @pytest.mark.parametrize(
+        ("status_code", "detail"),
+        [
+            (401, "Invalid token"),
+            (403, "account disabled"),
+            (429, "too many attempts"),
+        ],
+    )
+    async def test_authenticate_http_exception_is_not_rewritten(self, status_code: int, detail: str) -> None:
+        """Handler HTTPException must keep its status_code; do not wrap as AuthenticationError."""
         mock_auth_instance = Mock()
-
-        # Create a mock exception with detail attribute
-        mock_http_exception = Exception("Auth failed")
-        mock_http_exception.detail = "Invalid token"
-        mock_auth_instance._authenticate_handler = AsyncMock(side_effect=mock_http_exception)
+        mock_auth_instance._authenticate_handler = AsyncMock(
+            side_effect=Auth.exceptions.HTTPException(status_code=status_code, detail=detail)
+        )
 
         backend = LangGraphAuthBackend()
         backend.auth_instance = mock_auth_instance
 
-        # Mock the Auth.exceptions.HTTPException to be the same as our exception
-        with patch("aegra_api.core.auth_middleware.Auth") as mock_auth:
-            mock_auth.exceptions.HTTPException = Exception
+        mock_conn = Mock(spec=HTTPConnection)
+        mock_conn.headers = {"authorization": b"Bearer token123"}
 
-            mock_conn = Mock(spec=HTTPConnection)
-            mock_conn.headers = {"authorization": b"Bearer token123"}
+        with pytest.raises(Auth.exceptions.HTTPException) as exc_info:
+            await backend.authenticate(mock_conn)
 
-            with pytest.raises(AuthenticationError, match="Invalid token"):
-                await backend.authenticate(mock_conn)
+        assert exc_info.value.status_code == status_code
+        assert exc_info.value.detail == detail
+
+    @pytest.mark.asyncio
+    async def test_authenticate_unexpected_exception_stays_generic(self) -> None:
+        """Non-HTTPException handler bugs must not leak internals or invent a status."""
+        mock_auth_instance = Mock()
+        mock_auth_instance._authenticate_handler = AsyncMock(side_effect=RuntimeError("postgres://secret@internal/db"))
+
+        backend = LangGraphAuthBackend()
+        backend.auth_instance = mock_auth_instance
+
+        mock_conn = Mock(spec=HTTPConnection)
+        mock_conn.headers = {"authorization": b"Bearer token123"}
+
+        with pytest.raises(AuthenticationError, match="Authentication system error") as exc_info:
+            await backend.authenticate(mock_conn)
+
+        assert "secret" not in str(exc_info.value)
 
     @pytest.mark.asyncio
     async def test_authenticate_headers_conversion(self):

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.10.4"
+version = "0.10.5"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.10.4"
+version = "0.10.5"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -100,7 +100,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.10.4"
+version = "0.10.5"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
## Description

`@auth.authenticate` handlers that raise `Auth.exceptions.HTTPException` with a non-401 status (403, 429, 503, …) currently always produce **401 Unauthorized**. The status is dropped in two places:

1. `LangGraphAuthBackend.authenticate` wraps the handler exception in Starlette `AuthenticationError`, which has no `status_code`.
2. `require_auth` catches `Exception` and hardcodes `HTTPException(status_code=401, ...)`.

This matches LangGraph Platform poorly: clients treat 401 as “session invalid, clear credentials,” so a transient IdP outage (503) or a disabled account (403) looks like a logout.

The proposed contract is documented on [#543](https://github.com/aegra/aegra/issues/543#issuecomment-5406581841). This PR implements that contract.

## Type of Change
- [x] `fix`: Bug fix
- [ ] `feat`: New feature
- [x] `docs`: Documentation changes
- [ ] `style`: Code style/formatting
- [ ] `refactor`: Code refactoring
- [ ] `perf`: Performance improvement
- [x] `test`: Tests added/updated
- [ ] `chore`: Maintenance (dependencies, build, etc.)
- [ ] `ci`: CI/CD changes

## Related Issues
Fixes #543

## Changes Made
- Re-raise `Auth.exceptions.HTTPException` from `LangGraphAuthBackend.authenticate` instead of converting it to `AuthenticationError`.
- In `require_auth`, catch that exception *before* the generic handler and re-raise FastAPI `HTTPException` with the same `status_code` / `detail` / `headers` (same conversion `@auth.on` already uses in `auth_handlers.py`).
- Forward `HTTPException.headers` through the Agent Protocol error handler so values like `WWW-Authenticate` actually reach the client.
- Document the status-code contract under `docs/guides/authentication.mdx` (“Denying access”).

### Status contract

| Case | Status |
|---|---|
| Handler raises `Auth.exceptions.HTTPException` | Pass through `status_code` / `detail` / `headers` (SDK default is 401 when omitted) |
| Missing / invalid credentials with no explicit HTTPException | 401 (unchanged) |
| Authenticated but `@auth.on` denies | 403 (unchanged; this PR does not touch authorization) |
| Handler raises a non-HTTPException | Unchanged: generic `AuthenticationError("Authentication system error")` → 401, no internal exception text leaked |

Out of scope: #542 filter semantics, `@auth.on` dispatch, anonymous/noop fallback, 404 resource hiding.

### Before / after

Custom handler:

```python
raise Auth.exceptions.HTTPException(status_code=403, detail="account disabled")
```

| | Before | After |
|---|---|---|
| Disabled account (`403`) | `401` | `403` |
| Rate limit (`429`) | `401` | `429` |
| IdP down (`503`) | `401` | `503` |
| Invalid token (`401`) | `401` | `401` |
| Unexpected handler bug | `401`, no leak | `401`, no leak |
| No auth configured | anonymous `200` | anonymous `200` |

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] E2E tests added/updated
- [x] Manual testing performed

### Local results

**Unit + integration** (`uv run --package aegra-api pytest libs/aegra-api/tests/unit libs/aegra-api/tests/integration`): 1910 passed. Two failures unrelated to this change (flaky heartbeat timing; a DB test hitting a local Postgres without the `postgres` role). Auth-specific files: **77 passed**.

**Lint / types / security**
- `ruff format --check .` and `ruff check .`: pass
- `ty check`: pre-existing diagnostics only (none in the touched auth dispatch)
- `bandit`: no issues

**`make e2e-auth` equivalent** (JWT mock auth, LocalExecutor; isolated compose project on port 2126 because 2026/5433 were already in use):

```
37 passed, 5 deselected
```

Includes new coverage:
- `test_disabled_account_returns_403`
- `test_rate_limited_identity_returns_429`

Smoke against a live auth server:

```
no Authorization → 401
mock-jwt-disabled-user-… → 403
mock-jwt-ratelimited-user-… → 429
valid token → 200
```

**`make e2e-dev` equivalent**: 96 passed, 3 skipped, 27 failed. Failures are LLM runs against the placeholder `OPENAI_API_KEY` from `.env.example` (`Incorrect API key provided: sk-....`) plus a concurrent-create disconnect; not auth-status related. Thread search/CRUD/update-state paths that do not call the model passed.

## Checklist
- [x] Code follows project style (Ruff formatting)
- [x] All linting checks pass (`make lint`)
- [x] Type checking passes (`make type-check`) — pre-existing `ty` findings only
- [x] All tests pass (`make test`) — see notes above for two unrelated failures
- [x] Documentation updated (if needed)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] PR title follows Conventional Commits format

## Additional Notes

`aegra-api` and `aegra-cli` are bumped to **0.10.5** in `2e99753` (Greptile). Several open PRs (#549, #552, #553, plus local #471/#548 work) currently claim the same patch: whichever merges first owns 0.10.5, and later PRs will need another bump.

Auth status regression tests now register `agent_protocol_exception_handler` and assert the Agent Protocol `message` field plus `WWW-Authenticate`.

`on_auth_error` still hardcodes 401. That path is unused by `require_auth` (which replaced Starlette `AuthenticationMiddleware`); left it alone to avoid a behavior change on a dead path.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication responses now preserve handler-defined status codes, messages, and headers.
  * Account-disabled, rate-limited, and similar conditions return accurate responses instead of generic 401 errors.
  * Unexpected authentication failures continue to return secure, sanitized 401 responses.

* **Documentation**
  * Updated authentication guidance with examples for common denial scenarios and identity-provider outages.

* **Examples**
  * Expanded the JWT authentication example to demonstrate disabled-account and rate-limit responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR preserves explicit authentication-handler HTTP status codes, details, and headers through the FastAPI response path.
- Converts LangGraph authentication exceptions without replacing their status codes.
- Forwards exception headers through the Agent Protocol error handler.
- Adds unit, integration, and end-to-end coverage for 403, 429, and 503 responses.
- Synchronizes the API, CLI, and lockfile package versions at 0.10.5.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the previously reported synchronized version-bump issue is fixed at 0.10.5 across both packages and their lockfile entries.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/core/auth_deps.py | Converts explicit LangGraph authentication exceptions to FastAPI exceptions while preserving status, detail, and headers. |
| libs/aegra-api/src/aegra_api/core/auth_middleware.py | Re-raises handler-selected HTTP exceptions instead of collapsing them into statusless authentication errors. |
| libs/aegra-api/src/aegra_api/main.py | Includes HTTP exception headers in Agent Protocol error responses. |
| libs/aegra-api/pyproject.toml | Applies the required synchronized patch bump to version 0.10.5. |
| libs/aegra-cli/pyproject.toml | Keeps the CLI package version synchronized at 0.10.5. |
| uv.lock | Synchronizes the workspace lockfile entries with both package version bumps. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant API as FastAPI dependency
    participant Backend as LangGraphAuthBackend
    participant Handler as @auth.authenticate
    Client->>API: Protected request
    API->>Backend: authenticate(request)
    Backend->>Handler: invoke(headers)
    Handler-->>Backend: Auth HTTPException(status, detail, headers)
    Backend-->>API: re-raise unchanged
    API-->>Client: Agent Protocol response with preserved status and headers
```
</details>

<sub>Reviews (2): Last reviewed commit: ["test(api): register Agent Protocol handl..."](https://github.com/aegra/aegra/commit/2e997536b3757325b30904e44d06ede98189a4b0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56559596)</sub>

<!-- /greptile_comment -->