### PR TITLE
fix(api): load custom auth module once instead of per request

### DIFF
--- a/libs/aegra-api/src/aegra_api/core/auth_deps.py
+++ b/libs/aegra-api/src/aegra_api/core/auth_deps.py
@@ -4,7 +4,7 @@ from typing import Annotated, Any
 
 from fastapi import Depends, HTTPException, Request
 
-from aegra_api.core.auth_middleware import get_auth_backend
+from aegra_api.core.auth_middleware import get_auth_backend_async
 from aegra_api.models.auth import User
 
 
@@ -70,7 +70,7 @@ async def require_auth(request: Request) -> User:
     Raises:
         HTTPException: If user is not authenticated
     """
-    backend = get_auth_backend()
+    backend = await get_auth_backend_async()
 
     try:
         result = await backend.authenticate(request)

--- a/libs/aegra-api/src/aegra_api/core/auth_middleware.py
+++ b/libs/aegra-api/src/aegra_api/core/auth_middleware.py
@@ -63,6 +63,130 @@ class LangGraphUser(BaseUser):
         return self._user_data.copy()
 
 
+def _load_auth_from_file(file_path: Path, var_name: str) -> Auth | None:
+    """Load auth instance from a file path.
+
+    Args:
+        file_path: Path to the Python file
+        var_name: Name of the variable to load
+
+    Returns:
+        Auth instance or None if loading fails
+    """
+    try:
+        if not file_path.exists():
+            logger.warning(f"Auth file not found: {file_path}")
+            return None
+
+        if not file_path.is_file():
+            logger.warning(f"Auth path is not a file: {file_path} (is directory: {file_path.is_dir()})")
+            return None
+
+        # Create a unique module name based on the file path
+        module_name = f"auth_module_{file_path.stem}"
+
+        spec = importlib.util.spec_from_file_location(module_name, str(file_path))
+        if spec is None or spec.loader is None:
+            logger.error(f"Could not load auth module from {file_path}")
+            return None
+
+        auth_module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = auth_module
+        spec.loader.exec_module(auth_module)
+
+        auth_instance = getattr(auth_module, var_name, None)
+        if not isinstance(auth_instance, Auth):
+            logger.error(f"Variable '{var_name}' in {file_path} is not an Auth instance")
+            return None
+
+        logger.info(f"Successfully loaded auth instance from {file_path}:{var_name}")
+        return auth_instance
+
+    except Exception as e:
+        logger.error(f"Error loading auth from {file_path}: {e}", exc_info=True)
+        return None
+
+
+def _load_auth_from_module(module_path: str, var_name: str) -> Auth | None:
+    """Load auth instance from an installed module.
+
+    Args:
+        module_path: Dotted module path (e.g., 'mypackage.auth')
+        var_name: Name of the variable to load
+
+    Returns:
+        Auth instance or None if loading fails
+    """
+    try:
+        module = importlib.import_module(module_path)
+        auth_instance = getattr(module, var_name, None)
+
+        if not isinstance(auth_instance, Auth):
+            logger.error(f"Variable '{var_name}' in module {module_path} is not an Auth instance")
+            return None
+
+        logger.info(f"Successfully loaded auth instance from {module_path}:{var_name}")
+        return auth_instance
+
+    except ImportError as e:
+        logger.error(f"Could not import module {module_path}: {e}")
+        return None
+    except Exception as e:
+        logger.error(f"Error loading auth from {module_path}: {e}", exc_info=True)
+        return None
+
+
+@functools.lru_cache(maxsize=32)
+def _load_auth_from_path(path: str) -> Auth | None:
+    """Load Auth from './file.py:var' or 'module:var'. Cached per config path.
+
+    `aegra dev` reload starts a new process, so this does not hot-reload on disk edits.
+    """
+    if ":" not in path:
+        logger.error(f"Invalid auth path format (missing ':'): {path}")
+        return None
+
+    module_path, var_name = path.rsplit(":", 1)
+
+    # Handle file path format: ./file.py or ./path/to/file.py or ../file.py
+    is_file_path = module_path.endswith(".py") or module_path.startswith("./") or module_path.startswith("../")
+    if is_file_path:
+        file_path = Path(module_path)
+
+        # Resolve relative paths from config directory
+        if not file_path.is_absolute():
+            config_dir = get_config_dir()
+            if config_dir:
+                file_path = (config_dir / file_path).resolve()
+            else:
+                # Fallback to CWD if no config found
+                file_path = (Path.cwd() / file_path).resolve()
+
+        return _load_auth_from_file(file_path, var_name)
+
+    # Handle module format: module.path
+    return _load_auth_from_module(module_path, var_name)
+
+
+@functools.lru_cache(maxsize=1)
+def _cached_load_auth_from_config() -> Auth | None:
+    """Read auth.path from config and load. Cached for the process lifetime."""
+    try:
+        auth_config = load_auth_config()
+        if auth_config and "path" in auth_config:
+            auth_path = auth_config["path"]
+            logger.info(f"Loading auth from config path: {auth_path}")
+            auth_instance = _load_auth_from_path(auth_path)
+            if auth_instance:
+                return auth_instance
+            logger.warning(f"Failed to load auth from config path: {auth_path}")
+    except Exception as e:
+        logger.warning(f"Error loading auth config: {e}")
+
+    logger.debug("No auth instance found from config")
+    return None
+
+
 class LangGraphAuthBackend(AuthenticationBackend):
     """
     Authentication backend that uses the auth system.
@@ -91,128 +215,7 @@ class LangGraphAuthBackend(AuthenticationBackend):
         Returns:
             Auth instance or None if not found (noop handled in authenticate() method)
         """
-        # 1. Try loading from config
-        try:
-            auth_config = load_auth_config()
-            if auth_config and "path" in auth_config:
-                auth_path = auth_config["path"]
-                logger.info(f"Loading auth from config path: {auth_path}")
-                auth_instance = self._load_from_path(auth_path)
-                if auth_instance:
-                    return auth_instance
-                logger.warning(f"Failed to load auth from config path: {auth_path}")
-        except Exception as e:
-            logger.warning(f"Error loading auth config: {e}")
-
-        logger.debug("No auth instance found from config")
-        return None
-
-    def _load_from_path(self, path: str) -> Auth | None:
-        """Load auth instance from path in format './file.py:var' or 'module:var'.
-
-        Relative paths are resolved from the config file directory.
-
-        Args:
-            path: Import path in format './file.py:variable' or 'module.path:variable'
-
-        Returns:
-            Auth instance or None if loading fails
-        """
-        if ":" not in path:
-            logger.error(f"Invalid auth path format (missing ':'): {path}")
-            return None
-
-        module_path, var_name = path.rsplit(":", 1)
-
-        # Handle file path format: ./file.py or ./path/to/file.py or ../file.py
-        is_file_path = module_path.endswith(".py") or module_path.startswith("./") or module_path.startswith("../")
-        if is_file_path:
-            file_path = Path(module_path)
-
-            # Resolve relative paths from config directory
-            if not file_path.is_absolute():
-                config_dir = get_config_dir()
-                if config_dir:
-                    file_path = (config_dir / file_path).resolve()
-                else:
-                    # Fallback to CWD if no config found
-                    file_path = (Path.cwd() / file_path).resolve()
-
-            return self._load_from_file(file_path, var_name)
-
-        # Handle module format: module.path
-        return self._load_from_module(module_path, var_name)
-
-    def _load_from_file(self, file_path: Path, var_name: str) -> Auth | None:
-        """Load auth instance from a file path.
-
-        Args:
-            file_path: Path to the Python file
-            var_name: Name of the variable to load
-
-        Returns:
-            Auth instance or None if loading fails
-        """
-        try:
-            if not file_path.exists():
-                logger.warning(f"Auth file not found: {file_path}")
-                return None
-
-            if not file_path.is_file():
-                logger.warning(f"Auth path is not a file: {file_path} (is directory: {file_path.is_dir()})")
-                return None
-
-            # Create a unique module name based on the file path
-            module_name = f"auth_module_{file_path.stem}"
-
-            spec = importlib.util.spec_from_file_location(module_name, str(file_path))
-            if spec is None or spec.loader is None:
-                logger.error(f"Could not load auth module from {file_path}")
-                return None
-
-            auth_module = importlib.util.module_from_spec(spec)
-            sys.modules[module_name] = auth_module
-            spec.loader.exec_module(auth_module)
-
-            auth_instance = getattr(auth_module, var_name, None)
-            if not isinstance(auth_instance, Auth):
-                logger.error(f"Variable '{var_name}' in {file_path} is not an Auth instance")
-                return None
-
-            logger.info(f"Successfully loaded auth instance from {file_path}:{var_name}")
-            return auth_instance
-
-        except Exception as e:
-            logger.error(f"Error loading auth from {file_path}: {e}", exc_info=True)
-            return None
-
-    def _load_from_module(self, module_path: str, var_name: str) -> Auth | None:
-        """Load auth instance from an installed module.
-
-        Args:
-            module_path: Dotted module path (e.g., 'mypackage.auth')
-            var_name: Name of the variable to load
-
-        Returns:
-            Auth instance or None if loading fails
-        """
-        try:
-            module = importlib.import_module(module_path)
-            auth_instance = getattr(module, var_name, None)
-
-            if not isinstance(auth_instance, Auth):
-                logger.error(f"Variable '{var_name}' in module {module_path} is not an Auth instance")
-                return None
-
-            logger.info(f"Successfully loaded auth instance from {module_path}:{var_name}")
-            return auth_instance
-
-        except ImportError as e:
-            logger.error(f"Could not import module {module_path}: {e}")
-            return None
-        except Exception as e:
-            logger.error(f"Error loading auth from {module_path}: {e}", exc_info=True)
-            return None
+        return _cached_load_auth_from_config()
 
     async def authenticate(self, conn: HTTPConnection) -> tuple[AuthCredentials, BaseUser] | None:
         """
@@ -304,6 +307,13 @@ def get_auth_backend() -> AuthenticationBackend:
     else:
         logger.warning(f"Unknown AUTH_TYPE: {auth_type}, using noop")
         return LangGraphAuthBackend()
+
+
+def _clear_auth_loader_caches() -> None:
+    """Drop process-level auth loader caches. Tests call this for isolation."""
+    _cached_load_auth_from_config.cache_clear()
+    _load_auth_from_path.cache_clear()
+    get_auth_backend.cache_clear()
 
 
 def on_auth_error(conn: HTTPConnection, exc: AuthenticationError) -> JSONResponse:

--- a/libs/aegra-api/src/aegra_api/core/auth_middleware.py
+++ b/libs/aegra-api/src/aegra_api/core/auth_middleware.py
@@ -11,6 +11,7 @@ import importlib
 import importlib.util
 import sys
 import threading
+from concurrent.futures import Future
 from pathlib import Path
 from typing import Any, Protocol
 
@@ -34,19 +35,14 @@ logger = structlog.getLogger(__name__)
 
 # Thread callers (lru_cache concurrent misses). Never acquired on a running loop.
 _auth_thread_lock = threading.RLock()
-_auth_async_lock: asyncio.Lock | None = None
+# Shared in-flight backend fill. Sync waiters use Future.result(); async waiters wrap it.
+_auth_fill_guard = threading.Lock()
+_auth_backend_fill: Future[AuthenticationBackend] | None = None
 
 
 class _LruCachedFn[T](Protocol):
     def __call__(self) -> T: ...
     def cache_info(self) -> Any: ...
-
-
-def _get_auth_async_lock() -> asyncio.Lock:
-    global _auth_async_lock
-    if _auth_async_lock is None:
-        _auth_async_lock = asyncio.Lock()
-    return _auth_async_lock
 
 
 def _lru_fill_once[T](cached_fn: _LruCachedFn[T]) -> T:
@@ -324,6 +320,42 @@ class LangGraphAuthBackend(AuthenticationBackend):
             raise AuthenticationError("Authentication system error") from e
 
 
+def _claim_auth_backend_fill() -> tuple[Future[AuthenticationBackend], bool]:
+    """Return the in-flight fill future and whether the caller must populate it."""
+    global _auth_backend_fill
+    with _auth_fill_guard:
+        if _get_auth_backend_cached.cache_info().currsize:
+            done: Future[AuthenticationBackend] = Future()
+            done.set_result(_get_auth_backend_cached())
+            return done, False
+        if _auth_backend_fill is None or _auth_backend_fill.done():
+            _auth_backend_fill = Future()
+            return _auth_backend_fill, True
+        return _auth_backend_fill, False
+
+
+def _fail_auth_backend_fill(fut: Future[AuthenticationBackend], exc: BaseException) -> None:
+    """Publish a joinable error; never attach CancelledError to waiters."""
+    if fut.done():
+        return
+    if isinstance(exc, Exception):
+        fut.set_exception(exc)
+        return
+    fut.set_exception(RuntimeError("auth backend initialization failed"))
+
+
+def _complete_auth_backend_fill(fut: Future[AuthenticationBackend]) -> AuthenticationBackend:
+    """Run the cached constructor and publish the result to joiners."""
+    try:
+        result = _get_auth_backend_cached()
+    except BaseException as exc:
+        _fail_auth_backend_fill(fut, exc)
+        raise
+    if not fut.done():
+        fut.set_result(result)
+    return result
+
+
 @functools.lru_cache(maxsize=1)
 def _get_auth_backend_cached() -> AuthenticationBackend:
     auth_type = settings.app.AUTH_TYPE
@@ -345,28 +377,38 @@ def get_auth_backend() -> AuthenticationBackend:
     Returns:
         AuthenticationBackend instance
     """
-    return _lru_fill_once(_get_auth_backend_cached)
+    if _get_auth_backend_cached.cache_info().currsize:
+        return _get_auth_backend_cached()
+    fut, owner = _claim_auth_backend_fill()
+    if not owner:
+        return fut.result()
+    return _complete_auth_backend_fill(fut)
 
 
 async def get_auth_backend_async() -> AuthenticationBackend:
-    """Async single-flight wrapper for request-path backend construction."""
+    """Join get_auth_backend()'s in-flight Future; owner fills on this loop, not in to_thread."""
     if _get_auth_backend_cached.cache_info().currsize:
         return _get_auth_backend_cached()
-    async with _get_auth_async_lock():
-        if _get_auth_backend_cached.cache_info().currsize:
-            return _get_auth_backend_cached()
-        # Let a racing task wait on the lock before this fill runs.
+    fut, owner = _claim_auth_backend_fill()
+    if not owner:
+        return await asyncio.wrap_future(fut)
+    try:
+        # Let a racing task await the future before this fill runs.
         await asyncio.sleep(0)
-        return _get_auth_backend_cached()
+        return _complete_auth_backend_fill(fut)
+    except BaseException as exc:
+        _fail_auth_backend_fill(fut, exc)
+        raise
 
 
 def _clear_auth_loader_caches() -> None:
     """Drop process-level auth loader caches. Tests call this for isolation."""
-    global _auth_async_lock
-    _load_auth_from_config_cached.cache_clear()
-    _load_auth_from_path.cache_clear()
-    _get_auth_backend_cached.cache_clear()
-    _auth_async_lock = None
+    global _auth_backend_fill
+    with _auth_fill_guard:
+        _load_auth_from_config_cached.cache_clear()
+        _load_auth_from_path.cache_clear()
+        _get_auth_backend_cached.cache_clear()
+        _auth_backend_fill = None
 
 
 def on_auth_error(conn: HTTPConnection, exc: AuthenticationError) -> JSONResponse:

--- a/libs/aegra-api/src/aegra_api/core/auth_middleware.py
+++ b/libs/aegra-api/src/aegra_api/core/auth_middleware.py
@@ -35,7 +35,7 @@ logger = structlog.getLogger(__name__)
 
 # Thread callers (lru_cache concurrent misses). Never acquired on a running loop.
 _auth_thread_lock = threading.RLock()
-# Shared in-flight backend fill. Sync waiters use Future.result(); async waiters wrap it.
+# Shared in-flight backend fill. Callers join through get_auth_backend().
 _auth_fill_guard = threading.Lock()
 _auth_backend_fill: Future[AuthenticationBackend] | None = None
 
@@ -386,20 +386,11 @@ def get_auth_backend() -> AuthenticationBackend:
 
 
 async def get_auth_backend_async() -> AuthenticationBackend:
-    """Join get_auth_backend()'s in-flight Future; owner fills on this loop, not in to_thread."""
+    """Join get_auth_backend() off-loop so a sync waiter cannot deadlock this loop."""
     if _get_auth_backend_cached.cache_info().currsize:
         return _get_auth_backend_cached()
-    fut, owner = _claim_auth_backend_fill()
-    if not owner:
-        # shield: a cancelled joiner must not cancel the shared fill Future.
-        return await asyncio.shield(asyncio.wrap_future(fut))
-    try:
-        # Let a racing task await the future before this fill runs.
-        await asyncio.sleep(0)
-        return _complete_auth_backend_fill(fut)
-    except BaseException as exc:
-        _fail_auth_backend_fill(fut, exc)
-        raise
+    # shield: cancelling one waiter must not cancel the worker running the shared fill.
+    return await asyncio.shield(asyncio.to_thread(get_auth_backend))
 
 
 def _clear_auth_loader_caches() -> None:

--- a/libs/aegra-api/src/aegra_api/core/auth_middleware.py
+++ b/libs/aegra-api/src/aegra_api/core/auth_middleware.py
@@ -5,12 +5,14 @@ This module integrates authentication system with FastAPI
 using Starlette's AuthenticationMiddleware.
 """
 
+import asyncio
 import functools
 import importlib
 import importlib.util
 import sys
+import threading
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol
 
 import structlog
 from langgraph_sdk import Auth
@@ -29,6 +31,34 @@ from aegra_api.models.errors import AgentProtocolError
 from aegra_api.settings import settings
 
 logger = structlog.getLogger(__name__)
+
+# Thread callers (lru_cache concurrent misses). Never acquired on a running loop.
+_auth_thread_lock = threading.RLock()
+_auth_async_lock: asyncio.Lock | None = None
+
+
+class _LruCachedFn[T](Protocol):
+    def __call__(self) -> T: ...
+    def cache_info(self) -> Any: ...
+
+
+def _get_auth_async_lock() -> asyncio.Lock:
+    global _auth_async_lock
+    if _auth_async_lock is None:
+        _auth_async_lock = asyncio.Lock()
+    return _auth_async_lock
+
+
+def _lru_fill_once[T](cached_fn: _LruCachedFn[T]) -> T:
+    """Single-flight an lru_cache fill without blocking a running event loop."""
+    if cached_fn.cache_info().currsize:
+        return cached_fn()
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        with _auth_thread_lock:
+            return cached_fn()
+    return cached_fn()
 
 
 class LangGraphUser(BaseUser):
@@ -169,7 +199,7 @@ def _load_auth_from_path(path: str) -> Auth | None:
 
 
 @functools.lru_cache(maxsize=1)
-def _cached_load_auth_from_config() -> Auth | None:
+def _load_auth_from_config_cached() -> Auth | None:
     """Read auth.path from config and load. Cached for the process lifetime."""
     try:
         auth_config = load_auth_config()
@@ -185,6 +215,11 @@ def _cached_load_auth_from_config() -> Auth | None:
 
     logger.debug("No auth instance found from config")
     return None
+
+
+def _cached_load_auth_from_config() -> Auth | None:
+    """Load Auth from aegra.json; concurrent first-misses share one read."""
+    return _lru_fill_once(_load_auth_from_config_cached)
 
 
 class LangGraphAuthBackend(AuthenticationBackend):
@@ -290,15 +325,7 @@ class LangGraphAuthBackend(AuthenticationBackend):
 
 
 @functools.lru_cache(maxsize=1)
-def get_auth_backend() -> AuthenticationBackend:
-    """
-    Get authentication backend based on AUTH_TYPE environment variable.
-
-    Cached so the auth module is loaded once at first use, not per-request.
-
-    Returns:
-        AuthenticationBackend instance
-    """
+def _get_auth_backend_cached() -> AuthenticationBackend:
     auth_type = settings.app.AUTH_TYPE
 
     if auth_type in ["noop", "custom"]:
@@ -309,11 +336,37 @@ def get_auth_backend() -> AuthenticationBackend:
         return LangGraphAuthBackend()
 
 
+def get_auth_backend() -> AuthenticationBackend:
+    """
+    Get authentication backend based on AUTH_TYPE environment variable.
+
+    Cached so the auth module is loaded once at first use, not per-request.
+
+    Returns:
+        AuthenticationBackend instance
+    """
+    return _lru_fill_once(_get_auth_backend_cached)
+
+
+async def get_auth_backend_async() -> AuthenticationBackend:
+    """Async single-flight wrapper for request-path backend construction."""
+    if _get_auth_backend_cached.cache_info().currsize:
+        return _get_auth_backend_cached()
+    async with _get_auth_async_lock():
+        if _get_auth_backend_cached.cache_info().currsize:
+            return _get_auth_backend_cached()
+        # Let a racing task wait on the lock before this fill runs.
+        await asyncio.sleep(0)
+        return _get_auth_backend_cached()
+
+
 def _clear_auth_loader_caches() -> None:
     """Drop process-level auth loader caches. Tests call this for isolation."""
-    _cached_load_auth_from_config.cache_clear()
+    global _auth_async_lock
+    _load_auth_from_config_cached.cache_clear()
     _load_auth_from_path.cache_clear()
-    get_auth_backend.cache_clear()
+    _get_auth_backend_cached.cache_clear()
+    _auth_async_lock = None
 
 
 def on_auth_error(conn: HTTPConnection, exc: AuthenticationError) -> JSONResponse:

--- a/libs/aegra-api/src/aegra_api/core/auth_middleware.py
+++ b/libs/aegra-api/src/aegra_api/core/auth_middleware.py
@@ -391,7 +391,8 @@ async def get_auth_backend_async() -> AuthenticationBackend:
         return _get_auth_backend_cached()
     fut, owner = _claim_auth_backend_fill()
     if not owner:
-        return await asyncio.wrap_future(fut)
+        # shield: a cancelled joiner must not cancel the shared fill Future.
+        return await asyncio.shield(asyncio.wrap_future(fut))
     try:
         # Let a racing task await the future before this fill runs.
         await asyncio.sleep(0)

--- a/libs/aegra-api/tests/conftest.py
+++ b/libs/aegra-api/tests/conftest.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock
 import pytest
 from httpx import HTTPStatusError
 
+from aegra_api.core.auth_middleware import _clear_auth_loader_caches
 from tests.fixtures.auth import DummyUser
 from tests.fixtures.clients import (
     create_test_app,
@@ -129,8 +130,6 @@ def clear_auth_cache() -> Iterator[None]:
     Auth loaders and get_auth_backend() are process-cached; tests that swap
     aegra.json paths need a clean cache so they do not see a sibling's Auth.
     """
-    from aegra_api.core.auth_middleware import _clear_auth_loader_caches
-
     _clear_auth_loader_caches()
     yield
     _clear_auth_loader_caches()

--- a/libs/aegra-api/tests/conftest.py
+++ b/libs/aegra-api/tests/conftest.py
@@ -4,6 +4,7 @@ This file contains shared fixtures and configuration that are available
 to all tests across the test suite.
 """
 
+from collections.abc import Iterator
 from unittest.mock import AsyncMock
 
 import pytest
@@ -122,17 +123,17 @@ def runs_client():
 
 
 @pytest.fixture(autouse=True)
-def clear_auth_cache():
+def clear_auth_cache() -> Iterator[None]:
     """Clear auth caches before and after each test.
 
-    get_auth_backend() uses @lru_cache which can cause test isolation
-    issues when different tests need different auth configurations.
+    Auth loaders and get_auth_backend() are process-cached; tests that swap
+    aegra.json paths need a clean cache so they do not see a sibling's Auth.
     """
-    from aegra_api.core.auth_middleware import get_auth_backend
+    from aegra_api.core.auth_middleware import _clear_auth_loader_caches
 
-    get_auth_backend.cache_clear()
+    _clear_auth_loader_caches()
     yield
-    get_auth_backend.cache_clear()
+    _clear_auth_loader_caches()
 
 
 # --- AUTO-SKIP GEO-BLOCK FAILURES ---

--- a/libs/aegra-api/tests/integration/test_auth_flow.py
+++ b/libs/aegra-api/tests/integration/test_auth_flow.py
@@ -5,19 +5,25 @@ These tests validate:
 2. Mock JWT auth handler behavior
 3. User model with custom fields
 4. Noop auth fallback
+5. Custom auth module is loaded once and reused across requests
 """
 
+from __future__ import annotations
+
 import json
+from importlib.machinery import ModuleSpec
 from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
-from fastapi import Request
+from fastapi import Depends, FastAPI, Request
+from fastapi.testclient import TestClient
 from starlette.authentication import AuthCredentials, AuthenticationError
 from starlette.requests import HTTPConnection
 
+from aegra_api.core import auth_middleware as auth_middleware_module
 from aegra_api.core.auth_deps import require_auth
-from aegra_api.core.auth_middleware import LangGraphAuthBackend, LangGraphUser
+from aegra_api.core.auth_middleware import LangGraphAuthBackend, LangGraphUser, get_auth_backend
 from aegra_api.models.auth import User
 
 
@@ -348,3 +354,101 @@ class TestUserModelCustomFields:
             # Verify request scope was set
             assert mock_request.scope["user"] is not None
             assert mock_request.scope["auth"] is not None
+
+
+_CACHED_AUTH_SOURCE = """\
+from langgraph_sdk import Auth
+
+auth = Auth()
+
+
+@auth.authenticate
+async def authenticate(headers: dict) -> dict:
+    return {
+        "identity": "cached-user",
+        "display_name": "Cached User",
+        "is_authenticated": True,
+        "permissions": ["read"],
+        "team_id": "team-cache",
+    }
+"""
+
+
+def _count_auth_file_specs(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Record each importlib spec created for a custom auth file."""
+    real_spec_from_file_location = auth_middleware_module.importlib.util.spec_from_file_location
+    locations: list[str] = []
+
+    def counting_spec(
+        name: str,
+        location: str | None = None,
+        *args: object,
+        **kwargs: object,
+    ) -> ModuleSpec | None:
+        if location is not None:
+            locations.append(location)
+        return real_spec_from_file_location(name, location, *args, **kwargs)
+
+    monkeypatch.setattr(
+        auth_middleware_module.importlib.util,
+        "spec_from_file_location",
+        counting_spec,
+    )
+    return locations
+
+
+class TestAuthModuleCachedAcrossRequests:
+    """Auth handler behavior must stay identical while the module loads once."""
+
+    @pytest.fixture
+    def cached_auth_project(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+        """Project root with aegra.json pointing at a custom auth module."""
+        auth_file = tmp_path / "cached_auth.py"
+        auth_file.write_text(_CACHED_AUTH_SOURCE)
+        (tmp_path / "aegra.json").write_text(
+            json.dumps(
+                {
+                    "graphs": {"test": "./test.py:graph"},
+                    "auth": {"path": "./cached_auth.py:auth"},
+                }
+            )
+        )
+        monkeypatch.chdir(tmp_path)
+        return auth_file
+
+    @pytest.mark.asyncio
+    async def test_require_auth_loads_module_once_and_returns_same_user(
+        self, cached_auth_project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Several require_auth calls import the auth file once and keep handler results."""
+        locations = _count_auth_file_specs(monkeypatch)
+        users: list[User] = []
+        for _ in range(4):
+            mock_request = Mock(spec=Request)
+            mock_request.headers = {"authorization": "Bearer unused"}
+            mock_request.scope = {}
+            mock_request.user = None
+            users.append(await require_auth(mock_request))
+
+        assert [user.identity for user in users] == ["cached-user"] * 4
+        assert all(user.display_name == "Cached User" for user in users)
+        assert all(user.team_id == "team-cache" for user in users)
+        assert all(user.is_authenticated is True for user in users)
+        assert locations == [str(cached_auth_project.resolve())]
+        assert get_auth_backend() is get_auth_backend()
+
+    def test_http_requests_reuse_cached_auth(self, cached_auth_project: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """HTTP-level requests must not re-import the auth module."""
+        locations = _count_auth_file_specs(monkeypatch)
+
+        app = FastAPI()
+
+        @app.get("/whoami")
+        async def whoami_ok(user: User = Depends(require_auth)) -> dict[str, str]:
+            return {"identity": user.identity, "team_id": str(user.team_id)}
+
+        client = TestClient(app)
+        bodies = [client.get("/whoami").json() for _ in range(3)]
+
+        assert bodies == [{"identity": "cached-user", "team_id": "team-cache"}] * 3
+        assert locations == [str(cached_auth_project.resolve())]

--- a/libs/aegra-api/tests/integration/test_auth_flow.py
+++ b/libs/aegra-api/tests/integration/test_auth_flow.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import json
 from importlib.machinery import ModuleSpec
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from fastapi import Depends, FastAPI, Request
@@ -297,7 +297,10 @@ class TestUserModelCustomFields:
         mock_request.scope = {}
         mock_request.user = None
 
-        with patch("aegra_api.core.auth_deps.get_auth_backend", return_value=backend):
+        with patch(
+            "aegra_api.core.auth_deps.get_auth_backend_async",
+            AsyncMock(return_value=backend),
+        ):
             # Set scope with authenticated user
             mock_request.scope["user"] = langgraph_user
             mock_request.scope["auth"] = credentials
@@ -337,7 +340,10 @@ class TestUserModelCustomFields:
         mock_request.scope = {}
         mock_request.user = None
 
-        with patch("aegra_api.core.auth_deps.get_auth_backend", return_value=backend):
+        with patch(
+            "aegra_api.core.auth_deps.get_auth_backend_async",
+            AsyncMock(return_value=backend),
+        ):
             user = await require_auth(mock_request)
 
             # Verify user is authenticated and custom fields are present

--- a/libs/aegra-api/tests/unit/test_core/test_auth_deps.py
+++ b/libs/aegra-api/tests/unit/test_core/test_auth_deps.py
@@ -39,7 +39,10 @@ class TestRequireAuth:
         mock_request.scope = {}
         mock_request.user = None
 
-        with patch("aegra_api.core.auth_deps.get_auth_backend", return_value=mock_backend):
+        with patch(
+            "aegra_api.core.auth_deps.get_auth_backend_async",
+            AsyncMock(return_value=mock_backend),
+        ):
             user = await require_auth(mock_request)
 
             assert isinstance(user, User)
@@ -58,7 +61,10 @@ class TestRequireAuth:
         mock_request = Mock(spec=Request)
         mock_request.scope = {}
 
-        with patch("aegra_api.core.auth_deps.get_auth_backend", return_value=mock_backend):
+        with patch(
+            "aegra_api.core.auth_deps.get_auth_backend_async",
+            AsyncMock(return_value=mock_backend),
+        ):
             with pytest.raises(HTTPException) as exc_info:
                 await require_auth(mock_request)
 
@@ -74,7 +80,10 @@ class TestRequireAuth:
         mock_request = Mock(spec=Request)
         mock_request.scope = {}
 
-        with patch("aegra_api.core.auth_deps.get_auth_backend", return_value=mock_backend):
+        with patch(
+            "aegra_api.core.auth_deps.get_auth_backend_async",
+            AsyncMock(return_value=mock_backend),
+        ):
             with pytest.raises(HTTPException) as exc_info:
                 await require_auth(mock_request)
 
@@ -101,7 +110,10 @@ class TestRequireAuth:
         mock_request.scope = {}
         mock_request.user = None
 
-        with patch("aegra_api.core.auth_deps.get_auth_backend", return_value=mock_backend):
+        with patch(
+            "aegra_api.core.auth_deps.get_auth_backend_async",
+            AsyncMock(return_value=mock_backend),
+        ):
             user = await require_auth(mock_request)
 
             assert user.identity == "user-123"

--- a/libs/aegra-api/tests/unit/test_core/test_auth_middleware.py
+++ b/libs/aegra-api/tests/unit/test_core/test_auth_middleware.py
@@ -138,35 +138,6 @@ def _notify_when_auth_backend_claimed(
     return claimed
 
 
-def _notify_when_async_fill_wrapped(
-    monkeypatch: pytest.MonkeyPatch,
-    *,
-    waiters: int,
-) -> threading.Event:
-    """Set an event after `waiters` async joiners wrap the shared fill Future."""
-    wrapped = threading.Event()
-    guard = threading.Lock()
-    count = 0
-    real_wrap_future = asyncio.wrap_future
-
-    def counting_wrap_future(
-        future: Future[AuthenticationBackend],
-        *,
-        loop: asyncio.AbstractEventLoop | None = None,
-    ) -> asyncio.Future[AuthenticationBackend]:
-        nonlocal count
-        result = real_wrap_future(future, loop=loop)
-        if future is auth_middleware_module._auth_backend_fill:
-            with guard:
-                count += 1
-                if count >= waiters:
-                    wrapped.set()
-        return result
-
-    monkeypatch.setattr(asyncio, "wrap_future", counting_wrap_future)
-    return wrapped
-
-
 def _run_concurrent_calls_during_in_flight_import(
     *,
     load_started: threading.Event,
@@ -707,6 +678,75 @@ class TestAuthModuleLoadOnce:
         assert locations == [str(auth_file.resolve())]
 
     @pytest.mark.asyncio
+    async def test_async_fill_does_not_run_on_event_loop_thread(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Async init must complete the shared fill off the event-loop thread."""
+        _install_auth_config(tmp_path, monkeypatch)
+        loop_thread_id = threading.get_ident()
+        fill_thread_ids: list[int] = []
+        real_complete = auth_middleware_module._complete_auth_backend_fill
+
+        def tracking_complete(fut: Future[AuthenticationBackend]) -> AuthenticationBackend:
+            fill_thread_ids.append(threading.get_ident())
+            return real_complete(fut)
+
+        monkeypatch.setattr(auth_middleware_module, "_complete_auth_backend_fill", tracking_complete)
+
+        backend = await get_auth_backend_async()
+
+        assert isinstance(backend, LangGraphAuthBackend)
+        assert backend.auth_instance is not None
+        assert fill_thread_ids
+        assert loop_thread_id not in fill_thread_ids
+
+    @pytest.mark.asyncio
+    async def test_event_loop_sync_waiter_does_not_deadlock_async_fill(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A sync waiter on this loop must not block the worker that owns the fill."""
+        auth_file = _install_auth_config(tmp_path, monkeypatch)
+        locations, load_started, load_release = _block_first_auth_file_spec(monkeypatch)
+        loop_thread_id = threading.get_ident()
+        loop_waiting = threading.Event()
+        errors: list[BaseException] = []
+        real_future_result = Future.result
+
+        def tracking_result(
+            self: Future[AuthenticationBackend],
+            timeout: float | None = None,
+        ) -> AuthenticationBackend:
+            if self is auth_middleware_module._auth_backend_fill and threading.get_ident() == loop_thread_id:
+                loop_waiting.set()
+            return real_future_result(self, timeout)
+
+        monkeypatch.setattr(Future, "result", tracking_result)
+
+        def release_after_loop_waits() -> None:
+            if not loop_waiting.wait(timeout=5):
+                errors.append(TimeoutError("event-loop waiter did not block on shared fill"))
+            load_release.set()
+
+        releaser = threading.Thread(target=release_after_loop_waits)
+        releaser.start()
+        try:
+            async_task = asyncio.create_task(get_auth_backend_async())
+            assert await asyncio.to_thread(load_started.wait, 5)
+            sync_backend = get_auth_backend()
+            async_backend = await asyncio.wait_for(async_task, timeout=5)
+        finally:
+            load_release.set()
+            releaser.join(timeout=5)
+
+        assert errors == []
+        assert not releaser.is_alive()
+        assert not async_task.cancelled()
+        assert sync_backend is async_backend
+        assert isinstance(async_backend, LangGraphAuthBackend)
+        assert async_backend.auth_instance is not None
+        assert locations == [str(auth_file.resolve())]
+
+    @pytest.mark.asyncio
     async def test_concurrent_async_first_misses_load_auth_module_once(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
@@ -794,7 +834,6 @@ class TestAuthModuleLoadOnce:
         auth_file = _install_auth_config(tmp_path, monkeypatch)
         locations, load_started, load_release = _block_first_auth_file_spec(monkeypatch)
         all_claimed = _notify_when_auth_backend_claimed(monkeypatch, waiters=3)
-        joiners_wrapped = _notify_when_async_fill_wrapped(monkeypatch, waiters=2)
         sync_backends: list[object] = []
         errors: list[BaseException] = []
 
@@ -812,7 +851,6 @@ class TestAuthModuleLoadOnce:
             cancelled_joiner = asyncio.create_task(get_auth_backend_async())
             surviving_joiner = asyncio.create_task(get_auth_backend_async())
             assert await asyncio.to_thread(all_claimed.wait, 5)
-            assert await asyncio.to_thread(joiners_wrapped.wait, 5)
 
             shared_fill = auth_middleware_module._auth_backend_fill
             assert shared_fill is not None
@@ -824,6 +862,10 @@ class TestAuthModuleLoadOnce:
 
             load_release.set()
             surviving_backend = await asyncio.wait_for(surviving_joiner, timeout=5)
+            leftover = [task for task in asyncio.all_tasks() if task is not asyncio.current_task() and not task.done()]
+            if leftover:
+                _done, pending = await asyncio.wait(leftover, timeout=5)
+                assert not pending
         finally:
             load_release.set()
             sync_thread.join(timeout=5)
@@ -931,6 +973,24 @@ class TestAuthModuleLoadOnce:
         assert first_user.identity == "cached-user"
         assert second_user.identity == "cached-user"
         assert first_user.display_name == "Cached User"
+
+    def test_clear_auth_loader_caches_allows_reinitialization(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Clearing loader caches must drop the in-flight Future so a later call reloads."""
+        auth_file = _install_auth_config(tmp_path, monkeypatch)
+        locations = _count_spec_from_file_location(monkeypatch)
+
+        first = get_auth_backend()
+        auth_middleware_module._clear_auth_loader_caches()
+        assert auth_middleware_module._auth_backend_fill is None
+        second = get_auth_backend()
+
+        assert first is not second
+        assert isinstance(second, LangGraphAuthBackend)
+        assert first.auth_instance is not None
+        assert second.auth_instance is not None
+        assert locations == [str(auth_file.resolve()), str(auth_file.resolve())]
 
 
 class TestOnAuthError:

--- a/libs/aegra-api/tests/unit/test_core/test_auth_middleware.py
+++ b/libs/aegra-api/tests/unit/test_core/test_auth_middleware.py
@@ -1,6 +1,10 @@
 """Unit tests for auth middleware"""
 
+from __future__ import annotations
+
+import json
 import os
+from importlib.machinery import ModuleSpec
 from pathlib import Path
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -9,12 +13,70 @@ from starlette.authentication import AuthCredentials, AuthenticationError
 from starlette.requests import HTTPConnection
 from starlette.responses import JSONResponse
 
+from aegra_api.config import AuthConfig
+from aegra_api.core import auth_middleware as auth_middleware_module
 from aegra_api.core.auth_middleware import (
     LangGraphAuthBackend,
     LangGraphUser,
     get_auth_backend,
+    get_auth_instance,
     on_auth_error,
 )
+
+_COUNTING_AUTH_SOURCE = """\
+from langgraph_sdk import Auth
+
+auth = Auth()
+
+
+@auth.authenticate
+async def authenticate(headers: dict) -> dict:
+    return {
+        "identity": "cached-user",
+        "display_name": "Cached User",
+        "is_authenticated": True,
+        "permissions": ["read"],
+    }
+"""
+
+
+def _install_auth_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Write a custom auth module + aegra.json and chdir so the loader finds them."""
+    auth_file = tmp_path / "counting_auth.py"
+    auth_file.write_text(_COUNTING_AUTH_SOURCE)
+    (tmp_path / "aegra.json").write_text(
+        json.dumps(
+            {
+                "graphs": {"test": "./test.py:graph"},
+                "auth": {"path": "./counting_auth.py:auth"},
+            }
+        )
+    )
+    monkeypatch.chdir(tmp_path)
+    return auth_file
+
+
+def _count_spec_from_file_location(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    """Patch importlib so each auth-file spec creation is recorded."""
+    real_spec_from_file_location = auth_middleware_module.importlib.util.spec_from_file_location
+    locations: list[str] = []
+
+    def counting_spec(
+        name: str,
+        location: str | None = None,
+        *args: object,
+        **kwargs: object,
+    ) -> ModuleSpec | None:
+        if location is not None:
+            locations.append(location)
+        return real_spec_from_file_location(name, location, *args, **kwargs)
+
+    monkeypatch.setattr(
+        auth_middleware_module.importlib.util,
+        "spec_from_file_location",
+        counting_spec,
+    )
+    return locations
 
 
 class TestLangGraphUser:
@@ -412,29 +474,119 @@ class TestLangGraphAuthBackend:
 class TestGetAuthBackend:
     """Test get_auth_backend function"""
 
-    def test_get_auth_backend_noop(self):
+    def test_get_auth_backend_noop(self) -> None:
         """Test getting auth backend with noop type"""
         with patch.dict(os.environ, {"AUTH_TYPE": "noop"}):
             backend = get_auth_backend()
             assert isinstance(backend, LangGraphAuthBackend)
 
-    def test_get_auth_backend_custom(self):
+    def test_get_auth_backend_custom(self) -> None:
         """Test getting auth backend with custom type"""
         with patch.dict(os.environ, {"AUTH_TYPE": "custom"}):
             backend = get_auth_backend()
             assert isinstance(backend, LangGraphAuthBackend)
 
-    def test_get_auth_backend_unknown(self):
+    def test_get_auth_backend_unknown(self) -> None:
         """Test getting auth backend with unknown type"""
         with patch.dict(os.environ, {"AUTH_TYPE": "unknown"}):
             backend = get_auth_backend()
             assert isinstance(backend, LangGraphAuthBackend)
 
-    def test_get_auth_backend_default(self):
+    def test_get_auth_backend_default(self) -> None:
         """Test getting auth backend with no AUTH_TYPE set"""
         with patch.dict(os.environ, {}, clear=True):
             backend = get_auth_backend()
             assert isinstance(backend, LangGraphAuthBackend)
+
+    def test_get_auth_backend_returns_same_instance(self) -> None:
+        """get_auth_backend is a process singleton; repeated calls must not rebuild it."""
+        first = get_auth_backend()
+        second = get_auth_backend()
+        assert first is second
+
+
+class TestAuthModuleLoadOnce:
+    """Custom auth modules must be imported once per config path, not per request."""
+
+    def test_get_auth_backend_loads_auth_file_once(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Repeated get_auth_backend() calls import the auth file a single time."""
+        auth_file = _install_auth_config(tmp_path, monkeypatch)
+        locations = _count_spec_from_file_location(monkeypatch)
+
+        backends = [get_auth_backend() for _ in range(5)]
+
+        assert len({id(backend) for backend in backends}) == 1
+        assert isinstance(backends[0], LangGraphAuthBackend)
+        assert backends[0].auth_instance is not None
+        assert locations == [str(auth_file.resolve())]
+
+    def test_langgraph_auth_backend_init_reuses_cached_module(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Direct backend construction must still reuse the path-keyed module cache."""
+        auth_file = _install_auth_config(tmp_path, monkeypatch)
+        locations = _count_spec_from_file_location(monkeypatch)
+
+        first = LangGraphAuthBackend()
+        second = LangGraphAuthBackend()
+        via_factory = get_auth_backend()
+
+        assert isinstance(via_factory, LangGraphAuthBackend)
+        assert first.auth_instance is not None
+        assert first.auth_instance is second.auth_instance
+        assert first.auth_instance is via_factory.auth_instance
+        assert get_auth_instance() is first.auth_instance
+        assert locations == [str(auth_file.resolve())]
+
+    def test_missing_auth_file_is_not_reprobed_per_init(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A missing auth file is resolved once; later inits reuse that result."""
+        (tmp_path / "aegra.json").write_text(
+            json.dumps(
+                {
+                    "graphs": {"test": "./test.py:graph"},
+                    "auth": {"path": "./does_not_exist.py:auth"},
+                }
+            )
+        )
+        monkeypatch.chdir(tmp_path)
+        config_reads: list[int] = []
+        real_load_auth_config = auth_middleware_module.load_auth_config
+
+        def counting_load_auth_config() -> AuthConfig | None:
+            config_reads.append(1)
+            return real_load_auth_config()
+
+        monkeypatch.setattr(auth_middleware_module, "load_auth_config", counting_load_auth_config)
+
+        first = LangGraphAuthBackend()
+        second = LangGraphAuthBackend()
+
+        assert first.auth_instance is None
+        assert second.auth_instance is None
+        assert len(config_reads) == 1
+
+    @pytest.mark.asyncio
+    async def test_cached_auth_handler_still_authenticates(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Caching the Auth object must not change authenticate() results."""
+        _install_auth_config(tmp_path, monkeypatch)
+
+        backend = get_auth_backend()
+        assert isinstance(backend, LangGraphAuthBackend)
+
+        mock_conn = Mock(spec=HTTPConnection)
+        mock_conn.headers = {"authorization": "Bearer unused"}
+
+        first = await backend.authenticate(mock_conn)
+        second = await get_auth_backend().authenticate(mock_conn)
+
+        assert first is not None and second is not None
+        _, first_user = first
+        _, second_user = second
+        assert first_user.identity == "cached-user"
+        assert second_user.identity == "cached-user"
+        assert first_user.display_name == "Cached User"
 
 
 class TestOnAuthError:

--- a/libs/aegra-api/tests/unit/test_core/test_auth_middleware.py
+++ b/libs/aegra-api/tests/unit/test_core/test_auth_middleware.py
@@ -7,12 +7,13 @@ import json
 import os
 import threading
 from collections.abc import Callable
+from concurrent.futures import Future
 from importlib.machinery import ModuleSpec
 from pathlib import Path
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
-from starlette.authentication import AuthCredentials, AuthenticationError
+from starlette.authentication import AuthCredentials, AuthenticationBackend, AuthenticationError
 from starlette.requests import HTTPConnection
 from starlette.responses import JSONResponse
 
@@ -111,6 +112,30 @@ def _block_first_auth_file_spec(
         counting_spec,
     )
     return locations, load_started, load_release
+
+
+def _notify_when_auth_backend_claimed(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    waiters: int,
+) -> threading.Event:
+    """Set an event after `waiters` callers have claimed the shared fill Future."""
+    claimed = threading.Event()
+    guard = threading.Lock()
+    count = 0
+    real_claim = auth_middleware_module._claim_auth_backend_fill
+
+    def counting_claim() -> tuple[Future[AuthenticationBackend], bool]:
+        nonlocal count
+        result = real_claim()
+        with guard:
+            count += 1
+            if count >= waiters:
+                claimed.set()
+        return result
+
+    monkeypatch.setattr(auth_middleware_module, "_claim_auth_backend_fill", counting_claim)
+    return claimed
 
 
 def _run_concurrent_calls_during_in_flight_import(
@@ -680,6 +705,103 @@ class TestAuthModuleLoadOnce:
         assert isinstance(first, LangGraphAuthBackend)
         assert first.auth_instance is not None
         assert locations == [str(auth_file.resolve())]
+
+    @pytest.mark.asyncio
+    async def test_sync_thread_and_async_first_miss_load_auth_module_once(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A thread get_auth_backend() racing get_auth_backend_async() must import once."""
+        auth_file = _install_auth_config(tmp_path, monkeypatch)
+        locations, load_started, load_release = _block_first_auth_file_spec(monkeypatch)
+        both_claimed = _notify_when_auth_backend_claimed(monkeypatch, waiters=2)
+        sync_backends: list[object] = []
+        errors: list[BaseException] = []
+        sync_ready = threading.Event()
+        start_fill = threading.Event()
+
+        def call_sync() -> None:
+            sync_ready.set()
+            if not start_fill.wait(timeout=5):
+                errors.append(TimeoutError("sync caller was not released into the empty-cache fill"))
+                return
+            try:
+                sync_backends.append(get_auth_backend())
+            except Exception as exc:
+                errors.append(exc)
+
+        sync_thread = threading.Thread(target=call_sync)
+        sync_thread.start()
+        try:
+            assert await asyncio.to_thread(sync_ready.wait, 5)
+
+            async def call_async() -> object:
+                if not await asyncio.to_thread(start_fill.wait, 5):
+                    raise TimeoutError("async caller was not released into the empty-cache fill")
+                return await get_auth_backend_async()
+
+            async_task = asyncio.create_task(call_async())
+            start_fill.set()
+            assert await asyncio.to_thread(load_started.wait, 5)
+            assert await asyncio.to_thread(both_claimed.wait, 5)
+            load_release.set()
+            async_backend = await asyncio.wait_for(async_task, timeout=5)
+        finally:
+            load_release.set()
+            sync_thread.join(timeout=5)
+
+        assert errors == []
+        assert not sync_thread.is_alive()
+        assert len(sync_backends) == 1
+        assert sync_backends[0] is async_backend
+        assert isinstance(async_backend, LangGraphAuthBackend)
+        assert async_backend.auth_instance is not None
+        assert locations == [str(auth_file.resolve())]
+
+    @pytest.mark.asyncio
+    async def test_sync_and_async_joiners_see_same_fill_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A failed fill must set_exception so sync and async callers see the same error."""
+        both_claimed = _notify_when_auth_backend_claimed(monkeypatch, waiters=2)
+        sync_errors: list[BaseException] = []
+        sync_ready = threading.Event()
+        start_fill = threading.Event()
+
+        def exploding_init(self: LangGraphAuthBackend) -> None:
+            if not both_claimed.wait(timeout=5):
+                raise TimeoutError("second caller did not join before fill failed")
+            raise RuntimeError("backend fill failed")
+
+        monkeypatch.setattr(LangGraphAuthBackend, "__init__", exploding_init)
+
+        def call_sync() -> None:
+            sync_ready.set()
+            if not start_fill.wait(timeout=5):
+                sync_errors.append(TimeoutError("sync caller was not released into the empty-cache fill"))
+                return
+            try:
+                get_auth_backend()
+            except Exception as exc:
+                sync_errors.append(exc)
+
+        sync_thread = threading.Thread(target=call_sync)
+        sync_thread.start()
+        try:
+            assert await asyncio.to_thread(sync_ready.wait, 5)
+
+            async def call_async() -> None:
+                if not await asyncio.to_thread(start_fill.wait, 5):
+                    raise TimeoutError("async caller was not released into the empty-cache fill")
+                await get_auth_backend_async()
+
+            async_task = asyncio.create_task(call_async())
+            start_fill.set()
+            with pytest.raises(RuntimeError, match="backend fill failed") as async_raised:
+                await asyncio.wait_for(async_task, timeout=5)
+        finally:
+            sync_thread.join(timeout=5)
+
+        assert not sync_thread.is_alive()
+        assert len(sync_errors) == 1
+        assert sync_errors[0] is async_raised.value
 
     def test_missing_auth_file_is_not_reprobed_per_init(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """A missing auth file is resolved once; later inits reuse that result."""

--- a/libs/aegra-api/tests/unit/test_core/test_auth_middleware.py
+++ b/libs/aegra-api/tests/unit/test_core/test_auth_middleware.py
@@ -138,6 +138,35 @@ def _notify_when_auth_backend_claimed(
     return claimed
 
 
+def _notify_when_async_fill_wrapped(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    waiters: int,
+) -> threading.Event:
+    """Set an event after `waiters` async joiners wrap the shared fill Future."""
+    wrapped = threading.Event()
+    guard = threading.Lock()
+    count = 0
+    real_wrap_future = asyncio.wrap_future
+
+    def counting_wrap_future(
+        future: Future[AuthenticationBackend],
+        *,
+        loop: asyncio.AbstractEventLoop | None = None,
+    ) -> asyncio.Future[AuthenticationBackend]:
+        nonlocal count
+        result = real_wrap_future(future, loop=loop)
+        if future is auth_middleware_module._auth_backend_fill:
+            with guard:
+                count += 1
+                if count >= waiters:
+                    wrapped.set()
+        return result
+
+    monkeypatch.setattr(asyncio, "wrap_future", counting_wrap_future)
+    return wrapped
+
+
 def _run_concurrent_calls_during_in_flight_import(
     *,
     load_started: threading.Event,
@@ -755,6 +784,56 @@ class TestAuthModuleLoadOnce:
         assert sync_backends[0] is async_backend
         assert isinstance(async_backend, LangGraphAuthBackend)
         assert async_backend.auth_instance is not None
+        assert locations == [str(auth_file.resolve())]
+
+    @pytest.mark.asyncio
+    async def test_cancelled_async_joiner_does_not_cancel_shared_fill(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Cancelling one async joiner must not cancel the shared fill or other waiters."""
+        auth_file = _install_auth_config(tmp_path, monkeypatch)
+        locations, load_started, load_release = _block_first_auth_file_spec(monkeypatch)
+        all_claimed = _notify_when_auth_backend_claimed(monkeypatch, waiters=3)
+        joiners_wrapped = _notify_when_async_fill_wrapped(monkeypatch, waiters=2)
+        sync_backends: list[object] = []
+        errors: list[BaseException] = []
+
+        def call_sync() -> None:
+            try:
+                sync_backends.append(get_auth_backend())
+            except Exception as exc:
+                errors.append(exc)
+
+        sync_thread = threading.Thread(target=call_sync)
+        sync_thread.start()
+        try:
+            assert await asyncio.to_thread(load_started.wait, 5)
+
+            cancelled_joiner = asyncio.create_task(get_auth_backend_async())
+            surviving_joiner = asyncio.create_task(get_auth_backend_async())
+            assert await asyncio.to_thread(all_claimed.wait, 5)
+            assert await asyncio.to_thread(joiners_wrapped.wait, 5)
+
+            shared_fill = auth_middleware_module._auth_backend_fill
+            assert shared_fill is not None
+            cancelled_joiner.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await cancelled_joiner
+            assert not shared_fill.cancelled()
+            assert not shared_fill.done()
+
+            load_release.set()
+            surviving_backend = await asyncio.wait_for(surviving_joiner, timeout=5)
+        finally:
+            load_release.set()
+            sync_thread.join(timeout=5)
+
+        assert errors == []
+        assert not sync_thread.is_alive()
+        assert len(sync_backends) == 1
+        assert sync_backends[0] is surviving_backend
+        assert isinstance(surviving_backend, LangGraphAuthBackend)
+        assert surviving_backend.auth_instance is not None
         assert locations == [str(auth_file.resolve())]
 
     @pytest.mark.asyncio

--- a/libs/aegra-api/tests/unit/test_core/test_auth_middleware.py
+++ b/libs/aegra-api/tests/unit/test_core/test_auth_middleware.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
+import threading
+from collections.abc import Callable
 from importlib.machinery import ModuleSpec
 from pathlib import Path
 from unittest.mock import AsyncMock, Mock, patch
@@ -19,6 +22,7 @@ from aegra_api.core.auth_middleware import (
     LangGraphAuthBackend,
     LangGraphUser,
     get_auth_backend,
+    get_auth_backend_async,
     get_auth_instance,
     on_auth_error,
 )
@@ -77,6 +81,63 @@ def _count_spec_from_file_location(monkeypatch: pytest.MonkeyPatch) -> list[str]
         counting_spec,
     )
     return locations
+
+
+def _block_first_auth_file_spec(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[list[str], threading.Event, threading.Event]:
+    """Hold the first auth-file spec creation until the test releases it."""
+    real_spec_from_file_location = auth_middleware_module.importlib.util.spec_from_file_location
+    locations: list[str] = []
+    load_started = threading.Event()
+    load_release = threading.Event()
+
+    def counting_spec(
+        name: str,
+        location: str | None = None,
+        *args: object,
+        **kwargs: object,
+    ) -> ModuleSpec | None:
+        if location is not None:
+            locations.append(location)
+        load_started.set()
+        if not load_release.wait(timeout=5):
+            raise TimeoutError("in-flight auth import was not released")
+        return real_spec_from_file_location(name, location, *args, **kwargs)
+
+    monkeypatch.setattr(
+        auth_middleware_module.importlib.util,
+        "spec_from_file_location",
+        counting_spec,
+    )
+    return locations, load_started, load_release
+
+
+def _run_concurrent_calls_during_in_flight_import(
+    *,
+    load_started: threading.Event,
+    load_release: threading.Event,
+    target: Callable[[], None],
+) -> None:
+    """Release both callers together, then keep the first import in-flight."""
+    ready = threading.Barrier(2)
+
+    def gated() -> None:
+        ready.wait()
+        target()
+
+    first = threading.Thread(target=gated)
+    second = threading.Thread(target=gated)
+    first.start()
+    second.start()
+    try:
+        assert load_started.wait(timeout=5)
+    finally:
+        load_release.set()
+    first.join(timeout=5)
+    second.join(timeout=5)
+    assert not first.is_alive()
+    assert not second.is_alive()
 
 
 class TestLangGraphUser:
@@ -536,6 +597,88 @@ class TestAuthModuleLoadOnce:
         assert first.auth_instance is second.auth_instance
         assert first.auth_instance is via_factory.auth_instance
         assert get_auth_instance() is first.auth_instance
+        assert locations == [str(auth_file.resolve())]
+
+    def test_concurrent_first_misses_load_auth_module_once(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Two threads racing an empty cache must import/construct Auth once."""
+        auth_file = _install_auth_config(tmp_path, monkeypatch)
+        locations, load_started, load_release = _block_first_auth_file_spec(monkeypatch)
+        backends: list[LangGraphAuthBackend] = []
+        errors: list[Exception] = []
+
+        def construct_backend() -> None:
+            try:
+                backends.append(LangGraphAuthBackend())
+            except Exception as exc:
+                errors.append(exc)
+
+        _run_concurrent_calls_during_in_flight_import(
+            load_started=load_started,
+            load_release=load_release,
+            target=construct_backend,
+        )
+
+        assert errors == []
+        assert len(backends) == 2
+        assert backends[0].auth_instance is not None
+        assert backends[0].auth_instance is backends[1].auth_instance
+        assert locations == [str(auth_file.resolve())]
+
+    def test_concurrent_get_auth_backend_constructs_once(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Two threads racing get_auth_backend() must share one backend and one import."""
+        auth_file = _install_auth_config(tmp_path, monkeypatch)
+        locations, load_started, load_release = _block_first_auth_file_spec(monkeypatch)
+        backends: list[object] = []
+        errors: list[Exception] = []
+
+        def call_factory() -> None:
+            try:
+                backends.append(get_auth_backend())
+            except Exception as exc:
+                errors.append(exc)
+
+        _run_concurrent_calls_during_in_flight_import(
+            load_started=load_started,
+            load_release=load_release,
+            target=call_factory,
+        )
+
+        assert errors == []
+        assert len(backends) == 2
+        assert backends[0] is backends[1]
+        assert isinstance(backends[0], LangGraphAuthBackend)
+        assert backends[0].auth_instance is not None
+        assert locations == [str(auth_file.resolve())]
+
+    @pytest.mark.asyncio
+    async def test_concurrent_async_first_misses_load_auth_module_once(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Two async tasks racing an empty cache must import/construct Auth once."""
+        auth_file = _install_auth_config(tmp_path, monkeypatch)
+        locations = _count_spec_from_file_location(monkeypatch)
+        barrier = asyncio.Barrier(2)
+        in_flight = 0
+        max_in_flight = 0
+
+        async def load_backend() -> object:
+            nonlocal in_flight, max_in_flight
+            await barrier.wait()
+            in_flight += 1
+            max_in_flight = max(max_in_flight, in_flight)
+            try:
+                return await get_auth_backend_async()
+            finally:
+                in_flight -= 1
+
+        first, second = await asyncio.gather(load_backend(), load_backend())
+
+        assert max_in_flight == 2
+        assert first is second
+        assert isinstance(first, LangGraphAuthBackend)
+        assert first.auth_instance is not None
         assert locations == [str(auth_file.resolve())]
 
     def test_missing_auth_file_is_not_reprobed_per_init(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Description

Custom auth modules specified in `aegra.json` (`auth.path`) were imported on every `LangGraphAuthBackend` construction. That re-ran `importlib` and flooded logs with the config/load lines from #339.

This caches the loaded `Auth` object for the process lifetime, keyed by the config path. `aegra dev` reload starts a new process, so disk edits still pick up naturally — there is no in-process hot reload.

## Type of Change
- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation changes
- [ ] `style`: Code style/formatting
- [ ] `refactor`: Code refactoring
- [ ] `perf`: Performance improvement
- [ ] `test`: Tests added/updated
- [ ] `chore`: Maintenance (dependencies, build, etc.)
- [ ] `ci`: CI/CD changes

## Related Issues
Fixes #339

## Changes Made
- Cache `_load_auth_from_path(path)` with `@lru_cache` so the same `auth.path` is imported once per process.
- Cache config resolution (`_cached_load_auth_from_config`) so constructing `LangGraphAuthBackend` more than once does not re-read `aegra.json` or re-emit load logs.
- Keep `get_auth_backend()` as a process singleton; `get_auth_instance()` still delegates to it.
- Existing authenticate / load-failure branches and log *messages* are unchanged; only the number of load logs drops.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] E2E tests added/updated
- [x] Manual testing performed

Unit: `TestAuthModuleLoadOnce` counts `importlib.util.spec_from_file_location` across repeated `get_auth_backend()` / `LangGraphAuthBackend()` calls and asserts `authenticate()` results stay the same.

Integration: four `require_auth` calls plus three HTTP `/whoami` requests import the auth file once and return the same user fields.

E2E (auth): 35 passed / 5 deselected (`auth_only` suite against a local server with `aegra.auth.json`). After several `/assistants` requests, the three load log lines appeared once.

E2E (dev): 99 passed, 24 failed, 3 skipped. The failures are OpenAI `Incorrect API key provided: sk-....` from the placeholder `.env.example` key — not auth-loader related. Ports 2026/5433 were already in use locally, so this used an isolated Postgres + uvicorn on 2128 instead of `make e2e-dev` compose.

## Checklist
- [x] Code follows project style (Ruff formatting)
- [x] All linting checks pass (`make lint`)
- [x] Type checking passes (`make type-check`)
- [x] All tests pass (`make test`)
- [x] Documentation updated (if needed)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] PR title follows Conventional Commits format

## Additional Notes

Cache key is the `auth.path` string from config. Unchanged config is never reloaded. Failure results are cached the same way as success so later requests do not repeat the import.

`uv run ruff format --check .` and `uv run ruff check .` passed. `uv run bandit` reported no issues. `ty check` reports 56 existing diagnostics on main (none newly introduced in this change). `pytest` unit + integration: 1903 passed; 1 pre-existing failure (`test_insert_assistant_with_large_configurable_prompt_succeeds`) against a local Postgres that has no `postgres` role — unrelated to this PR.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Authentication modules and backend instances are reused across requests.
  * Reduced duplicate authentication initialization during concurrent requests and startup.

* **Reliability**
  * Synchronous and asynchronous requests now share consistent authentication results.
  * Authentication initialization errors are consistently propagated to concurrent callers.
  * Cancelled asynchronous requests no longer disrupt shared authentication initialization.

* **Tests**
  * Added coverage for concurrent initialization, backend reuse, asynchronous authentication, singleton behavior, and custom authentication flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->









<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR now initializes custom authentication through a process-level, concurrency-safe cache and routes asynchronous request authentication through an off-loop initializer.
- Shares one in-flight backend initialization across synchronous and asynchronous callers.
- Caches config resolution and custom auth-module loading.
- Adds concurrency, cancellation, error-propagation, singleton, and request-level regression coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/core/auth_middleware.py | Adds process-level auth caches and coordinated backend initialization for concurrent synchronous and asynchronous callers. |
| libs/aegra-api/src/aegra_api/core/auth_deps.py | Moves request authentication to the asynchronous backend accessor so initialization runs off the event loop. |
| libs/aegra-api/tests/conftest.py | Centralizes complete auth-loader cache cleanup in an autouse fixture and places its import at module scope. |
| libs/aegra-api/tests/integration/test_auth_flow.py | Verifies repeated dependency and HTTP authentication calls reuse one imported custom auth module. |
| libs/aegra-api/tests/unit/test_core/test_auth_middleware.py | Adds regression coverage for singleton initialization, concurrent callers, cancellation, and shared initialization failures. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant R as Request
  participant A as Async auth dependency
  participant W as Worker thread
  participant F as Shared fill
  participant C as Cached backend
  R->>A: require_auth()
  A->>W: to_thread(get_auth_backend)
  W->>F: claim initialization
  alt backend not initialized
    F->>C: construct and cache backend
    C-->>F: backend
  else initialization already running
    F-->>W: join existing Future
  end
  W-->>A: shared backend
  A-->>R: authenticated user
```
</details>

<sub>Reviews (5): Last reviewed commit: ["fix(api): avoid event-loop deadlock duri..."](https://github.com/aegra/aegra/commit/5ab3e763596bd00a725e08bd92c7b5a0e953f22a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56561419)</sub>

**Context used:**

- Knowledge Base — [Authentication and authorization](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/authentication-authorization.md)

<!-- /greptile_comment -->