### PR TITLE
fix(api): accept config.configurable.checkpoint_id as a checkpoint-only resume

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -4667,7 +4667,7 @@
               }
             ],
             "title": "Config",
-            "description": "Execution config"
+            "description": "Execution config. A checkpoint-only resume may also be expressed here as config.configurable.checkpoint_id (the LangGraph SDK's spelling) \u2014 equivalent to the top-level 'checkpoint' field."
           },
           "context": {
             "anyOf": [
@@ -4693,7 +4693,7 @@
               }
             ],
             "title": "Checkpoint",
-            "description": "Checkpoint configuration (e.g., {'checkpoint_id': '...', 'checkpoint_ns': ''})"
+            "description": "Checkpoint configuration (e.g., {'checkpoint_id': '...', 'checkpoint_ns': ''}). Merged into config.configurable; config.configurable.checkpoint_id is an equivalent spelling accepted for checkpoint-only resumes."
           },
           "stream": {
             "type": "boolean",

--- a/libs/aegra-api/src/aegra_api/models/runs.py
+++ b/libs/aegra-api/src/aegra_api/models/runs.py
@@ -35,11 +35,22 @@ class RunCreate(BaseModel):
         None,
         description="Input data for the run. Optional when resuming from a checkpoint.",
     )
-    config: dict[str, Any] | None = Field(default_factory=dict, description="Execution config")
+    config: dict[str, Any] | None = Field(
+        default_factory=dict,
+        description=(
+            "Execution config. A checkpoint-only resume may also be expressed here as "
+            "config.configurable.checkpoint_id (the LangGraph SDK's spelling) — "
+            "equivalent to the top-level 'checkpoint' field."
+        ),
+    )
     context: dict[str, Any] | None = Field(default_factory=dict, description="Execution context")
     checkpoint: dict[str, Any] | None = Field(
         None,
-        description="Checkpoint configuration (e.g., {'checkpoint_id': '...', 'checkpoint_ns': ''})",
+        description=(
+            "Checkpoint configuration (e.g., {'checkpoint_id': '...', 'checkpoint_ns': ''}). "
+            "Merged into config.configurable; config.configurable.checkpoint_id is an "
+            "equivalent spelling accepted for checkpoint-only resumes."
+        ),
     )
     stream: bool = Field(False, description="Enable streaming response")
     stream_mode: str | list[str] | None = Field(None, description="Requested stream mode(s)")

--- a/libs/aegra-api/src/aegra_api/models/runs.py
+++ b/libs/aegra-api/src/aegra_api/models/runs.py
@@ -136,8 +136,19 @@ class RunCreate(BaseModel):
                 raise ValueError("Cannot specify both 'input' and 'command' - they are mutually exclusive")
         # Checkpoint-only resume keeps input=None so Pregel resumes from next=[...]
         # instead of restarting from __start__ with an empty input.
+        #
+        # The checkpoint may also arrive as config.configurable.checkpoint_id —
+        # the legacy-compliant spelling the LangGraph SDK uses (its ThreadStream
+        # folds `forkFrom` there before dispatch, expecting the server-side
+        # merge). Execution already honors it: create_run_config() merges the
+        # top-level `checkpoint` dict into `configurable` anyway, so the two
+        # spellings are equivalent past validation. Without this, SDK-driven
+        # regenerate/fork (run.start with only forkFrom) is rejected here.
         if self.input is None and self.command is None and self.checkpoint is None:
-            raise ValueError("Must specify at least one of 'input', 'command', or 'checkpoint'")
+            configurable = (self.config or {}).get("configurable")
+            has_configurable_checkpoint = isinstance(configurable, dict) and bool(configurable.get("checkpoint_id"))
+            if not has_configurable_checkpoint:
+                raise ValueError("Must specify at least one of 'input', 'command', or 'checkpoint'")
         return self
 
 

--- a/libs/aegra-api/tests/unit/test_models/test_runcreate_validation.py
+++ b/libs/aegra-api/tests/unit/test_models/test_runcreate_validation.py
@@ -26,6 +26,27 @@ class TestRunCreateValidation:
         assert run_create.command is None
         assert run_create.checkpoint == {"checkpoint_id": "chk-1", "checkpoint_ns": ""}
 
+    def test_configurable_checkpoint_id_counts_as_checkpoint(self):
+        """config.configurable.checkpoint_id is the LangGraph SDK's spelling of a
+        checkpoint-only resume (ThreadStream folds forkFrom there). Execution
+        already honors it — create_run_config merges the top-level checkpoint
+        into configurable — so validation must accept it too, keeping input None.
+        """
+        run_create = RunCreate(
+            assistant_id="agent",
+            config={"configurable": {"checkpoint_id": "chk-1"}},
+        )
+
+        assert run_create.input is None
+        assert run_create.command is None
+        assert run_create.checkpoint is None
+
+    def test_empty_configurable_checkpoint_id_still_rejected(self):
+        """An empty/absent checkpoint_id in configurable must not satisfy the
+        input/command/checkpoint requirement."""
+        with pytest.raises(ValidationError, match="Must specify at least one"):
+            RunCreate(assistant_id="agent", config={"configurable": {"checkpoint_id": ""}})
+
     def test_rejects_payload_without_input_command_or_checkpoint(self):
         """Ensure payloads with no input, command, or checkpoint are rejected."""
         with pytest.raises(ValueError, match="Must specify at least one of 'input', 'command', or 'checkpoint'"):


### PR DESCRIPTION
Fixes #558

## What

`RunCreate.validate_input_command_exclusivity` now treats a non-empty `config.configurable.checkpoint_id` as satisfying the input/command/checkpoint requirement, exactly like the top-level `checkpoint` field.

## Why

The LangGraph SDK dispatches checkpoint-only resumes (regenerate/fork) as `run.start` with `forkFrom` folded into `config.configurable.checkpoint_id` (`foldForkFromIntoConfig`, documented there as the single legacy-compliant spelling that expects the server-side merge). Aegra already implements the merge — `create_run_config()` folds the top-level `checkpoint` dict into `configurable` — so past validation the two spellings are equivalent. Only the validator disagreed, rejecting every SDK-driven regenerate with `Must specify at least one of 'input', 'command', or 'checkpoint'` and leaving assistant-ui/`useStream` clients with a regenerate button that silently does nothing.

No execution change: validation-only.

## Testing

- Two new cases in `test_runcreate_validation.py`: configurable checkpoint_id accepted (input stays `None` for Pregel resume), empty checkpoint_id still rejected. Full `tests/unit/test_models` suite: 54 passed.
- End-to-end against a real assistant-ui client (`@langchain/langgraph-sdk` 1.9.31 / `@assistant-ui/react-langchain` 0.0.27): the previously-failing regenerate `run.start` returns success, the run executes from the forked checkpoint (fresh provider response id on the regenerated answer), and the UI replaces the answer in place.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Checkpoint-only resume requests are now accepted when a valid checkpoint ID is provided in the configuration.
  * Resume requests can proceed without additional input or commands when using a valid checkpoint.
  * Empty checkpoint IDs continue to be rejected when no other resume information is supplied.
* **Documentation**
  * Clarified checkpoint-only resume options and how checkpoint configuration is merged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR allows SDK-style checkpoint-only resumes and updates the API documentation to describe the newly accepted nested spelling.
- Accepts a non-empty `config.configurable.checkpoint_id` when input, command, and top-level checkpoint are absent.
- Preserves `input=None` for checkpoint resume semantics.
- Updates the generated OpenAPI descriptions and adds validation coverage for populated and empty checkpoint IDs.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the previously reported documentation omission is fixed in both the model descriptions and generated OpenAPI schema.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/models/runs.py | Aligns validation and field documentation with the SDK’s nested checkpoint-only resume representation. |
| libs/aegra-api/tests/unit/test_models/test_runcreate_validation.py | Covers acceptance of a populated nested checkpoint ID and rejection of an empty one. |
| docs/openapi.json | Updates the generated API schema to document the supported nested checkpoint spelling. |

</details>

<sub>Reviews (2): Last reviewed commit: ["docs(api): document configurable.checkpo..."](https://github.com/aegra/aegra/commit/3eb27b585f03fbfec65860bcbb1a110f939fb37f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57833072)</sub>

<!-- /greptile_comment -->