### PR TITLE
fix(api): emit end event when rejoining a finished run via Last-Event-ID

### DIFF
--- a/docs/guides/streaming.mdx
+++ b/docs/guides/streaming.mdx
@@ -252,7 +252,7 @@ Aegra stores streaming events in a replay buffer (Redis Lists when `REDIS_BROKER
 
 1. Track the last event ID you received
 2. Reconnect to `GET /threads/{thread_id}/runs/{run_id}/stream` with `Last-Event-ID` header
-3. You'll receive all events from where you left off, then an `end` event if the run has finished
+3. You'll receive any available buffered events from where you left off, then an `end` event if the run has finished. After cleanup or restart, replay may be gone and the stream emits only the synthesized `end`.
 
 Events are retained for 1 hour after the run completes.
 

--- a/docs/guides/streaming.mdx
+++ b/docs/guides/streaming.mdx
@@ -153,7 +153,7 @@ If you created a background run, you can stream it later:
 GET /threads/{thread_id}/runs/{run_id}/stream
 ```
 
-This supports reconnection via the `Last-Event-ID` header. If the connection drops, the client can reconnect and receive events from where it left off.
+This supports reconnection via the `Last-Event-ID` header. If the connection drops, the client can reconnect and receive events from where it left off. If the run is already in a terminal state, the stream still emits an `end` event after replaying any remaining buffer — including when `Last-Event-ID` is present (the JavaScript SDK always sends this header).
 
 ### Wait for completion
 
@@ -252,7 +252,7 @@ Aegra stores streaming events in a replay buffer (Redis Lists when `REDIS_BROKER
 
 1. Track the last event ID you received
 2. Reconnect to `GET /threads/{thread_id}/runs/{run_id}/stream` with `Last-Event-ID` header
-3. You'll receive all events from where you left off
+3. You'll receive all events from where you left off, then an `end` event if the run has finished
 
 Events are retained for 1 hour after the run completes.
 

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.10.4"
+version = "0.10.5"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-api/src/aegra_api/services/streaming_service.py
+++ b/libs/aegra-api/src/aegra_api/services/streaming_service.py
@@ -6,13 +6,26 @@ from typing import Any
 
 import structlog
 
-from aegra_api.core.sse import create_error_event
+from aegra_api.core.sse import create_end_event, create_error_event
 from aegra_api.models import Run
 from aegra_api.services.broker import broker_manager
 from aegra_api.services.event_converter import EventConverter
 from aegra_api.utils import extract_event_sequence
 
 logger = structlog.getLogger(__name__)
+
+# Same set as run_waiters.TERMINAL_STATES — kept local to avoid importing that
+# module (run_waiters → executor → local_executor → streaming_service).
+_TERMINAL_STATUSES = frozenset({"success", "error", "interrupted"})
+
+
+def _is_end_sse(sse_event: str) -> bool:
+    return sse_event.startswith("event: end")
+
+
+def _terminal_end_status(run_status: str) -> str:
+    """Match the header-free short-circuit in ``stream_run``."""
+    return "error" if run_status == "error" else run_status
 
 
 class StreamingService:
@@ -100,12 +113,21 @@ class StreamingService:
             if last_event_id:
                 last_sent_sequence = extract_event_sequence(last_event_id)
 
+            replayed_end = False
             async for event_id, sse_event in self._replay_stored_events(run_id, last_event_id):
                 # Track the highest replayed sequence for live dedup
                 replayed_seq = extract_event_sequence(event_id)
                 if replayed_seq > last_sent_sequence:
                     last_sent_sequence = replayed_seq
+                replayed_end = replayed_end or _is_end_sse(sse_event)
                 yield sse_event
+
+            # Broker may be gone after restart/cleanup. Don't aiter() an empty
+            # unfinished broker created by replay — that hangs (#472).
+            if run.status in _TERMINAL_STATUSES:
+                if not replayed_end:
+                    yield create_end_event(status=_terminal_end_status(run.status))
+                return
 
             # Stream live events if run is still active
             async for sse_event in self._stream_live_events(run, last_sent_sequence):
@@ -146,7 +168,7 @@ class StreamingService:
         # If run is in a terminal state and broker is either missing or finished,
         # there are no live events to stream. Using get_broker (not get_or_create)
         # avoids creating a blank broker that would hang forever in aiter().
-        if run.status in ["success", "error", "interrupted"] and (broker is None or broker.is_finished()):
+        if run.status in _TERMINAL_STATUSES and (broker is None or broker.is_finished()):
             return
 
         if broker is None:

--- a/libs/aegra-api/tests/integration/test_api/test_stream_run_rejoin.py
+++ b/libs/aegra-api/tests/integration/test_api/test_stream_run_rejoin.py
@@ -1,0 +1,113 @@
+"""HTTP-level coverage for rejoining a finished run via Last-Event-ID (#472)."""
+
+import asyncio
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+from aegra_api.core.orm import Run as RunORM
+from aegra_api.services.broker import BrokerManager
+from tests.fixtures.clients import create_test_app
+from tests.fixtures.database import DummySessionBase
+
+
+def _make_session_maker(session_instance: DummySessionBase) -> MagicMock:
+    """Return a callable mimicking ``async_sessionmaker``."""
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=session_instance)
+    ctx.__aexit__ = AsyncMock(return_value=False)
+    return MagicMock(return_value=ctx)
+
+
+def _finished_run_orm(*, status: str = "success") -> RunORM:
+    now = datetime.now(UTC)
+    return RunORM(
+        run_id="test-run-123",
+        thread_id="test-thread-123",
+        assistant_id="test-assistant-123",
+        user_id="test-user",
+        status=status,
+        input={},
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def _app_with_finished_run(run_orm: RunORM) -> tuple[FastAPI, DummySessionBase]:
+    app = create_test_app(include_runs=True, include_threads=False)
+
+    class Session(DummySessionBase):
+        async def scalar(self, _stmt: object) -> RunORM:
+            return run_orm
+
+    return app, Session()
+
+
+async def _read_sse_body(resp: httpx.Response, *, timeout: float = 2.0) -> str:
+    """Read SSE bytes until `end` or the stream closes. Fail fast on hang."""
+
+    async def _consume() -> str:
+        body = bytearray()
+        async for chunk in resp.aiter_bytes():
+            body.extend(chunk)
+            if b"event: end" in body:
+                return bytes(body).decode()
+        return bytes(body).decode()
+
+    return await asyncio.wait_for(_consume(), timeout=timeout)
+
+
+@pytest.mark.asyncio
+async def test_stream_emits_end_when_rejoining_finished_run_with_last_event_id() -> None:
+    """GET /stream on a terminal run with Last-Event-ID must emit end and close.
+
+    After restart the in-memory broker is gone. The header-free path already
+    emits end; the JS SDK always sends Last-Event-ID (defaulting to -1) and
+    used to hang on heartbeats instead.
+    """
+    app, session = _app_with_finished_run(_finished_run_orm(status="success"))
+    manager = BrokerManager()
+
+    with (
+        patch("aegra_api.api.runs._get_session_maker", return_value=_make_session_maker(session)),
+        patch("aegra_api.services.streaming_service.broker_manager", manager),
+    ):
+        transport = httpx.ASGITransport(app=app)
+        async with (
+            httpx.AsyncClient(transport=transport, base_url="http://test", timeout=2.0) as client,
+            client.stream(
+                "GET",
+                "/threads/test-thread-123/runs/test-run-123/stream",
+                headers={"Accept": "text/event-stream", "Last-Event-ID": "-1"},
+            ) as resp,
+        ):
+            assert resp.status_code == 200
+            text = await _read_sse_body(resp)
+
+    assert "event: end" in text
+    assert '{"status":"success"}' in text
+
+
+@pytest.mark.asyncio
+async def test_stream_header_free_terminal_run_still_emits_end() -> None:
+    """Without Last-Event-ID, a finished run still takes the short-circuit end."""
+    app, session = _app_with_finished_run(_finished_run_orm(status="success"))
+
+    with patch("aegra_api.api.runs._get_session_maker", return_value=_make_session_maker(session)):
+        transport = httpx.ASGITransport(app=app)
+        async with (
+            httpx.AsyncClient(transport=transport, base_url="http://test", timeout=2.0) as client,
+            client.stream(
+                "GET",
+                "/threads/test-thread-123/runs/test-run-123/stream",
+                headers={"Accept": "text/event-stream"},
+            ) as resp,
+        ):
+            assert resp.status_code == 200
+            text = await _read_sse_body(resp)
+
+    assert text.startswith("event: end")
+    assert '{"status":"success"}' in text

--- a/libs/aegra-api/tests/unit/test_services/test_streaming_service.py
+++ b/libs/aegra-api/tests/unit/test_services/test_streaming_service.py
@@ -1,5 +1,6 @@
 """Unit tests for streaming_service module"""
 
+import asyncio
 from collections.abc import AsyncGenerator
 from datetime import UTC, datetime
 from typing import Any
@@ -8,7 +9,34 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from aegra_api.models import Run
+from aegra_api.services.broker import BrokerManager
 from aegra_api.services.streaming_service import StreamingService
+
+
+def _run(*, run_id: str = "run-123", status: str = "success") -> Run:
+    now = datetime.now(UTC)
+    return Run(
+        run_id=run_id,
+        status=status,
+        user_id="user-1",
+        thread_id="thread-1",
+        assistant_id="agent",
+        input={"message": "hello"},
+        created_at=now,
+        updated_at=now,
+    )
+
+
+async def _drain(
+    service: StreamingService,
+    run: Run,
+    *,
+    last_event_id: str | None = None,
+) -> list[str]:
+    events: list[str] = []
+    async for event in service.stream_run_execution(run, last_event_id):
+        events.append(event)
+    return events
 
 
 @pytest.mark.asyncio
@@ -387,3 +415,70 @@ class TestStreamingService:
         with patch("aegra_api.services.streaming_service.broker_manager") as mock_manager:
             await service.cleanup_run(run_id)
             mock_manager.cleanup_broker.assert_called_with(run_id)
+
+    async def test_rejoin_finished_run_without_broker_emits_end(self) -> None:
+        """Finished run + Last-Event-ID must emit end when the broker is gone.
+
+        Regression for #472: get_or_create_broker after restart yields an empty
+        unfinished broker, and aiter() waits forever instead of closing.
+        """
+        service = StreamingService()
+        run = _run(status="success")
+        manager = BrokerManager()
+
+        with patch("aegra_api.services.streaming_service.broker_manager", manager):
+            events = await asyncio.wait_for(
+                _drain(service, run, last_event_id="-1"),
+                timeout=1.0,
+            )
+
+        body = "".join(events)
+        assert "event: end" in body
+        assert '{"status":"success"}' in body
+
+    async def test_rejoin_finished_run_does_not_duplicate_replayed_end(self) -> None:
+        """If replay already includes end, do not emit a second terminal event."""
+        service = StreamingService()
+        run = _run(status="success")
+        manager = BrokerManager()
+        broker = manager.get_or_create_broker(run.run_id)
+        await broker.put("run-123_event_1", ("values", {"a": 1}))
+        await broker.put("run-123_event_2", ("end", {"status": "success"}))
+
+        with patch("aegra_api.services.streaming_service.broker_manager", manager):
+            events = await asyncio.wait_for(
+                _drain(service, run, last_event_id="-1"),
+                timeout=1.0,
+            )
+
+        end_events = [event for event in events if event.startswith("event: end")]
+        assert len(end_events) == 1
+        assert '{"status":"success"}' in end_events[0]
+
+    @pytest.mark.parametrize(
+        ("run_status", "end_status"),
+        [
+            ("success", "success"),
+            ("error", "error"),
+            ("interrupted", "interrupted"),
+        ],
+    )
+    async def test_rejoin_finished_run_end_status_matches_run(
+        self,
+        run_status: str,
+        end_status: str,
+    ) -> None:
+        """Synthesized end status must match the header-free terminal path."""
+        service = StreamingService()
+        run = _run(status=run_status)
+        manager = BrokerManager()
+
+        with patch("aegra_api.services.streaming_service.broker_manager", manager):
+            events = await asyncio.wait_for(
+                _drain(service, run, last_event_id="-1"),
+                timeout=1.0,
+            )
+
+        body = "".join(events)
+        assert "event: end" in body
+        assert f'{{"status":"{end_status}"}}' in body

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.10.4"
+version = "0.10.5"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.10.4"
+version = "0.10.5"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -100,7 +100,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.10.4"
+version = "0.10.5"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
## Description

Rejoining a finished run with `Last-Event-ID` (the JS SDK always sends this header, defaulting to `-1`) hung on SSE heartbeats after the broker/replay buffer was gone.

`stream_run` only emits a terminal `end` when **no** `Last-Event-ID` is present. With the header it always falls through to `stream_run_execution` so missed events can be replayed. `_replay_stored_events` calls `get_or_create_broker`, which after restart/TTL expiry creates a **new empty unfinished** broker. `_stream_live_events` then `aiter()`s that queue forever.

This keeps replay (needed when Redis still has events), then if the persisted run status is already terminal and replay did not include `end`, emits the same `create_end_event(status=...)` as the header-free path and closes. If replay already had `end`, it is not duplicated.

v2 thread SSE already backstops this in `_drain_run` (`event_streaming/session.py`). This PR only changes v1 run-scoped `GET /threads/{thread_id}/runs/{run_id}/stream`. Cancel semantics (#528/#529/#539) and v2 idle grace (#461/#541) are untouched. No new env vars, no broker/replay storage refactor. `aegra-api` and `aegra-cli` are at `0.10.5` (57f0009). That patch collides with #549/#553 and any other open PRs claiming the same number; whoever merges first takes `0.10.5`.

### Reproducer (before)

`aegra dev`, `stress_test` graph, wait the run to `success`, restart the server so the in-memory broker is gone.

```
# no header — closes immediately
curl -sN -m 8 -H 'Accept: text/event-stream' \
  "localhost:2026/threads/$THREAD_ID/runs/$RUN_ID/stream"
# event: end
# data: {"status":"success"}

# JS SDK path — hung on heartbeats
curl -sN -m 12 -H 'Accept: text/event-stream' -H 'Last-Event-ID: -1' \
  "localhost:2026/threads/$THREAD_ID/runs/$RUN_ID/stream"
# : heartbeat
# curl exit 28; no end
```

After this change the same `Last-Event-ID: -1` rejoin emits `event: end` / `{"status":"success"}` in ~30ms (dev) / ~90ms (prod with Redis FLUSHALL + API restart).

## Type of Change
- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation changes
- [ ] `style`: Code style/formatting
- [ ] `refactor`: Code refactoring
- [ ] `perf`: Performance improvement
- [ ] `test`: Tests added/updated
- [ ] `chore`: Maintenance (dependencies, build, etc.)
- [ ] `ci`: CI/CD changes

## Related Issues
Fixes #472

## Changes Made
- After replay in `StreamingService.stream_run_execution`, if `run.status` is terminal (`success` / `error` / `interrupted`) and replay did not already include an `end` SSE, yield `create_end_event(status=...)` (no event id — same wire format as the header-free short-circuit) and return instead of `aiter()`ing a blank broker.
- Do not emit a second `end` when the replay buffer still has one.
- Document that a finished-run rejoin with `Last-Event-ID` still emits `end`.

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] E2E tests added/updated
- [x] Manual testing performed

### Unit / integration

```
uv run ruff format --check . && uv run ruff check .
uv run ty check libs/aegra-api/src/ libs/aegra-cli/src/
uv run bandit -c pyproject.toml -r libs/aegra-api/src/ libs/aegra-cli/src/
uv run --package aegra-api pytest libs/aegra-api/tests/unit libs/aegra-api/tests/integration
```

- ruff format + ruff check: pass
- bandit: no issues
- `ty check`: 56 diagnostics, all pre-existing on `main` (same baseline as other recent PRs)
- pytest unit + integration: **1903 passed**; 1 pre-existing failure (`test_insert_assistant_with_large_configurable_prompt_succeeds`, host Postgres `role "postgres" does not exist`) — unrelated

New coverage:
- unit: rejoin of a finished run with an empty broker emits `end`; does not duplicate a replayed `end`; status matches success/error/interrupted
- integration: HTTP `GET /stream` with `Last-Event-ID: -1` on a finished run and empty `BrokerManager` emits `end` and closes (times out the hang); header-free short-circuit still emits `end`

### E2E

E2E is not in PR CI. Local host ports 6379/2026 were occupied by other clones, so this used the same pytest invocations as `make e2e-dev` / `make e2e-prod` with a compose override mapping Redis `16379:6379` (and for a follow-up prod rejoin, API `2027:2026`). Aegra still talks to `redis:6379` on the compose network.

```
# equivalent to make e2e-dev (LocalExecutor, REDIS_BROKER_ENABLED=false)
docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d
uv run --package aegra-api pytest libs/aegra-api/tests/e2e/ -m "not prod_only" \
  --ignore=libs/aegra-api/tests/e2e/manual_auth_tests \
  --ignore=libs/aegra-api/tests/e2e/multi_instance -v --tb=short

# equivalent to make e2e-prod (WorkerExecutor + Redis)
docker compose up -d
uv run --package aegra-api pytest libs/aegra-api/tests/e2e/ \
  --ignore=libs/aegra-api/tests/e2e/manual_auth_tests \
  --ignore=libs/aegra-api/tests/e2e/multi_instance -v --tb=short
```

- **e2e-dev:** 95 passed, 28 failed, 3 skipped, 17 deselected
- **e2e-prod:** 100 passed, 40 failed, 3 skipped

Graph / LLM cases failed with the placeholder `.env` key (`Incorrect API key provided: sk-....`, OpenAI 401). Those are skipped here, not caused by this change. e2e-dev also had three concurrent assistant-create `RemoteProtocolError` disconnects and `test_thread_deletion_removes_checkpoints` hitting a host DB as user `postgres`. e2e-prod reconciliation tests additionally failed connecting to host Postgres (`password authentication failed for user "postgres"`) — they talk to `localhost:5432`, not the compose DB.

Streaming / reconnect cases **without** an LLM passed in both modes, including:
- `test_background_run_and_join_e2e`
- `test_streaming_error_replay_on_reconnect`
- `test_reconnect_with_since_resumes_without_replaying_seen_events`
- `test_stateless_stream_returns_sse_events`
- `test_sdk_thread_stream_run_start_and_events`
- prod: `test_worker_stream_produces_events`, `test_sse_client_disconnect_cancels_via_redis`

### Manual prod (empty Redis + restart)

`stress_test` run → `FLUSHALL` on Redis → restart `aegra` → `Last-Event-ID: -1`:

```
event: end
data: {"status":"success"}
```

elapsed ~93ms, exit 0, no heartbeat, no `id` line (matches the header-free wire format).

## Checklist
- [x] Code follows project style (Ruff formatting)
- [x] All linting checks pass (`make lint`)
- [x] Type checking passes (`make type-check`)
- [x] All tests pass (`make test`)
- [x] Documentation updated (if needed)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] PR title follows Conventional Commits format

## Additional Notes

Does not overlap with #529 (cancel / Redis pub/sub) or #541 (v2 SSE idle grace). `get_or_create_broker` in replay is kept so Redis-backed replay still works when the buffer exists.

`0.10.5` collides with #549/#553 (and any other PRs bumping the same patch); whoever merges first occupies that number.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Completed runs now reliably emit an `end` event when clients connect or reconnect to the stream.
  * Replayed events are delivered before the final `end` event, without duplicating an existing one.
  * Stream behavior now works consistently with or without a `Last-Event-ID` header.

* **Documentation**
  * Updated streaming guidance to clarify reconnection and terminal-run behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR fixes v1 run-stream reconnection so terminal runs replay available events, synthesize a missing `end` event, and close instead of waiting indefinitely on an empty broker.
- Detects terminal run status after replay and avoids duplicating a replayed `end` event.
- Adds unit and HTTP integration regression coverage for terminal reconnect behavior.
- Documents the updated SSE contract.
- Synchronizes the `aegra-api` and `aegra-cli` patch versions at `0.10.5`, resolving the previous review finding.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the previously reported synchronized version bump is now present in both package manifests and the lockfile.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/services/streaming_service.py | Adds the terminal-state replay backstop and suppresses duplicate terminal events. |
| libs/aegra-api/tests/unit/test_services/test_streaming_service.py | Covers missing brokers, replayed terminal events, and all supported terminal statuses. |
| libs/aegra-api/tests/integration/test_api/test_stream_run_rejoin.py | Verifies the HTTP stream emits `end` and closes for terminal runs with or without `Last-Event-ID`. |
| docs/guides/streaming.mdx | Documents replay and synthesized terminal-event behavior after cleanup or restart. |
| libs/aegra-api/pyproject.toml | Applies the required API patch-version bump to 0.10.5. |
| libs/aegra-cli/pyproject.toml | Keeps the CLI package version synchronized at 0.10.5. |
| uv.lock | Synchronizes the workspace lock entries with both package version bumps. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Stream as StreamingService
    participant Replay as Replay buffer
    participant Run as Persisted run
    Client->>Stream: Reconnect with Last-Event-ID
    Stream->>Replay: Replay events after ID
    Replay-->>Stream: Available buffered events
    Stream-->>Client: Replayed SSE events
    Stream->>Run: Check terminal status
    alt Replay included end
        Stream-->>Client: Close stream
    else Terminal without replayed end
        Stream-->>Client: Synthesized end event
        Stream-->>Client: Close stream
    else Run still active
        Stream-->>Client: Continue live streaming
    end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["docs: describe SSE replay as available b..."](https://github.com/aegra/aegra/commit/57f00097fff3089431d126d543b2f19581c94929) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56565457)</sub>

<!-- /greptile_comment -->
