### PR TITLE
fix(api): flush a first byte when a v2 event stream opens

### DIFF
--- a/libs/aegra-api/src/aegra_api/api/event_streaming.py
+++ b/libs/aegra-api/src/aegra_api/api/event_streaming.py
@@ -169,5 +169,16 @@ async def post_thread_command(
 
 async def _frame_events(session_stream: ThreadEventSession) -> AsyncGenerator[str, None]:
     """Frame v2 event envelopes as SSE messages (event=method, data=envelope, id=seq)."""
+    # Flush the response headers and a first byte the moment the stream opens.
+    # sse-starlette's first ping only fires after one full ping interval, and a
+    # quiet stream (fresh thread, no events yet) writes nothing until then. A
+    # client that gates on the response's first byte before treating the
+    # subscription as ready (the LangGraph SDK does this when rotating its
+    # shared /stream/events subscription) therefore stalls a full keepalive
+    # interval on every subscribe — on a new thread's first run that is long
+    # enough for the whole run to finish, so tokens arrive as one replay burst
+    # instead of streaming. An SSE comment is invisible to parsers and
+    # unblocks such clients immediately.
+    yield ": hello\n\n"
     async for envelope in session_stream.stream():
         yield format_sse_message(envelope["method"], envelope, str(envelope["seq"]))

--- a/libs/aegra-api/tests/integration/test_api/test_event_streaming.py
+++ b/libs/aegra-api/tests/integration/test_api/test_event_streaming.py
@@ -150,6 +150,19 @@ class TestStreamRoute:
         resp = client.post("/threads/t1/stream/events", json={"channels": ["messages"]})
         assert resp.status_code == 404
 
+    def test_stream_flushes_first_byte_before_any_event(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A quiet stream must emit a first byte at open, not one ping interval later.
+
+        Clients that gate readiness on the response's first byte (the LangGraph
+        SDK's shared-subscription rotation does) otherwise stall a full
+        keepalive interval on every subscribe against a thread with no events.
+        """
+        client = TestClient(_make_app(monkeypatch))
+        with client.stream("POST", "/threads/t1/stream/events", json={"channels": ["messages"]}) as resp:
+            assert resp.status_code == 200
+            first = next(resp.iter_text())
+        assert first.startswith(": hello")
+
     def test_stream_emits_v2_frames(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """A run on the thread streams content-block frames over SSE."""
         run_id = f"run-{uuid.uuid4().hex[:8]}"


### PR DESCRIPTION
Fixes #554

## What

`POST /threads/{id}/stream/events` now yields an SSE comment (`: hello`) as the generator's first item, so response headers and a first byte reach the client the moment the stream opens — instead of one full ping interval later (the first keepalive was previously the first write on a quiet stream).

## Why

Clients that gate subscription readiness on the response's first byte stall a full keepalive interval per subscribe against a quiet stream. The LangGraph SDK's `ThreadStream` shared-subscription rotation awaits the new handle's first byte before swapping filters, and rotations are serialized — so on a new thread's first run the `messages`-channel pump can attach only after the run has finished, delivering all tokens as one replay burst instead of streaming. (Second turn onward streams fine, which hides the root cause.) Measurements in #554.

SSE comments are invisible to parsers, so existing consumers are unaffected. The legacy `/runs/stream` path effectively already flushes at open by emitting a `metadata` event on join; this brings the v2 thread stream in line.

## Testing

- New regression test: `test_stream_flushes_first_byte_before_any_event` — quiet stream must yield a first chunk starting with `: hello` at open.
- `libs/aegra-api/tests/integration/test_api/test_event_streaming.py` 11 passed, `test_sse_keepalive.py` + `test_sse_utils.py` 23 passed, ruff check/format clean.
- Verified end-to-end against a LangGraph SDK client: with the fix, the first turn on a fresh thread token-streams live (previously: single burst at run end).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Event streams now send an immediate readiness signal when opened, allowing clients to detect that streaming is active without waiting for the first keepalive interval.

* **Tests**
  * Added coverage to verify the first response data is delivered immediately when an event stream starts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes the v2 thread event stream immediately emit an SSE comment so clients receive response bytes before the first event or keepalive.
- Adds an initial `: hello` comment to `_frame_events`.
- Adds an integration regression test asserting that the comment is the first chunk received.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge functionally, with non-blocking repository-compliance cleanup needed for comments, documentation, and release versioning.

The SSE prelude follows the existing formatted-bytes delivery path and has regression coverage, but the changeset omits required documentation and version updates and introduces an overlong narrative comment.

**Files Needing Attention:** libs/aegra-api/src/aegra_api/api/event_streaming.py

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/api/event_streaming.py | Adds the immediate SSE prelude correctly, but does not satisfy repository requirements for concise comments, documentation, and versioning. |
| libs/aegra-api/tests/integration/test_api/test_event_streaming.py | Adds focused coverage that verifies a quiet stream returns the new comment as its first chunk. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20aegra%2Faegra%20PR%20%23555%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%E2%95%AD%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AE%0A%E2%94%82%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%E2%94%82%0A%E2%94%82%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%E2%94%82%0A%E2%95%B0%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%94%80%E2%95%AF%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=aegra%2Faegra&pr=555&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fapi%2Fevent_streaming.py%3A172-180%0A**Complete%20release%20requirements**%0A%0AThis%20user-visible%20streaming%20change%20adds%20a%20nine-line%20narrative%20comment%20while%20omitting%20the%20required%20documentation%20and%20matching%20package-version%20updates%2C%20leaving%20the%20new%20wire%20behavior%20undocumented%20and%20the%20bug%20fix%20absent%20from%20release%20versioning.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=aegra%2Faegra&pr=555&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fapi%2Fevent_streaming.py%3A172-180%0A**Complete%20release%20requirements**%0A%0AThis%20user-visible%20streaming%20change%20adds%20a%20nine-line%20narrative%20comment%20while%20omitting%20the%20required%20documentation%20and%20matching%20package-version%20updates%2C%20leaving%20the%20new%20wire%20behavior%20undocumented%20and%20the%20bug%20fix%20absent%20from%20release%20versioning.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=555&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22fix%2Fv2-sse-immediate-first-byte%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fv2-sse-immediate-first-byte%22.%0A%0A%23%23%23%20Issue%201%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fapi%2Fevent_streaming.py%3A172-180%0A**Complete%20release%20requirements**%0A%0AThis%20user-visible%20streaming%20change%20adds%20a%20nine-line%20narrative%20comment%20while%20omitting%20the%20required%20documentation%20and%20matching%20package-version%20updates%2C%20leaving%20the%20new%20wire%20behavior%20undocumented%20and%20the%20bug%20fix%20absent%20from%20release%20versioning.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=aegra%2Faegra&pr=555&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(api): flush a first byte when a v2 e..."](https://github.com/aegra/aegra/commit/3ca65b4acaf0844b7600eee2fc15bc02c4d82756) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56973176)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/aegra/aegra/blob/main/CLAUDE.md))

<!-- /greptile_comment -->