### PR TITLE
fix(api): include documented state fields in GET /threads/{thread_id}

### DIFF
--- a/docs/guides/threads-and-state.mdx
+++ b/docs/guides/threads-and-state.mdx
@@ -47,7 +47,18 @@ Threads have a status that reflects their current state:
 ```python
 thread = await client.threads.get(thread_id)
 print(thread["status"])  # "idle", "busy", "interrupted", "error"
+print(thread["values"])  # latest checkpoint values, or {}
+print(thread["interrupts"])  # task-id → interrupt list, or {}
+print(thread.get("state_updated_at"))
 ```
+
+`GET /threads/{thread_id}` returns the thread record plus a projection of the
+latest checkpoint: `values`, `interrupts` (keyed by task id), `config`, and
+`state_updated_at`. This is distinct from [`GET /threads/{thread_id}/state`](#getting-thread-state),
+which also includes `next`, `tasks`, and checkpoint identifiers.
+
+For a thread with no checkpoint, `values`, `interrupts`, and `config` are empty
+objects and `state_updated_at` is null.
 
 <Note>
   The snippets below assume you are inside an `async def` function with an initialized `client` — see the example above.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -850,7 +850,7 @@
           "Threads"
         ],
         "summary": "Get Thread",
-        "description": "Get a thread by its ID.\n\nReturns 404 if the thread does not exist or does not belong to the\nauthenticated user.",
+        "description": "Get a thread by its ID.\n\nReturns the thread record plus the latest checkpoint projection\n(`values`, `interrupts`, `config`, `state_updated_at`). Distinct from\nGET /threads/{thread_id}/state, which also includes next/tasks/checkpoint.\nReturns 404 if the thread does not exist or does not belong to the\nauthenticated user.",
         "operationId": "get_thread_threads__thread_id__get",
         "parameters": [
           {
@@ -5213,6 +5213,37 @@
             "format": "date-time",
             "title": "Updated At",
             "description": "Timestamp when the thread was last updated."
+          },
+          "state_updated_at": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "State Updated At",
+            "description": "Timestamp when the thread's checkpoint state was last updated."
+          },
+          "config": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Config",
+            "description": "Runnable config from the latest checkpoint."
+          },
+          "values": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Values",
+            "description": "Current checkpoint values (the thread's latest state)."
+          },
+          "interrupts": {
+            "additionalProperties": true,
+            "type": "object",
+            "title": "Interrupts",
+            "description": "Current interrupts keyed by task id."
           }
         },
         "type": "object",

--- a/libs/aegra-api/src/aegra_api/api/threads.py
+++ b/libs/aegra-api/src/aegra_api/api/threads.py
@@ -187,7 +187,7 @@ async def _load_thread_state_fields(thread: ThreadORM, user: User) -> dict[str, 
     if not isinstance(thread_metadata, dict):
         return empty
     graph_id = thread_metadata.get("graph_id")
-    if not graph_id:
+    if not isinstance(graph_id, str) or not graph_id:
         return empty
 
     thread_id = str(getattr(thread, "thread_id", ""))

--- a/libs/aegra-api/src/aegra_api/api/threads.py
+++ b/libs/aegra-api/src/aegra_api/api/threads.py
@@ -86,11 +86,20 @@ def _resolve_sort(request: ThreadSearchRequest) -> tuple[Any, bool]:
 # --- Helper for safe ORM -> Pydantic conversion (Test/Mock compatible) ---
 
 
-def _serialize_thread(thread_orm: ThreadORM, default_metadata: dict[str, Any] | None = None) -> Thread:
+def _serialize_thread(
+    thread_orm: ThreadORM,
+    default_metadata: dict[str, Any] | None = None,
+    *,
+    values: dict[str, Any] | None = None,
+    interrupts: dict[str, Any] | None = None,
+    config: dict[str, Any] | None = None,
+    state_updated_at: datetime | None = None,
+) -> Thread:
     """
     Safely converts ThreadORM to Thread model using dictionary construction.
     This handles None values and MagicMocks that appear in tests, preventing
-    Pydantic V2 ValidationErrors.
+    Pydantic V2 ValidationErrors. Checkpoint fields default to empty unless
+    the caller loaded them (GET /threads/{id} only).
     """
 
     def _coerce_str(val: Any, default: str) -> str:
@@ -146,8 +155,65 @@ def _serialize_thread(thread_orm: ThreadORM, default_metadata: dict[str, Any] | 
             "user_id": u_id,
             "created_at": c_at,
             "updated_at": u_at,
+            "state_updated_at": state_updated_at,
+            "config": config if isinstance(config, dict) else {},
+            "values": values if isinstance(values, dict) else {},
+            "interrupts": interrupts if isinstance(interrupts, dict) else {},
         }
     )
+
+
+def _empty_thread_state_fields() -> dict[str, Any]:
+    """Documented Thread state fields when no checkpoint exists."""
+    return {
+        "values": {},
+        "interrupts": {},
+        "config": {},
+        "state_updated_at": None,
+    }
+
+
+async def _load_thread_state_fields(thread: ThreadORM, user: User) -> dict[str, Any]:
+    """Load Thread-contract fields from the latest checkpoint.
+
+    Uses the same get_graph → aget_state path as GET /threads/{id}/state, but
+    never 404s: a missing checkpoint is an empty projection, not a missing thread.
+    """
+    empty = _empty_thread_state_fields()
+    thread_metadata = getattr(thread, "metadata_json", None) or {}
+    if not isinstance(thread_metadata, dict):
+        return empty
+    graph_id = thread_metadata.get("graph_id")
+    if not graph_id:
+        return empty
+
+    thread_id = str(getattr(thread, "thread_id", ""))
+    from aegra_api.services.langgraph_service import (
+        create_thread_config,
+        get_langgraph_service,
+    )
+
+    langgraph_service = get_langgraph_service()
+    config: dict[str, Any] = create_thread_config(thread_id, user)
+    try:
+        async with langgraph_service.get_graph(
+            graph_id,
+            config=config,
+            access_context="threads.read",
+            user=user,
+        ) as agent:
+            agent = agent.with_config(config)
+            state_snapshot = await agent.aget_state(config, subgraphs=False)
+        if not state_snapshot:
+            return empty
+        return thread_state_service.project_snapshot_to_thread_fields(state_snapshot, thread_id)
+    except HTTPException as exc:
+        if exc.status_code == 404:
+            return empty
+        raise
+    except Exception as e:
+        logger.exception("Failed to retrieve latest state for thread '%s'", thread_id)
+        raise HTTPException(500, f"Failed to retrieve thread state: {str(e)}") from e
 
 
 # --- Endpoints ---
@@ -265,6 +331,9 @@ async def get_thread(
 ) -> Thread:
     """Get a thread by its ID.
 
+    Returns the thread record plus the latest checkpoint projection
+    (`values`, `interrupts`, `config`, `state_updated_at`). Distinct from
+    GET /threads/{thread_id}/state, which also includes next/tasks/checkpoint.
     Returns 404 if the thread does not exist or does not belong to the
     authenticated user.
     """
@@ -283,7 +352,8 @@ async def get_thread(
     if not thread:
         raise HTTPException(404, f"Thread '{thread_id}' not found")
 
-    return _serialize_thread(thread)
+    state_fields = await _load_thread_state_fields(thread, user)
+    return _serialize_thread(thread, **state_fields)
 
 
 @router.patch("/threads/{thread_id}", response_model=Thread, responses={**NOT_FOUND})

--- a/libs/aegra-api/src/aegra_api/api/threads.py
+++ b/libs/aegra-api/src/aegra_api/api/threads.py
@@ -37,6 +37,10 @@ from aegra_api.models import (
     User,
 )
 from aegra_api.models.errors import CONFLICT, NOT_FOUND, AgentProtocolError
+from aegra_api.services.langgraph_service import (
+    create_thread_config,
+    get_langgraph_service,
+)
 from aegra_api.services.streaming_service import streaming_service
 from aegra_api.services.thread_state_service import ThreadStateService
 from aegra_api.utils.run_utils import strip_pinned_config_keys
@@ -176,8 +180,7 @@ def _empty_thread_state_fields() -> dict[str, Any]:
 async def _load_thread_state_fields(thread: ThreadORM, user: User) -> dict[str, Any]:
     """Load Thread-contract fields from the latest checkpoint.
 
-    Uses the same get_graph → aget_state path as GET /threads/{id}/state, but
-    never 404s: a missing checkpoint is an empty projection, not a missing thread.
+    A missing checkpoint or unresolvable graph is an empty projection, not a 404.
     """
     empty = _empty_thread_state_fields()
     thread_metadata = getattr(thread, "metadata_json", None) or {}
@@ -188,11 +191,6 @@ async def _load_thread_state_fields(thread: ThreadORM, user: User) -> dict[str, 
         return empty
 
     thread_id = str(getattr(thread, "thread_id", ""))
-    from aegra_api.services.langgraph_service import (
-        create_thread_config,
-        get_langgraph_service,
-    )
-
     langgraph_service = get_langgraph_service()
     config: dict[str, Any] = create_thread_config(thread_id, user)
     try:
@@ -211,9 +209,16 @@ async def _load_thread_state_fields(thread: ThreadORM, user: User) -> dict[str, 
         if exc.status_code == 404:
             return empty
         raise
+    except ValueError:
+        logger.info(
+            "Graph '%s' could not be resolved for thread '%s'; returning empty state fields",
+            graph_id,
+            thread_id,
+        )
+        return empty
     except Exception as e:
         logger.exception("Failed to retrieve latest state for thread '%s'", thread_id)
-        raise HTTPException(500, f"Failed to retrieve thread state: {str(e)}") from e
+        raise HTTPException(500, "Failed to retrieve thread state") from e
 
 
 # --- Endpoints ---

--- a/libs/aegra-api/src/aegra_api/models/threads.py
+++ b/libs/aegra-api/src/aegra_api/models/threads.py
@@ -47,6 +47,22 @@ class Thread(BaseModel):
     user_id: str = Field(..., description="Identifier of the user who owns this thread.")
     created_at: datetime = Field(..., description="Timestamp when the thread was created.")
     updated_at: datetime = Field(..., description="Timestamp when the thread was last updated.")
+    state_updated_at: datetime | None = Field(
+        None,
+        description="Timestamp when the thread's checkpoint state was last updated.",
+    )
+    config: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Runnable config from the latest checkpoint.",
+    )
+    values: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Current checkpoint values (the thread's latest state).",
+    )
+    interrupts: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Current interrupts keyed by task id.",
+    )
 
     @field_validator("status", mode="before")
     @classmethod

--- a/libs/aegra-api/src/aegra_api/services/thread_state_service.py
+++ b/libs/aegra-api/src/aegra_api/services/thread_state_service.py
@@ -6,6 +6,7 @@ from typing import Any
 import structlog
 
 from aegra_api.core.serializers import LangGraphSerializer
+from aegra_api.core.serializers.base import SerializationError
 from aegra_api.models.threads import ThreadCheckpoint, ThreadState
 
 logger = structlog.getLogger(__name__)
@@ -89,6 +90,37 @@ class ThreadStateService:
                 continue
 
         return thread_states
+
+    def project_snapshot_to_thread_fields(self, snapshot: Any, thread_id: str) -> dict[str, Any]:
+        """Project a checkpoint snapshot onto the Thread response contract.
+
+        Thread carries values, task-keyed interrupts, config, and state_updated_at.
+        It must not include ThreadState fields such as next, tasks, or checkpoint.
+        """
+        thread_state = self.convert_snapshot_to_thread_state(snapshot, thread_id)
+        interrupts: dict[str, Any] = {
+            str(task["id"]): task["interrupts"]
+            for task in thread_state.tasks
+            if task.get("id") and task.get("interrupts")
+        }
+        values = thread_state.values if isinstance(thread_state.values, dict) else {}
+        return {
+            "values": values,
+            "interrupts": interrupts,
+            "config": self._as_json_object(getattr(snapshot, "config", None)),
+            "state_updated_at": thread_state.created_at,
+        }
+
+    def _as_json_object(self, value: Any) -> dict[str, Any]:
+        """Best-effort JSON object for Thread.config; never raise to the caller."""
+        if not isinstance(value, dict):
+            return {}
+        try:
+            serialized = self.serializer.serialize(value)
+        except SerializationError:
+            logger.warning("Failed to serialize thread config to a JSON object")
+            return {}
+        return serialized if isinstance(serialized, dict) else {}
 
     def _extract_created_at(self, snapshot: Any) -> datetime | None:
         """Extract created_at timestamp from snapshot"""

--- a/libs/aegra-api/tests/e2e/test_threads/test_get_thread_state_fields.py
+++ b/libs/aegra-api/tests/e2e/test_threads/test_get_thread_state_fields.py
@@ -1,0 +1,50 @@
+"""E2E: GET /threads/{thread_id} includes documented Thread state fields."""
+
+from typing import Any
+
+import pytest
+
+from tests.e2e._utils import elog, get_e2e_client
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_get_thread_includes_empty_state_fields_without_checkpoint() -> None:
+    """A thread with no runs still returns the documented state keys."""
+    client = get_e2e_client()
+    created: dict[str, Any] = await client.threads.create()
+    thread_id = created["thread_id"]
+
+    fetched: dict[str, Any] = await client.threads.get(thread_id)
+    elog("GET thread (no checkpoint)", fetched)
+
+    assert fetched["thread_id"] == thread_id
+    assert fetched["values"] == {}
+    assert fetched["interrupts"] == {}
+    assert fetched["config"] == {}
+    assert fetched.get("state_updated_at") is None
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_get_thread_includes_latest_checkpoint_values_after_run() -> None:
+    """After a run, GET /threads/{id} exposes the latest checkpoint values."""
+    client = get_e2e_client()
+    created: dict[str, Any] = await client.threads.create()
+    thread_id = created["thread_id"]
+
+    await client.runs.wait(
+        thread_id=thread_id,
+        assistant_id="stress_test",
+        input={"messages": [{"role": "user", "content": '{"delay": 0.1, "steps": 1}'}]},
+    )
+
+    fetched: dict[str, Any] = await client.threads.get(thread_id)
+    elog("GET thread after run", fetched)
+
+    messages = fetched["values"]["messages"]
+    assert messages[-1]["content"]
+    assert isinstance(fetched["interrupts"], dict)
+    assert fetched["state_updated_at"] is not None
+    assert "next" not in fetched
+    assert "checkpoint" not in fetched

--- a/libs/aegra-api/tests/integration/test_api/test_threads_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_threads_crud.py
@@ -401,7 +401,7 @@ class TestGetThread:
         app.dependency_overrides[core_get_session] = override_get_session_dep(Session)
         client = make_client(app)
 
-        with patch("aegra_api.services.langgraph_service.get_langgraph_service") as mock_get_service:
+        with patch("aegra_api.api.threads.get_langgraph_service") as mock_get_service:
             resp = client.get("/threads/nonexistent")
 
         assert resp.status_code == 404
@@ -439,7 +439,7 @@ class TestGetThread:
         mock_agent.aget_state.return_value = snapshot
         mock_agent.with_config = Mock(return_value=mock_agent)
 
-        with patch("aegra_api.services.langgraph_service.get_langgraph_service") as mock_get_service:
+        with patch("aegra_api.api.threads.get_langgraph_service") as mock_get_service:
             mock_service = mock_get_service.return_value
             mock_service.get_graph = create_get_graph_mock(return_value=mock_agent)
 
@@ -472,7 +472,7 @@ class TestGetThread:
         mock_agent.aget_state.return_value = None
         mock_agent.with_config = Mock(return_value=mock_agent)
 
-        with patch("aegra_api.services.langgraph_service.get_langgraph_service") as mock_get_service:
+        with patch("aegra_api.api.threads.get_langgraph_service") as mock_get_service:
             mock_service = mock_get_service.return_value
             mock_service.get_graph = create_get_graph_mock(return_value=mock_agent)
 
@@ -485,6 +485,56 @@ class TestGetThread:
         assert data["interrupts"] == {}
         assert data["config"] == {}
         assert data["state_updated_at"] is None
+
+    def test_get_thread_returns_empty_state_fields_when_graph_not_found(self) -> None:
+        """Unresolvable graph_id must not 500 the thread record."""
+        app = create_test_app(include_runs=False, include_threads=True)
+        thread = _thread_row("test-123", metadata={"graph_id": "missing-graph"})
+
+        class Session(DummySessionBase):
+            async def scalar(self, _stmt: object) -> object:
+                return thread
+
+        app.dependency_overrides[core_get_session] = override_get_session_dep(Session)
+        client = make_client(app)
+
+        with patch("aegra_api.api.threads.get_langgraph_service") as mock_get_service:
+            mock_service = mock_get_service.return_value
+            mock_service.get_graph = create_get_graph_mock(side_effect=ValueError("Graph not found: missing-graph"))
+
+            resp = client.get("/threads/test-123")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["thread_id"] == "test-123"
+        assert data["metadata"]["graph_id"] == "missing-graph"
+        assert data["values"] == {}
+        assert data["interrupts"] == {}
+        assert data["config"] == {}
+        assert data["state_updated_at"] is None
+
+    def test_get_thread_returns_500_without_internal_exception_details(self) -> None:
+        """Unexpected state-load errors must not leak exception text."""
+        app = create_test_app(include_runs=False, include_threads=True)
+        thread = _thread_row("test-123", metadata={"graph_id": "test-graph"})
+
+        class Session(DummySessionBase):
+            async def scalar(self, _stmt: object) -> object:
+                return thread
+
+        app.dependency_overrides[core_get_session] = override_get_session_dep(Session)
+        client = make_client(app)
+
+        with patch("aegra_api.api.threads.get_langgraph_service") as mock_get_service:
+            mock_service = mock_get_service.return_value
+            mock_service.get_graph = create_get_graph_mock(side_effect=RuntimeError("secret boom"))
+
+            resp = client.get("/threads/test-123")
+
+        assert resp.status_code == 500
+        detail = resp.json()["detail"]
+        assert detail == "Failed to retrieve thread state"
+        assert "secret boom" not in str(resp.json())
 
 
 class TestDeleteThread:

--- a/libs/aegra-api/tests/integration/test_api/test_threads_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_threads_crud.py
@@ -19,6 +19,7 @@ from tests.fixtures.database import (
     DummySessionBase,
     override_get_session_dep,
 )
+from tests.fixtures.langgraph import make_interrupt, make_snapshot, make_task
 from tests.fixtures.session_fixtures import BasicSession, override_session_dependency
 from tests.fixtures.test_helpers import DummyRun, DummyThread
 
@@ -369,6 +370,10 @@ class TestGetThread:
         data = resp.json()
         assert data["thread_id"] == "test-123"
         assert data["metadata"]["purpose"] == "testing"
+        assert data["values"] == {}
+        assert data["interrupts"] == {}
+        assert data["config"] == {}
+        assert data["state_updated_at"] is None
 
     def test_get_thread_not_found(self):
         """Test getting a non-existent thread"""
@@ -384,6 +389,102 @@ class TestGetThread:
         resp = client.get("/threads/nonexistent")
         assert resp.status_code == 404
         assert "not found" in resp.json()["detail"]
+
+    def test_get_thread_not_found_does_not_load_checkpoint(self) -> None:
+        """404 must not touch the graph/checkpointer path."""
+        app = create_test_app(include_runs=False, include_threads=True)
+
+        class Session(DummySessionBase):
+            async def scalar(self, _stmt: object) -> None:
+                return None
+
+        app.dependency_overrides[core_get_session] = override_get_session_dep(Session)
+        client = make_client(app)
+
+        with patch("aegra_api.services.langgraph_service.get_langgraph_service") as mock_get_service:
+            resp = client.get("/threads/nonexistent")
+
+        assert resp.status_code == 404
+        mock_get_service.assert_not_called()
+
+    def test_get_thread_includes_latest_checkpoint_state_fields(self) -> None:
+        """GET /threads/{id} projects values, interrupts, config, state_updated_at."""
+        app = create_test_app(include_runs=False, include_threads=True)
+        thread = _thread_row("test-123", metadata={"graph_id": "test-graph"})
+
+        class Session(DummySessionBase):
+            async def scalar(self, _stmt: object) -> object:
+                return thread
+
+        app.dependency_overrides[core_get_session] = override_get_session_dep(Session)
+        client = make_client(app)
+
+        interrupt = make_interrupt(value="approve?", interrupt_id="int-1")
+        snapshot = make_snapshot(
+            {"messages": [{"type": "human", "content": "hello"}]},
+            {
+                "configurable": {
+                    "thread_id": "test-123",
+                    "checkpoint_id": "cp-1",
+                    "checkpoint_ns": "",
+                }
+            },
+            created_at="2024-06-01T12:00:00Z",
+            next_nodes=("agent",),
+            tasks=(make_task(id="task-abc", interrupts=(interrupt,)),),
+            interrupts=(interrupt,),
+        )
+
+        mock_agent = AsyncMock()
+        mock_agent.aget_state.return_value = snapshot
+        mock_agent.with_config = Mock(return_value=mock_agent)
+
+        with patch("aegra_api.services.langgraph_service.get_langgraph_service") as mock_get_service:
+            mock_service = mock_get_service.return_value
+            mock_service.get_graph = create_get_graph_mock(return_value=mock_agent)
+
+            resp = client.get("/threads/test-123")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["thread_id"] == "test-123"
+        assert data["values"]["messages"][-1]["content"] == "hello"
+        assert data["interrupts"]["task-abc"][0]["id"] == "int-1"
+        assert data["config"]["configurable"]["checkpoint_id"] == "cp-1"
+        assert data["state_updated_at"].startswith("2024-06-01")
+        assert "next" not in data
+        assert "tasks" not in data
+        assert "checkpoint" not in data
+
+    def test_get_thread_with_graph_but_no_snapshot_returns_empty_state_fields(self) -> None:
+        """A missing checkpoint must not 404 the thread record."""
+        app = create_test_app(include_runs=False, include_threads=True)
+        thread = _thread_row("test-123", metadata={"graph_id": "test-graph"})
+
+        class Session(DummySessionBase):
+            async def scalar(self, _stmt: object) -> object:
+                return thread
+
+        app.dependency_overrides[core_get_session] = override_get_session_dep(Session)
+        client = make_client(app)
+
+        mock_agent = AsyncMock()
+        mock_agent.aget_state.return_value = None
+        mock_agent.with_config = Mock(return_value=mock_agent)
+
+        with patch("aegra_api.services.langgraph_service.get_langgraph_service") as mock_get_service:
+            mock_service = mock_get_service.return_value
+            mock_service.get_graph = create_get_graph_mock(return_value=mock_agent)
+
+            resp = client.get("/threads/test-123")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["thread_id"] == "test-123"
+        assert data["values"] == {}
+        assert data["interrupts"] == {}
+        assert data["config"] == {}
+        assert data["state_updated_at"] is None
 
 
 class TestDeleteThread:

--- a/libs/aegra-api/tests/integration/test_api/test_threads_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_threads_crud.py
@@ -513,6 +513,81 @@ class TestGetThread:
         assert data["config"] == {}
         assert data["state_updated_at"] is None
 
+    def test_get_thread_returns_empty_state_fields_when_graph_id_is_list(self) -> None:
+        """Non-string graph_id must not reach get_graph (list is truthy)."""
+        app = create_test_app(include_runs=False, include_threads=True)
+        thread = _thread_row("test-123", metadata={"graph_id": ["agent"]})
+
+        class Session(DummySessionBase):
+            async def scalar(self, _stmt: object) -> object:
+                return thread
+
+        app.dependency_overrides[core_get_session] = override_get_session_dep(Session)
+        client = make_client(app)
+
+        with patch("aegra_api.api.threads.get_langgraph_service") as mock_get_service:
+            resp = client.get("/threads/test-123")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["thread_id"] == "test-123"
+        assert data["metadata"]["graph_id"] == ["agent"]
+        assert data["values"] == {}
+        assert data["interrupts"] == {}
+        assert data["config"] == {}
+        assert data["state_updated_at"] is None
+        mock_get_service.assert_not_called()
+
+    def test_get_thread_returns_empty_state_fields_when_graph_id_is_dict(self) -> None:
+        """Non-string graph_id must not reach get_graph (dict is truthy)."""
+        app = create_test_app(include_runs=False, include_threads=True)
+        thread = _thread_row("test-123", metadata={"graph_id": {"name": "agent"}})
+
+        class Session(DummySessionBase):
+            async def scalar(self, _stmt: object) -> object:
+                return thread
+
+        app.dependency_overrides[core_get_session] = override_get_session_dep(Session)
+        client = make_client(app)
+
+        with patch("aegra_api.api.threads.get_langgraph_service") as mock_get_service:
+            resp = client.get("/threads/test-123")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["thread_id"] == "test-123"
+        assert data["metadata"]["graph_id"] == {"name": "agent"}
+        assert data["values"] == {}
+        assert data["interrupts"] == {}
+        assert data["config"] == {}
+        assert data["state_updated_at"] is None
+        mock_get_service.assert_not_called()
+
+    def test_get_thread_returns_empty_state_fields_when_graph_id_is_empty_string(self) -> None:
+        """Empty-string graph_id is not a resolvable graph; skip get_graph."""
+        app = create_test_app(include_runs=False, include_threads=True)
+        thread = _thread_row("test-123", metadata={"graph_id": ""})
+
+        class Session(DummySessionBase):
+            async def scalar(self, _stmt: object) -> object:
+                return thread
+
+        app.dependency_overrides[core_get_session] = override_get_session_dep(Session)
+        client = make_client(app)
+
+        with patch("aegra_api.api.threads.get_langgraph_service") as mock_get_service:
+            resp = client.get("/threads/test-123")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["thread_id"] == "test-123"
+        assert data["metadata"]["graph_id"] == ""
+        assert data["values"] == {}
+        assert data["interrupts"] == {}
+        assert data["config"] == {}
+        assert data["state_updated_at"] is None
+        mock_get_service.assert_not_called()
+
     def test_get_thread_returns_500_without_internal_exception_details(self) -> None:
         """Unexpected state-load errors must not leak exception text."""
         app = create_test_app(include_runs=False, include_threads=True)

--- a/libs/aegra-api/tests/unit/test_models/test_thread_status_validation.py
+++ b/libs/aegra-api/tests/unit/test_models/test_thread_status_validation.py
@@ -64,6 +64,43 @@ class TestThreadStatusValidation:
         assert thread.status == "busy"
 
 
+class TestThreadDocumentedStateFields:
+    """Thread JSON must expose Agent Server / LangGraph SDK state fields."""
+
+    def test_thread_defaults_empty_state_fields(self) -> None:
+        thread = Thread(
+            thread_id="test-thread-1",
+            status="idle",
+            metadata={},
+            user_id="test-user",
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+        assert thread.values == {}
+        assert thread.interrupts == {}
+        assert thread.config == {}
+        assert thread.state_updated_at is None
+
+    def test_thread_accepts_populated_state_fields(self) -> None:
+        updated = datetime(2024, 6, 1, 12, 0, tzinfo=UTC)
+        thread = Thread(
+            thread_id="test-thread-1",
+            status="interrupted",
+            metadata={},
+            user_id="test-user",
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+            state_updated_at=updated,
+            config={"configurable": {"thread_id": "test-thread-1"}},
+            values={"messages": [{"type": "human", "content": "hi"}]},
+            interrupts={"task-1": [{"id": "int-1", "value": "approve?"}]},
+        )
+        assert thread.values["messages"][0]["content"] == "hi"
+        assert thread.interrupts["task-1"][0]["id"] == "int-1"
+        assert thread.config["configurable"]["thread_id"] == "test-thread-1"
+        assert thread.state_updated_at == updated
+
+
 class TestThreadSearchRequestStatusValidation:
     """Tests for ThreadSearchRequest status filter validation."""
 

--- a/libs/aegra-api/tests/unit/test_services/test_thread_state_service.py
+++ b/libs/aegra-api/tests/unit/test_services/test_thread_state_service.py
@@ -128,3 +128,50 @@ def test_convert_snapshots_to_thread_states_skips_failures():
 
     assert result == ["converted"]
     assert mock_convert.call_count == 2
+
+
+def test_project_snapshot_to_thread_fields_maps_task_keyed_interrupts() -> None:
+    service = ThreadStateService()
+    default_interrupt = make_interrupt(interrupt_id=TEST_INTERRUPT_ID)
+    snapshot = make_snapshot(
+        {"messages": [{"type": "human", "content": "hi"}]},
+        {
+            "configurable": {
+                "checkpoint_id": "checkpoint-1",
+                "checkpoint_ns": "",
+                "thread_id": "thread-123",
+            }
+        },
+        created_at="2024-01-01T00:00:00Z",
+        next_nodes=("node_1",),
+        tasks=(make_task(interrupts=(default_interrupt,)),),
+        interrupts=(default_interrupt,),
+    )
+
+    result = service.project_snapshot_to_thread_fields(snapshot, "thread-123")
+
+    assert result["values"] == {"messages": [{"type": "human", "content": "hi"}]}
+    assert result["interrupts"] == {"task-1": [{"value": "Provide value:", "id": TEST_INTERRUPT_ID}]}
+    assert result["state_updated_at"] == datetime(2024, 1, 1, tzinfo=UTC)
+    assert result["config"]["configurable"]["checkpoint_id"] == "checkpoint-1"
+    assert "next" not in result
+    assert "tasks" not in result
+    assert "checkpoint" not in result
+
+
+def test_project_snapshot_to_thread_fields_skips_tasks_without_interrupts() -> None:
+    service = ThreadStateService()
+    snapshot = make_snapshot(
+        {"foo": "bar"},
+        {"configurable": {"checkpoint_id": "cp-empty"}},
+        created_at=None,
+        tasks=(make_task(id="idle-task", interrupts=()),),
+        interrupts=(),
+    )
+
+    result = service.project_snapshot_to_thread_fields(snapshot, "thread-123")
+
+    assert result["values"] == {"foo": "bar"}
+    assert result["interrupts"] == {}
+    assert result["state_updated_at"] is None
+    assert result["config"]["configurable"]["checkpoint_id"] == "cp-empty"


### PR DESCRIPTION
## Description

`GET /threads/{thread_id}` now returns the documented Thread state fields (`values`, `interrupts`, `config`, `state_updated_at`) from the latest checkpoint, matching the Agent Server / LangGraph SDK `Thread` contract. Distinct from `GET /threads/{thread_id}/state`, which still includes `next`, `tasks`, and checkpoint identifiers.

## Type of Change
- [x] `fix`: Bug fix
- [ ] `feat`: New feature
- [ ] `docs`: Documentation changes
- [ ] `style`: Code style/formatting
- [ ] `refactor`: Code refactoring
- [ ] `perf`: Performance improvement
- [x] `test`: Tests added/updated
- [ ] `chore`: Maintenance (dependencies, build, etc.)
- [ ] `ci`: CI/CD changes

## Related Issues
Fixes #523

## Changes Made
- Extend the shared `Thread` response schema with `values`, `interrupts` (task-id keyed), `config`, and `state_updated_at`.
- Populate those fields on `GET /threads/{thread_id}` via the same `get_graph` → `aget_state` → `ThreadStateService` path as `/state`, projecting only Thread-contract fields.
- Empty `values` / `interrupts` / `config` and null `state_updated_at` when no checkpoint exists; 404 semantics and `user_id` ownership filtering are unchanged.
- List/search/create/patch keep the new keys as empty defaults (batched state on search is #330 / #467).

## Reproducer

```bash
TID=$(curl -sS -X POST http://localhost:2026/threads \
  -H 'Content-Type: application/json' -d '{}' | jq -r .thread_id)

curl -sS -X POST "http://localhost:2026/threads/$TID/runs/wait" \
  -H 'Content-Type: application/json' \
  -d '{"assistant_id":"stress_test","input":{"messages":[{"role":"user","content":"{\"delay\":0.1,\"steps\":1}"}]}}' \
  >/dev/null

curl -sS "http://localhost:2026/threads/$TID"
```

### Before
```json
{
  "thread_id": "...",
  "status": "idle",
  "metadata": {},
  "user_id": "anonymous",
  "created_at": "...",
  "updated_at": "..."
}
```

### After
```json
{
  "thread_id": "...",
  "status": "idle",
  "metadata": {},
  "user_id": "anonymous",
  "created_at": "...",
  "updated_at": "...",
  "state_updated_at": "2026-08-25T07:56:29.154926Z",
  "config": { "configurable": { "checkpoint_id": "..." } },
  "values": { "messages": [ { "type": "human", "content": "..." }, { "type": "ai", "content": "..." } ] },
  "interrupts": {}
}
```

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] E2E tests added/updated
- [x] Manual testing performed

```bash
uv run ruff format --check . && uv run ruff check .
uv run ty check libs/aegra-api/src/ libs/aegra-cli/src/
uv run bandit -c pyproject.toml -r libs/aegra-api/src/ libs/aegra-cli/src/
uv run --package aegra-api pytest libs/aegra-api/tests/unit libs/aegra-api/tests/integration
uv run --package aegra-api pytest libs/aegra-api/tests/e2e/test_threads/test_get_thread_state_fields.py
```

Results:
- ruff format/check: pass
- bandit: no issues
- ty: pre-existing `dict[str, Any]` vs `RunnableConfig` mismatches on `threads.py` (same pattern as `get_thread_state`); not introduced as a new class of error
- unit + integration: 1903 passed; 1 failed (`test_insert_assistant_with_large_configurable_prompt_succeeds`) due to local Postgres on :5432 (`role "postgres" does not exist`) — unrelated to this change
- e2e (new file, `stress_test` graph, no LLM): 2 passed
- related thread e2e (search + concurrent create): 9 passed
- `make e2e-dev` full suite not run: `.env` has placeholder `OPENAI_API_KEY=sk-...`

## Checklist
- [x] Code follows project style (Ruff formatting)
- [x] All linting checks pass (`make lint`)
- [x] Type checking passes (`make type-check`) — same pre-existing ty findings as `main`
- [x] All tests pass (`make test`) — see note above for the one env-dependent DB test
- [x] Documentation updated (if needed)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] PR title follows Conventional Commits format

## Additional Notes
Does not refactor checkpoint loading into a shared service (that overlap with #467 is left for a follow-up). Does not change `/state` or `/history` response contracts.

Made with [Cursor](https://cursor.com)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Thread retrieval now includes the latest checkpoint’s values, interrupts, configuration, and update timestamp.
  * Threads without checkpoints return empty state fields and no update timestamp.
  * State projections distinguish thread status details from full thread-state responses.

* **Documentation**
  * Updated API documentation and usage guidance to describe the new response fields and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR extends single-thread retrieval with the latest checkpoint projection while preserving empty defaults when no checkpoint or resolvable graph exists.
- Adds `values`, task-keyed `interrupts`, `config`, and `state_updated_at` to the shared thread response model.
- Loads and projects the latest graph checkpoint for `GET /threads/{thread_id}`.
- Moves service imports to module scope, safely handles unresolved graphs, and sanitizes unexpected state-loading errors.
- Updates the OpenAPI contract, user documentation, and unit, integration, and end-to-end coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/api/threads.py | Loads the latest checkpoint for single-thread reads, returns empty projections for unresolved graphs, sanitizes failures, and now keeps service imports at module scope. |
| libs/aegra-api/src/aegra_api/models/threads.py | Extends the public Thread model with documented checkpoint projection fields and safe empty defaults. |
| libs/aegra-api/src/aegra_api/services/thread_state_service.py | Projects snapshots into the narrower Thread response contract, including task-keyed interrupts and JSON-safe configuration. |
| libs/aegra-api/tests/integration/test_api/test_threads_crud.py | Covers populated and empty projections, unresolved and malformed graph identifiers, lookup ordering, and sanitized errors. |
| docs/openapi.json | Updates the generated API description and Thread schema for the newly returned state fields. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Client
  participant ThreadsAPI
  participant Database
  participant GraphService
  participant StateService
  Client->>ThreadsAPI: "GET /threads/{thread_id}"
  ThreadsAPI->>Database: Load user-owned thread
  alt Thread missing or inaccessible
    ThreadsAPI-->>Client: 404
  else Thread found without resolvable graph
    ThreadsAPI-->>Client: Thread with empty state fields
  else Graph is resolvable
    ThreadsAPI->>GraphService: Load graph and latest state
    alt No checkpoint
      ThreadsAPI-->>Client: Thread with empty state fields
    else Checkpoint exists
      GraphService-->>ThreadsAPI: State snapshot
      ThreadsAPI->>StateService: Project Thread contract fields
      StateService-->>ThreadsAPI: values, interrupts, config, state_updated_at
      ThreadsAPI-->>Client: Thread with latest state projection
    end
  end
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(api): skip GET thread state load for..."](https://github.com/aegra/aegra/commit/aa6f171bf0eba80dab3d4c32534a91f0e78b095d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56570172)</sub>

<!-- /greptile_comment -->