### PR TITLE
fix(worker): treat uvloop dead-transport RuntimeError as a transport failure in the Redis broker

### DIFF
--- a/libs/aegra-api/src/aegra_api/services/redis_broker.py
+++ b/libs/aegra-api/src/aegra_api/services/redis_broker.py
@@ -31,6 +31,10 @@ logger = structlog.getLogger(__name__)
 
 _serializer = GeneralSerializer()
 
+# uvloop surfaces I/O on a closed transport as RuntimeError instead of a redis
+# ConnectionError; both are transport failures for every broker Redis guard.
+_TRANSPORT_ERRORS: tuple[type[Exception], ...] = (RedisError, RuntimeError)
+
 # TTL for the replay buffer — safety net for runs that crash without cleanup.
 # cleanup_run() deletes the broker on normal completion; this TTL only matters
 # if cleanup never fires (e.g. process crash, OOM kill).
@@ -44,7 +48,7 @@ _BACKOFF_MAX = 30.0
 _BACKOFF_FACTOR = 2.0
 
 # Bounded retry for the write path (put). The read path (aiter) retries
-# RedisError indefinitely; the write path must be bounded so a producer can't
+# transport errors indefinitely; the write path must be bounded so a producer can't
 # block forever, but it should still retry a transient blip rather than drop the
 # event — a dropped event is a permanently lost SSE token.
 _PUT_MAX_ATTEMPTS = 3
@@ -129,7 +133,7 @@ class RedisRunBroker(BaseRunBroker):
 
                 if is_end:
                     self._finished = True
-            except RedisError as e:
+            except _TRANSPORT_ERRORS as e:
                 logger.error(
                     f"Redis {operation} write failed for run {self.run_id} after {_PUT_MAX_ATTEMPTS} attempts: {e}"
                 )
@@ -160,14 +164,14 @@ class RedisRunBroker(BaseRunBroker):
         Mirrors the retry/backoff the read path (aiter) already applies, so a
         transient client-side blip (e.g. socket timeout) is retried instead of
         dropping the event. Bounded by ``_PUT_MAX_ATTEMPTS`` so a producer never
-        blocks indefinitely; the final ``RedisError`` propagates to ``put()``.
+        blocks indefinitely; the final transport error propagates to ``put()``.
         """
         attempt = 0
         while True:
             try:
                 await op(message)
                 return
-            except RedisError as e:
+            except _TRANSPORT_ERRORS as e:
                 attempt += 1
                 if attempt >= _PUT_MAX_ATTEMPTS:
                     raise
@@ -187,7 +191,7 @@ class RedisRunBroker(BaseRunBroker):
                     yield event_id, payload
                 # Clean exit from _subscribe_and_listen (end event or finished)
                 break
-            except RedisError as e:
+            except _TRANSPORT_ERRORS as e:
                 attempt += 1
                 delay = _backoff_delay(attempt)
                 logger.warning(
@@ -258,7 +262,7 @@ class RedisRunBroker(BaseRunBroker):
                 if isinstance(payload, tuple) and len(payload) >= 1 and payload[0] == "end":
                     self._finished = True
                     return True
-        except RedisError as e:
+        except _TRANSPORT_ERRORS as e:
             logger.warning(f"Failed checking replay buffer for end event for run {self.run_id}: {e}")
         return False
 
@@ -266,7 +270,7 @@ class RedisRunBroker(BaseRunBroker):
         try:
             client = redis_manager.get_client()
             raw_messages = await client.lrange(self._cache_key, 0, _REPLAY_MAX_EVENTS - 1)  # type: ignore[invalid-await]
-        except RedisError as e:
+        except _TRANSPORT_ERRORS as e:
             logger.error(f"Redis replay failed for run {self.run_id}: {e}")
             return []
 
@@ -395,7 +399,7 @@ class RedisBrokerManager(BaseBrokerManager):
             client = redis_manager.get_client()
             await client.publish(self._cancel_channel, message)
             logger.info(f"Published {action} command for run {run_id}")
-        except RedisError as e:
+        except _TRANSPORT_ERRORS as e:
             logger.error(f"Failed to publish {action} for run {run_id}: {e}")
             # Fall back to local execution - if the task is on this instance,
             # we can still cancel it even if Redis publish fails.
@@ -408,7 +412,7 @@ class RedisBrokerManager(BaseBrokerManager):
             value = await client.get(f"{self._counter_prefix}{run_id}")
             if value is not None:
                 return int(value)
-        except (RedisError, ValueError) as e:
+        except (*_TRANSPORT_ERRORS, ValueError) as e:
             logger.warning(f"Failed to read event counter for run {run_id}: {e}")
         return 0
 
@@ -425,7 +429,7 @@ class RedisBrokerManager(BaseBrokerManager):
             seq = await client.incr(counter_key)
             await client.expire(counter_key, _REPLAY_TTL_SECONDS)
             return generate_event_id(run_id, int(seq))
-        except RedisError as e:
+        except _TRANSPORT_ERRORS as e:
             logger.warning(f"Failed to allocate event_id for run {run_id}: {e}")
             # Fallback: use timestamp-based ID (unique but not sequential)
             return generate_event_id(run_id, int(time.time() * 1000))
@@ -439,7 +443,7 @@ class RedisBrokerManager(BaseBrokerManager):
                 attempt = 0
             except asyncio.CancelledError:
                 break
-            except RedisError as e:
+            except _TRANSPORT_ERRORS as e:
                 attempt += 1
                 delay = _backoff_delay(attempt)
                 logger.error(

--- a/libs/aegra-api/tests/unit/test_services/test_redis_broker.py
+++ b/libs/aegra-api/tests/unit/test_services/test_redis_broker.py
@@ -2,6 +2,8 @@
 
 import asyncio
 import json
+from collections.abc import AsyncIterator
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -843,7 +845,7 @@ class TestTransportErrorResilience:
         broker = self._make_broker()
         calls = {"n": 0}
 
-        async def fake_subscribe():  # type: ignore[no-untyped-def]
+        async def fake_subscribe() -> AsyncIterator[tuple[str, Any]]:
             calls["n"] += 1
             if calls["n"] == 1:
                 raise self._TRANSPORT_RUNTIME_ERROR

--- a/libs/aegra-api/tests/unit/test_services/test_redis_broker.py
+++ b/libs/aegra-api/tests/unit/test_services/test_redis_broker.py
@@ -772,3 +772,185 @@ class TestRedisBrokerManager:
 
             await manager.stop()
             assert manager._running is False
+
+
+class TestTransportErrorResilience:
+    """uvloop surfaces I/O on a dead transport as RuntimeError, not RedisError.
+
+    Every resilience guard in the broker must treat it as the transport
+    failure it is — otherwise a single dead connection kills the run.
+    """
+
+    _TRANSPORT_RUNTIME_ERROR = RuntimeError(
+        "unable to perform operation on <TCPTransport closed=True reading=False>; the handler is closed"
+    )
+
+    def _make_broker(self, run_id: str = "run-123") -> RedisRunBroker:
+        return RedisRunBroker(
+            run_id,
+            f"aegra:run:{run_id}",
+            f"aegra:run:cache:{run_id}",
+            f"aegra:run:counter:{run_id}",
+        )
+
+    def _make_manager(self) -> RedisBrokerManager:
+        return RedisBrokerManager()
+
+    @pytest.mark.asyncio
+    async def test_put_survives_transport_runtime_error(self) -> None:
+        """put() must not propagate a dead-transport RuntimeError to the producer"""
+        broker = self._make_broker()
+        mock_pipe = MagicMock()
+        mock_pipe.execute = AsyncMock(side_effect=self._TRANSPORT_RUNTIME_ERROR)
+        mock_client = MagicMock()
+        mock_client.publish = AsyncMock()
+        mock_client.pipeline.return_value = mock_pipe
+
+        with (
+            patch("aegra_api.services.redis_broker.redis_manager") as mock_rm,
+            patch("aegra_api.services.redis_broker.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            mock_rm.get_client.return_value = mock_client
+
+            await broker.put("evt-1", ("values", {"data": "test"}))
+
+        assert mock_pipe.execute.await_count == _PUT_MAX_ATTEMPTS
+
+    @pytest.mark.asyncio
+    async def test_put_retries_transport_runtime_error_then_succeeds(self) -> None:
+        """A transient dead-transport blip on the cache write is retried like a RedisError"""
+        broker = self._make_broker()
+        mock_pipe = MagicMock()
+        mock_pipe.execute = AsyncMock(side_effect=[self._TRANSPORT_RUNTIME_ERROR, None])
+        mock_client = MagicMock()
+        mock_client.publish = AsyncMock()
+        mock_client.pipeline.return_value = mock_pipe
+
+        with (
+            patch("aegra_api.services.redis_broker.redis_manager") as mock_rm,
+            patch("aegra_api.services.redis_broker.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            mock_rm.get_client.return_value = mock_client
+
+            await broker.put("evt-1", ("values", {"msg": "hi"}))
+
+        assert mock_pipe.execute.await_count == 2
+        mock_client.publish.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_aiter_retries_on_transport_runtime_error(self) -> None:
+        """aiter() must reconnect after a dead-transport RuntimeError, not die"""
+        broker = self._make_broker()
+        calls = {"n": 0}
+
+        async def fake_subscribe():  # type: ignore[no-untyped-def]
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise self._TRANSPORT_RUNTIME_ERROR
+            broker._finished = True
+            return
+            yield  # pragma: no cover — makes this an async generator
+
+        with (
+            patch.object(broker, "_subscribe_and_listen", side_effect=lambda: fake_subscribe()),
+            patch("aegra_api.services.redis_broker.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            events = [e async for e in broker.aiter()]
+
+        assert events == []
+        assert calls["n"] == 2
+
+    @pytest.mark.asyncio
+    async def test_allocate_event_id_falls_back_on_transport_runtime_error(self) -> None:
+        """allocate_event_id keeps its timestamp fallback on a dead transport"""
+        manager = self._make_manager()
+        mock_client = AsyncMock()
+        mock_client.incr.side_effect = self._TRANSPORT_RUNTIME_ERROR
+
+        with patch("aegra_api.services.redis_broker.redis_manager") as mock_rm:
+            mock_rm.get_client.return_value = mock_client
+
+            event_id = await manager.allocate_event_id("run-123")
+
+        assert isinstance(event_id, str)
+        assert event_id
+
+    @pytest.mark.asyncio
+    async def test_get_event_sequence_handles_transport_runtime_error(self) -> None:
+        """get_event_sequence returns 0 on a dead transport instead of raising"""
+        manager = self._make_manager()
+        mock_client = AsyncMock()
+        mock_client.get.side_effect = self._TRANSPORT_RUNTIME_ERROR
+
+        with patch("aegra_api.services.redis_broker.redis_manager") as mock_rm:
+            mock_rm.get_client.return_value = mock_client
+
+            result = await manager.get_event_sequence("run-123")
+
+        assert result == 0
+
+    @pytest.mark.asyncio
+    async def test_request_cancel_falls_back_on_transport_runtime_error(self) -> None:
+        """request_cancel falls back to local cancel on a dead transport"""
+        manager = self._make_manager()
+        mock_client = MagicMock()
+        mock_client.publish = AsyncMock(side_effect=self._TRANSPORT_RUNTIME_ERROR)
+
+        with (
+            patch("aegra_api.services.redis_broker.redis_manager") as mock_rm,
+            patch.object(manager, "_execute_cancel", new_callable=AsyncMock) as mock_exec,
+        ):
+            mock_rm.get_client.return_value = mock_client
+
+            await manager.request_cancel("run-123", "cancel")
+
+            mock_exec.assert_awaited_once_with("run-123", emit_end_event=True)
+
+    @pytest.mark.asyncio
+    async def test_cancel_listener_survives_transport_runtime_error(self) -> None:
+        """The cancel listener must reconnect after a dead transport, not die silently"""
+        manager = self._make_manager()
+        manager._running = True
+        calls = {"n": 0}
+
+        async def fake_handle() -> None:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise self._TRANSPORT_RUNTIME_ERROR
+            manager._running = False
+
+        with (
+            patch.object(manager, "_subscribe_and_handle_cancels", side_effect=fake_handle),
+            patch("aegra_api.services.redis_broker.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            await manager._listen_for_cancel_commands()
+
+        assert calls["n"] == 2
+
+    @pytest.mark.asyncio
+    async def test_replay_returns_empty_on_transport_runtime_error(self) -> None:
+        """replay() degrades to an empty list on a dead transport instead of raising"""
+        broker = self._make_broker()
+        mock_client = AsyncMock()
+        mock_client.lrange.side_effect = self._TRANSPORT_RUNTIME_ERROR
+
+        with patch("aegra_api.services.redis_broker.redis_manager") as mock_rm:
+            mock_rm.get_client.return_value = mock_client
+
+            result = await broker.replay(None)
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_check_end_in_buffer_returns_false_on_transport_runtime_error(self) -> None:
+        """_check_end_in_buffer treats a dead transport as 'no end event seen'"""
+        broker = self._make_broker()
+        mock_client = AsyncMock()
+        mock_client.lrange.side_effect = self._TRANSPORT_RUNTIME_ERROR
+
+        with patch("aegra_api.services.redis_broker.redis_manager") as mock_rm:
+            mock_rm.get_client.return_value = mock_client
+
+            result = await broker._check_end_in_buffer()
+
+        assert result is False


### PR DESCRIPTION
We're running aegra as the runtime for an enterprise agent platform (entry-level scale, WorkerExecutor + Redis broker under uvloop), and we hit runs being killed by a failure class the broker is clearly designed to survive. Full mechanism and production data in #556 — short version: when a pooled connection's TCP transport dies, uvloop raises `RuntimeError` ("unable to perform operation on <TCPTransport closed=True ...>") instead of a redis `ConnectionError`, and every resilience guard in `redis_broker.py` catches `RedisError` only.

The broker already has the right machinery for exactly this situation: `allocate_event_id` has a timestamp fallback, `put()` retries with bounded backoff and swallows the final error so a publish failure never kills the producer, `aiter()` and the cancel listener have reconnect loops. A dead-transport `RuntimeError` bypasses all of it: it escapes `allocate_event_id` (awaited without guards in `_stream_legacy`, `_stream_native_v2` and `_signal_end_event`), propagates out of `_stream_graph`, and the run fails. The cancel listener dies permanently, silently disabling cross-instance cancels until restart.

The fix keeps one source of truth: a module-level `_TRANSPORT_ERRORS: tuple[type[Exception], ...] = (RedisError, RuntimeError)` used by every resilience guard in the file. Two properties worth calling out for review: `asyncio.CancelledError` derives from `BaseException`, so cancellation semantics are untouched; and each guard wraps only the Redis awaits (client calls / pipeline execute), so the wider catch cannot mask errors coming from graph or serialization code.

## Changes Made

- `redis_broker.py`: add `_TRANSPORT_ERRORS` and use it in the 9 resilience guards that caught `RedisError` (`put`, `_write_with_retry`, `aiter`, `_check_end_in_buffer`, `replay`, `request_cancel`, `get_event_sequence` — kept `ValueError` alongside —, `allocate_event_id`, `_listen_for_cancel_commands`). Two stale comments updated to say "transport error".

## Testing

- 9 new regression tests in `TestTransportErrorResilience` (mirroring the file's existing mock patterns), one per guard, all using the real uvloop error message as `side_effect`. All 9 fail on `main` (the `RuntimeError` propagates) and pass with this change.
- Locally: full unit tier green (aegra-api 1533 passed, aegra-cli 192 passed), `ruff format`/`ruff check` clean. E2E suites need the compose services and are left to CI.

## Backward compatibility

No API or behavior change for `RedisError` paths — the change only widens which exceptions the *existing* fallback/retry behavior applies to. Delivery semantics are unchanged (`put()` was already documented at-least-once with `event_id` de-duplication).

Fixes #556


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when the Redis connection closes unexpectedly.
  * Operations now retry or gracefully fall back during transport failures, including publishing, event retrieval, cancellation, replay, and live updates.
  * Redis listeners can reconnect more reliably after connection interruptions.

* **Tests**
  * Added coverage for recovery and fallback behavior across Redis-backed operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR broadens the Redis broker’s existing transport-failure recovery paths to handle uvloop dead-transport `RuntimeError` exceptions.
- Adds a shared transport-exception tuple across broker publishing, replay, event sequencing, cancellation, and listener paths.
- Adds regression coverage for retry, fallback, and reconnection behavior.
- Replaces the previously suppressed test-helper return annotation with an explicit async-iterator type.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/services/redis_broker.py | Extends existing Redis resilience guards to handle uvloop dead-transport runtime errors. |
| libs/aegra-api/tests/unit/test_services/test_redis_broker.py | Adds transport-error regression tests and fully resolves the prior missing return-annotation finding. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test(worker): annotate fake\_subscribe re..."](https://github.com/aegra/aegra/commit/f5ff2180da0acf1fe30bc7561d25fde6cf4268db) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57036527)</sub>

<!-- /greptile_comment -->