### PR TITLE
feat(redis): support redis+sentinel:// URLs for HA deployments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -59,6 +59,9 @@ LOG_VERBOSITY=standard # standard, verbose (verbose outputs request-id)
 # executed by concurrent worker tasks with lease-based crash recovery.
 # When disabled (dev mode), runs execute as in-process asyncio tasks.
 REDIS_BROKER_ENABLED=false
+# For a Sentinel-managed HA Redis, use the redis+sentinel:// scheme instead of an
+# endpoint (rediss+sentinel:// for TLS). See docs/reference/environment-variables.
+# REDIS_URL=redis+sentinel://sentinel-a:26379,sentinel-b:26379/mymaster/0
 REDIS_URL=redis://localhost:6379/0
 # REDIS_CHANNEL_PREFIX=aegra:run:
 # REDIS_MAX_CONNECTIONS=250

--- a/docs/guides/deployment.mdx
+++ b/docs/guides/deployment.mdx
@@ -158,6 +158,15 @@ containers:
 
 PostgreSQL should be a managed service (CloudSQL, RDS, etc.) or a StatefulSet with persistent volumes. Redis should be a managed service (ElastiCache, Memorystore, etc.) or a separate Deployment.
 
+If Redis is run by a Sentinel-based operator, point `REDIS_URL` at the sentinels rather than at a data node, so the client follows a failover instead of pinning to whichever node it dialled first:
+
+```yaml
+- name: REDIS_URL
+  value: redis+sentinel://redis-sentinel:26379/mymaster/0
+```
+
+See [Sentinel](/reference/environment-variables#sentinel) for the full URL format.
+
 Set `terminationGracePeriodSeconds` a few seconds above `WORKER_DRAIN_TIMEOUT` (default 30). On SIGTERM the pod waits that long for in-flight runs to finish, then hands the rest back to the queue for other pods to resume from the last checkpoint. A pod killed mid-hand-off still recovers: before the database reset, the lease reaper reclaims the runs after lease expiry; after the reset but before the queue push, the stuck-pending scan re-enqueues them after `STUCK_PENDING_THRESHOLD_SECONDS`. See the [worker architecture guide](/guides/worker-architecture#graceful-shutdown).
 
 ## Database configuration

--- a/docs/guides/deployment.mdx
+++ b/docs/guides/deployment.mdx
@@ -165,7 +165,7 @@ If Redis is run by a Sentinel-based operator, point `REDIS_URL` at the sentinels
   value: redis+sentinel://redis-sentinel:26379/mymaster/0
 ```
 
-See [Sentinel](/reference/environment-variables#sentinel) for the full URL format.
+Use `rediss+sentinel://` to wrap both the discovery and the master connection in TLS. See [Sentinel](/reference/environment-variables#sentinel) for the full URL format, including the certificate-hostname caveat that catches most first attempts.
 
 Set `terminationGracePeriodSeconds` a few seconds above `WORKER_DRAIN_TIMEOUT` (default 30). On SIGTERM the pod waits that long for in-flight runs to finish, then hands the rest back to the queue for other pods to resume from the last checkpoint. A pod killed mid-hand-off still recovers: before the database reset, the lease reaper reclaims the runs after lease expiry; after the reset but before the queue push, the stuck-pending scan re-enqueues them after `STUCK_PENDING_THRESHOLD_SECONDS`. See the [worker architecture guide](/guides/worker-architecture#graceful-shutdown).
 

--- a/docs/guides/worker-architecture.mdx
+++ b/docs/guides/worker-architecture.mdx
@@ -306,7 +306,7 @@ All worker settings are configured via environment variables. See the [environme
 | Variable | Default | Description |
 |:---------|:--------|:------------|
 | `REDIS_BROKER_ENABLED` | `false` | Enable Redis workers and broker |
-| `REDIS_URL` | `redis://localhost:6379/0` | Redis connection URL |
+| `REDIS_URL` | `redis://localhost:6379/0` | Redis connection URL. Use `redis+sentinel://host:26379/<master>` for a Sentinel-managed HA Redis ([reference](/reference/environment-variables#sentinel)) |
 | `WORKER_COUNT` | `3` | Worker loops per instance |
 | `N_JOBS_PER_WORKER` | `10` | Concurrent runs per worker loop |
 | `BG_JOB_TIMEOUT_SECS` | `3600` | Max execution time per run (1 hour) |

--- a/docs/reference/environment-variables.mdx
+++ b/docs/reference/environment-variables.mdx
@@ -180,7 +180,7 @@ They are only accepted on `rediss+sentinel://`; passing them to the plaintext sc
   2. Issue the data-node certificates with IP SANs.
   3. Set `ssl_check_hostname=false` and rely on CA verification alone. This is the weakest option -- it still proves the peer holds a certificate your CA signed, but no longer that it is the host you meant to reach.
 
-  Aegra keeps redis-py's secure defaults and does not pick for you.
+  Aegra will not weaken verification for you. `ssl_check_hostname` is pinned to `true` unless you set it, because redis-py's *async* client defaulted it to `false` before 6.0 and Aegra supports redis-py from 5.0 -- inheriting that default would have turned hostname verification off silently on older installs.
 </Warning>
 
 ## Workers

--- a/docs/reference/environment-variables.mdx
+++ b/docs/reference/environment-variables.mdx
@@ -148,11 +148,40 @@ redis+sentinel://[username:password@]host[:port][,host[:port]...]/<master_name>[
 | userinfo | Credentials for the **data nodes**, exactly as in a plain `redis://` URL |
 | `sentinel_username` / `sentinel_password` | Credentials for the **sentinels**, which usually differ from the data nodes' |
 
-Sentinel is opt-in and changes nothing else: a `redis://` or `rediss://` URL takes the direct path as before. A malformed `redis+sentinel://` URL is rejected at startup rather than at the first connection.
+Sentinel is opt-in and changes nothing else: a `redis://` or `rediss://` URL takes the direct path as before. A malformed sentinel URL is rejected at startup rather than at the first connection.
 
-<Note>
-  TLS to Sentinel-managed data nodes (`rediss+sentinel://`) is not supported yet, and is rejected with an explicit error rather than silently connecting in plaintext.
-</Note>
+#### TLS
+
+Use the `rediss+sentinel://` scheme. TLS then wraps **both** hops -- the sentinel discovery traffic and the connection to the master it returns. Wrapping only the master would leave the discovery exchange, and the sentinel AUTH that goes with it, in the clear.
+
+```bash
+REDIS_URL=rediss+sentinel://sentinel-a:26379,sentinel-b:26379/mymaster/0?ssl_ca_certs=/certs/ca.pem
+```
+
+The `ssl_*` query parameters are named as redis-py names them on a `rediss://` URL, so the two schemes stay consistent:
+
+| Parameter | Meaning |
+|-----------|---------|
+| `ssl_cert_reqs` | `none`, `optional` or `required`. Defaults to `required` |
+| `ssl_ca_certs` | Path to the CA bundle |
+| `ssl_ca_path` | Directory of CA certificates |
+| `ssl_certfile` / `ssl_keyfile` | Client certificate and key, for mutual TLS |
+| `ssl_password` | Password for an encrypted `ssl_keyfile` |
+| `ssl_check_hostname` | Verify the certificate against the hostname. Defaults to `true` |
+
+They are only accepted on `rediss+sentinel://`; passing them to the plaintext scheme is an error rather than a silent no-op.
+
+<Warning>
+  **Sentinel returns the master's IP address, not its hostname.** With the default `ssl_check_hostname=true`, TLS verification then compares the certificate against an IP and fails, typically with `certificate verify failed: IP address mismatch`.
+
+  Three ways out, best first:
+
+  1. Configure Redis with `sentinel announce-hostnames yes` and `sentinel resolve-hostnames yes` (Redis 6.2+) so the sentinels report names your certificate actually covers.
+  2. Issue the data-node certificates with IP SANs.
+  3. Set `ssl_check_hostname=false` and rely on CA verification alone. This is the weakest option -- it still proves the peer holds a certificate your CA signed, but no longer that it is the host you meant to reach.
+
+  Aegra keeps redis-py's secure defaults and does not pick for you.
+</Warning>
 
 ## Workers
 

--- a/docs/reference/environment-variables.mdx
+++ b/docs/reference/environment-variables.mdx
@@ -124,9 +124,35 @@ Aegra uses two connection pools: one for SQLAlchemy (metadata) and one for LangG
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `REDIS_BROKER_ENABLED` | `false` | Enable Redis for multi-instance SSE streaming and worker job dispatch |
-| `REDIS_URL` | `redis://localhost:6379/0` | Redis connection URL |
+| `REDIS_URL` | `redis://localhost:6379/0` | Redis connection URL. `redis+sentinel://` connects through Sentinel -- see below |
 | `REDIS_CHANNEL_PREFIX` | `aegra:run:` | Prefix for Redis pub/sub channels |
 | `REDIS_MAX_CONNECTIONS` | `250` | Maximum Redis connection pool size |
+
+### Sentinel
+
+For a Sentinel-managed HA Redis, give `REDIS_URL` the `redis+sentinel://` scheme instead of an endpoint. Aegra then asks the sentinels for the current master at connect time, and re-resolves it after a failover.
+
+```bash
+REDIS_URL=redis+sentinel://sentinel-a:26379,sentinel-b:26379,sentinel-c:26379/mymaster/0
+```
+
+```text
+redis+sentinel://[username:password@]host[:port][,host[:port]...]/<master_name>[/<db>][?sentinel_username=&sentinel_password=]
+```
+
+| Part | Meaning |
+|------|---------|
+| host list | Comma-separated sentinel endpoints. Port defaults to `26379`. IPv6 literals take brackets: `[::1]:26379` |
+| `master_name` | The monitored master's name, as the sentinels know it. Required |
+| `db` | Database index on the data nodes. Defaults to `0` |
+| userinfo | Credentials for the **data nodes**, exactly as in a plain `redis://` URL |
+| `sentinel_username` / `sentinel_password` | Credentials for the **sentinels**, which usually differ from the data nodes' |
+
+Sentinel is opt-in and changes nothing else: a `redis://` or `rediss://` URL takes the direct path as before. A malformed `redis+sentinel://` URL is rejected at startup rather than at the first connection.
+
+<Note>
+  TLS to Sentinel-managed data nodes (`rediss+sentinel://`) is not supported yet, and is rejected with an explicit error rather than silently connecting in plaintext.
+</Note>
 
 ## Workers
 

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.10.5"
+version = "0.10.6"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-api/src/aegra_api/core/redis_manager.py
+++ b/libs/aegra-api/src/aegra_api/core/redis_manager.py
@@ -23,11 +23,11 @@ class RedisManager:
     initialized during app lifespan and closed on shutdown.
 
     Connects one of two ways, chosen by REDIS_URL's scheme. A ``redis://``
-    URL dials that endpoint directly. A ``redis+sentinel://`` URL goes through
-    Sentinel instead, which resolves the current master at connect time and
-    re-resolves it after a failover. Both paths hand back the same
-    ``redis.asyncio.Redis``, so nothing downstream of ``get_client()`` knows
-    the difference.
+    URL dials that endpoint directly. A ``redis+sentinel://`` URL (or
+    ``rediss+sentinel://`` for TLS) goes through Sentinel instead, which
+    resolves the current master at connect time and re-resolves it after a
+    failover. Both paths hand back the same ``redis.asyncio.Redis``, so
+    nothing downstream of ``get_client()`` knows the difference.
     """
 
     def __init__(self) -> None:
@@ -70,6 +70,11 @@ class RedisManager:
         credentials, so they get separate connection kwargs. ``master_for``
         returns a client whose pool re-queries the sentinels whenever it needs
         a connection, which is what makes it follow a failover.
+
+        On the TLS scheme both hops are wrapped: ``ssl=True`` makes
+        ``Redis`` pick ``SSLConnection`` for the sentinels, and
+        ``SentinelConnectionPool`` pick ``SentinelManagedSSLConnection`` for
+        the master.
         """
         sentinel_kwargs = self._connection_kwargs()
         if config.sentinel_username is not None:
@@ -83,6 +88,11 @@ class RedisManager:
             master_kwargs["username"] = config.username
         if config.password is not None:
             master_kwargs["password"] = config.password
+
+        if config.ssl:
+            for kwargs in (sentinel_kwargs, master_kwargs):
+                kwargs["ssl"] = True
+                kwargs.update(config.ssl_options)
 
         self._sentinel = Sentinel(
             list(config.hosts),
@@ -116,6 +126,7 @@ class RedisManager:
                 "Redis broker initialized via Sentinel",
                 sentinels=[f"{host}:{port}" for host, port in sentinel_config.hosts],
                 master_name=sentinel_config.master_name,
+                tls=sentinel_config.ssl,
             )
         else:
             parsed = urlparse(settings.redis.REDIS_URL)

--- a/libs/aegra-api/src/aegra_api/core/redis_manager.py
+++ b/libs/aegra-api/src/aegra_api/core/redis_manager.py
@@ -1,15 +1,17 @@
 """Redis connection manager for the event broker."""
 
+from typing import Any
 from urllib.parse import urlparse
 
 import redis.asyncio as aioredis
 import structlog
 from redis.asyncio.retry import Retry
+from redis.asyncio.sentinel import Sentinel
 from redis.backoff import ExponentialBackoff
 from redis.exceptions import ConnectionError as RedisConnectionError
 from redis.exceptions import TimeoutError as RedisTimeoutError
 
-from aegra_api.settings import settings
+from aegra_api.settings import SentinelConfig, settings
 
 logger = structlog.get_logger(__name__)
 
@@ -19,36 +21,105 @@ class RedisManager:
 
     Follows the same pattern as DatabaseManager: a global singleton
     initialized during app lifespan and closed on shutdown.
+
+    Connects one of two ways, chosen by REDIS_URL's scheme. A ``redis://``
+    URL dials that endpoint directly. A ``redis+sentinel://`` URL goes through
+    Sentinel instead, which resolves the current master at connect time and
+    re-resolves it after a failover. Both paths hand back the same
+    ``redis.asyncio.Redis``, so nothing downstream of ``get_client()`` knows
+    the difference.
     """
 
     def __init__(self) -> None:
         self._pool: aioredis.ConnectionPool | None = None
         self._client: aioredis.Redis | None = None
+        self._sentinel: Sentinel | None = None
 
-    async def initialize(self) -> None:
-        """Create connection pool and verify connectivity."""
-        if self._client is not None:
-            return
+    @staticmethod
+    def _connection_kwargs() -> dict[str, Any]:
+        """Connection settings shared by the direct and Sentinel paths.
 
-        # Directly constructed pools default to zero retries; bounded retries survive
-        # idle disconnects/failovers. Lease acquisition deduplicates RPUSH replays (#505).
-        self._pool = aioredis.ConnectionPool.from_url(
-            settings.redis.REDIS_URL,
-            max_connections=settings.redis.REDIS_MAX_CONNECTIONS,
-            decode_responses=True,
-            health_check_interval=settings.redis.REDIS_HEALTH_CHECK_INTERVAL,
-            retry=Retry(
+        Built fresh per call so each pool gets its own Retry instance.
+        Directly constructed pools default to zero retries; bounded retries
+        survive idle disconnects and failovers. Lease acquisition deduplicates
+        RPUSH replays (#505).
+        """
+        return {
+            "decode_responses": True,
+            "health_check_interval": settings.redis.REDIS_HEALTH_CHECK_INTERVAL,
+            "retry": Retry(
                 ExponentialBackoff(cap=1.0, base=0.05),
                 settings.redis.REDIS_RETRY_ATTEMPTS,
             ),
-            retry_on_error=[RedisConnectionError, RedisTimeoutError],
+            "retry_on_error": [RedisConnectionError, RedisTimeoutError],
+        }
+
+    def _connect_direct(self) -> None:
+        """Dial REDIS_URL directly."""
+        self._pool = aioredis.ConnectionPool.from_url(
+            settings.redis.REDIS_URL,
+            max_connections=settings.redis.REDIS_MAX_CONNECTIONS,
+            **self._connection_kwargs(),
         )
         self._client = aioredis.Redis(connection_pool=self._pool)
 
+    def _connect_sentinel(self, config: SentinelConfig) -> None:
+        """Resolve the master through Sentinel.
+
+        The sentinels and the data nodes are separate servers with separate
+        credentials, so they get separate connection kwargs. ``master_for``
+        returns a client whose pool re-queries the sentinels whenever it needs
+        a connection, which is what makes it follow a failover.
+        """
+        sentinel_kwargs = self._connection_kwargs()
+        if config.sentinel_username is not None:
+            sentinel_kwargs["username"] = config.sentinel_username
+        if config.sentinel_password is not None:
+            sentinel_kwargs["password"] = config.sentinel_password
+
+        master_kwargs = self._connection_kwargs()
+        master_kwargs["db"] = config.db
+        if config.username is not None:
+            master_kwargs["username"] = config.username
+        if config.password is not None:
+            master_kwargs["password"] = config.password
+
+        self._sentinel = Sentinel(
+            list(config.hosts),
+            sentinel_kwargs=sentinel_kwargs,
+            **master_kwargs,
+        )
+        self._client = self._sentinel.master_for(
+            config.master_name,
+            max_connections=settings.redis.REDIS_MAX_CONNECTIONS,
+        )
+        # Tracked so close() tears the master pool down the same way it does
+        # for the direct path.
+        self._pool = self._client.connection_pool
+
+    async def initialize(self) -> None:
+        """Create the connection pool and verify connectivity."""
+        if self._client is not None:
+            return
+
+        sentinel_config = settings.redis.sentinel
+        if sentinel_config is not None:
+            self._connect_sentinel(sentinel_config)
+        else:
+            self._connect_direct()
+
         await self._client.ping()  # type: ignore[invalid-await]  # redis.asyncio stubs
-        # Log only host info, not full URL which may contain credentials
-        parsed = urlparse(settings.redis.REDIS_URL)
-        logger.info("Redis broker initialized", host=parsed.hostname, port=parsed.port)
+
+        # Log endpoints only, never the URL itself, which may carry credentials
+        if sentinel_config is not None:
+            logger.info(
+                "Redis broker initialized via Sentinel",
+                sentinels=[f"{host}:{port}" for host, port in sentinel_config.hosts],
+                master_name=sentinel_config.master_name,
+            )
+        else:
+            parsed = urlparse(settings.redis.REDIS_URL)
+            logger.info("Redis broker initialized", host=parsed.hostname, port=parsed.port)
 
     async def close(self) -> None:
         """Close Redis connection pool."""
@@ -58,6 +129,12 @@ class RedisManager:
         if self._pool:
             await self._pool.disconnect()
             self._pool = None
+        if self._sentinel:
+            # The sentinel clients hold pools of their own, separate from the
+            # master pool above.
+            for sentinel_client in self._sentinel.sentinels:
+                await sentinel_client.aclose()
+            self._sentinel = None
         logger.info("Redis broker connections closed")
 
     def get_client(self) -> aioredis.Redis:

--- a/libs/aegra-api/src/aegra_api/settings.py
+++ b/libs/aegra-api/src/aegra_api/settings.py
@@ -333,6 +333,7 @@ class ObservabilitySettings(EnvBase):
 SENTINEL_SCHEME = "redis+sentinel"
 SENTINEL_TLS_SCHEME = "rediss+sentinel"
 DEFAULT_SENTINEL_PORT = 26379
+MAX_PORT = 65535
 _SENTINEL_AUTH_PARAMS = frozenset({"sentinel_username", "sentinel_password"})
 # TLS options, named as redis-py names them on a rediss:// URL so the two
 # schemes stay consistent. Only accepted on the TLS scheme.
@@ -437,7 +438,11 @@ def _split_sentinel_hosts(netloc_hosts: str) -> tuple[tuple[str, int], ...]:
         if port_str and not port_str.isdigit():
             msg = f"Non-integer port in REDIS_URL sentinel endpoint: `{spec}` -- got `{port_str}`"
             raise ValueError(msg)
-        hosts.append((host, int(port_str) if port_str else DEFAULT_SENTINEL_PORT))
+        port = int(port_str) if port_str else DEFAULT_SENTINEL_PORT
+        if not 1 <= port <= MAX_PORT:
+            msg = f"Port out of range in REDIS_URL sentinel endpoint: `{spec}` -- got `{port}`"
+            raise ValueError(msg)
+        hosts.append((host, port))
     if not hosts:
         raise ValueError("REDIS_URL names no sentinel endpoints")
     return tuple(hosts)
@@ -497,6 +502,12 @@ def _parse_sentinel_url(url: str) -> SentinelConfig:
         msg = f"Unsupported query parameters in REDIS_URL: {unknown}. Supported: {sorted(supported)}"
         raise ValueError(msg)
 
+    ssl_options = _parse_ssl_options(query)
+    if ssl_enabled:
+        # redis-py's *async* SSLConnection defaulted check_hostname to False
+        # before 6.0, and our floor is >=5.0.0. Pin it instead of inheriting.
+        ssl_options.setdefault("ssl_check_hostname", True)
+
     return SentinelConfig(
         hosts=hosts,
         master_name=master_name,
@@ -506,7 +517,7 @@ def _parse_sentinel_url(url: str) -> SentinelConfig:
         sentinel_username=query.get("sentinel_username") or None,
         sentinel_password=query.get("sentinel_password") or None,
         ssl=ssl_enabled,
-        ssl_options=_parse_ssl_options(query),
+        ssl_options=ssl_options,
     )
 
 

--- a/libs/aegra-api/src/aegra_api/settings.py
+++ b/libs/aegra-api/src/aegra_api/settings.py
@@ -1,7 +1,7 @@
 import logging
 import re
-from typing import Annotated
-from urllib.parse import parse_qsl, quote_plus, urlencode
+from typing import Annotated, NamedTuple
+from urllib.parse import SplitResult, parse_qsl, quote_plus, unquote, urlencode, urlsplit
 
 from pydantic import BeforeValidator, Field, computed_field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -330,11 +330,147 @@ class ObservabilitySettings(EnvBase):
     PHOENIX_API_KEY: str | None = None
 
 
+SENTINEL_SCHEME = "redis+sentinel"
+DEFAULT_SENTINEL_PORT = 26379
+# Only these two are read off the query string. Anything else is a typo or an
+# assumption we do not honour, and silently ignoring it misconfigures the
+# client without a word.
+_SENTINEL_QUERY_PARAMS = frozenset({"sentinel_username", "sentinel_password"})
+
+
+class SentinelConfig(NamedTuple):
+    """A parsed ``redis+sentinel://`` URL."""
+
+    hosts: tuple[tuple[str, int], ...]
+    master_name: str
+    db: int
+    username: str | None
+    password: str | None
+    sentinel_username: str | None
+    sentinel_password: str | None
+
+
+def _split_redis_url(url: str) -> SplitResult:
+    """urlsplit REDIS_URL, naming the setting when the URL is unparseable.
+
+    Stdlib raises a bare "Invalid IPv6 URL" for an unbalanced bracket, which
+    does not say which setting is at fault.
+    """
+    try:
+        return urlsplit(url)
+    except ValueError as exc:
+        msg = f"REDIS_URL is not a valid URL: {exc}"
+        raise ValueError(msg) from exc
+
+
+def _split_sentinel_hosts(netloc_hosts: str) -> tuple[tuple[str, int], ...]:
+    """Split the comma-separated host list of a sentinel URL authority.
+
+    Accepts "host:port", bare "host" (defaulting to 26379), and bracketed IPv6
+    literals such as "[::1]:26379".
+    """
+    hosts: list[tuple[str, int]] = []
+    for entry in netloc_hosts.split(","):
+        spec = entry.strip()
+        if not spec:
+            continue
+        if spec.startswith("["):
+            if "]" not in spec:
+                msg = f"Malformed IPv6 sentinel endpoint in REDIS_URL: `{spec}` -- missing closing bracket"
+                raise ValueError(msg)
+            bracket_end = spec.index("]")
+            host = spec[1:bracket_end]
+            rest = spec[bracket_end + 1 :]
+            if rest and not rest.startswith(":"):
+                # urlsplit rejects unbalanced brackets before we get here, so
+                # this only guards direct callers of this helper.
+                msg = f"Malformed sentinel endpoint in REDIS_URL: `{spec}`"
+                raise ValueError(msg)
+            port_str = rest[1:] if rest.startswith(":") else ""
+        else:
+            host, separator, port_str = spec.rpartition(":")
+            if not separator:
+                host, port_str = port_str, ""
+        if not host:
+            msg = f"Sentinel endpoint in REDIS_URL is missing a host: `{spec}`"
+            raise ValueError(msg)
+        if port_str and not port_str.isdigit():
+            msg = f"Non-integer port in REDIS_URL sentinel endpoint: `{spec}` -- got `{port_str}`"
+            raise ValueError(msg)
+        hosts.append((host, int(port_str) if port_str else DEFAULT_SENTINEL_PORT))
+    if not hosts:
+        raise ValueError("REDIS_URL names no sentinel endpoints")
+    return tuple(hosts)
+
+
+def _parse_sentinel_url(url: str) -> SentinelConfig:
+    """Parse ``redis+sentinel://[user:pass@]host:port[,host:port]/master[/db]``.
+
+    Userinfo is the *data node's* credentials, matching what it means in a
+    plain ``redis://`` URL. The sentinels' own AUTH, which is usually
+    different, comes from the ``sentinel_username`` / ``sentinel_password``
+    query parameters.
+    """
+    split = _split_redis_url(url)
+
+    authority = split.netloc
+    userinfo, _, hostpart = authority.rpartition("@")
+    username: str | None = None
+    password: str | None = None
+    if userinfo:
+        raw_user, _, raw_password = userinfo.partition(":")
+        username = unquote(raw_user) or None
+        password = unquote(raw_password) or None
+
+    hosts = _split_sentinel_hosts(hostpart)
+
+    segments = [segment for segment in split.path.split("/") if segment]
+    if not segments:
+        raise ValueError(
+            f"REDIS_URL is missing the master name. Expected {SENTINEL_SCHEME}://host:port/<master_name>[/<db>]"
+        )
+    if len(segments) > 2:
+        msg = f"REDIS_URL has too many path segments: `{split.path}`. Expected /<master_name>[/<db>]"
+        raise ValueError(msg)
+    master_name = unquote(segments[0])
+    db = 0
+    if len(segments) == 2:
+        if not segments[1].isdigit():
+            msg = f"Non-integer database index in REDIS_URL: `{segments[1]}`"
+            raise ValueError(msg)
+        db = int(segments[1])
+
+    query = dict(parse_qsl(split.query, keep_blank_values=True))
+    unknown = sorted(set(query) - _SENTINEL_QUERY_PARAMS)
+    if unknown:
+        msg = f"Unsupported query parameters in REDIS_URL: {unknown}. Supported: {sorted(_SENTINEL_QUERY_PARAMS)}"
+        raise ValueError(msg)
+
+    return SentinelConfig(
+        hosts=hosts,
+        master_name=master_name,
+        db=db,
+        username=username,
+        password=password,
+        sentinel_username=query.get("sentinel_username") or None,
+        sentinel_password=query.get("sentinel_password") or None,
+    )
+
+
 class RedisSettings(EnvBase):
     """Redis settings for the event broker.
 
     When REDIS_BROKER_ENABLED is True, SSE streaming uses Redis pub/sub
     instead of in-memory queues, enabling multi-instance deployments.
+
+    REDIS_URL selects how the client connects. ``redis://`` and ``rediss://``
+    dial a single endpoint, as before. ``redis+sentinel://`` instead resolves
+    the current master through Sentinel and re-resolves it after a failover:
+
+        redis+sentinel://sentinel-a:26379,sentinel-b:26379/mymaster/0
+
+    Sentinel is entirely opt-in -- keep a ``redis://`` URL and nothing about
+    the existing behaviour changes.
     """
 
     REDIS_BROKER_ENABLED: bool = False
@@ -347,6 +483,26 @@ class RedisSettings(EnvBase):
     # Non-negative retries after the initial attempt (up to 4 calls total) on
     # connection and timeout errors, with exponential backoff 50ms..1s.
     REDIS_RETRY_ATTEMPTS: int = Field(default=3, ge=0)
+
+    @property
+    def sentinel(self) -> SentinelConfig | None:
+        """The parsed sentinel URL, or None for a direct connection."""
+        if _split_redis_url(self.REDIS_URL).scheme != SENTINEL_SCHEME:
+            return None
+        return _parse_sentinel_url(self.REDIS_URL)
+
+    @model_validator(mode="after")
+    def _validate_redis_url(self) -> "RedisSettings":
+        """Parse a sentinel URL at startup so a typo fails before first connect."""
+        scheme = _split_redis_url(self.REDIS_URL).scheme
+        if scheme == f"{SENTINEL_SCHEME}s" or scheme == "rediss+sentinel":
+            raise ValueError(
+                "TLS to Sentinel-managed nodes is not supported yet; use "
+                f"{SENTINEL_SCHEME}:// or open an issue if you need it"
+            )
+        if scheme == SENTINEL_SCHEME:
+            _parse_sentinel_url(self.REDIS_URL)
+        return self
 
 
 class WorkerSettings(EnvBase):

--- a/libs/aegra-api/src/aegra_api/settings.py
+++ b/libs/aegra-api/src/aegra_api/settings.py
@@ -331,15 +331,29 @@ class ObservabilitySettings(EnvBase):
 
 
 SENTINEL_SCHEME = "redis+sentinel"
+SENTINEL_TLS_SCHEME = "rediss+sentinel"
 DEFAULT_SENTINEL_PORT = 26379
-# Only these two are read off the query string. Anything else is a typo or an
-# assumption we do not honour, and silently ignoring it misconfigures the
-# client without a word.
-_SENTINEL_QUERY_PARAMS = frozenset({"sentinel_username", "sentinel_password"})
+_SENTINEL_AUTH_PARAMS = frozenset({"sentinel_username", "sentinel_password"})
+# TLS options, named as redis-py names them on a rediss:// URL so the two
+# schemes stay consistent. Only accepted on the TLS scheme.
+_SENTINEL_TLS_PARAMS = frozenset(
+    {
+        "ssl_cert_reqs",
+        "ssl_ca_certs",
+        "ssl_ca_path",
+        "ssl_certfile",
+        "ssl_keyfile",
+        "ssl_password",
+        "ssl_check_hostname",
+    }
+)
+_SSL_CERT_REQS = frozenset({"none", "optional", "required"})
+_TRUE_VALUES = frozenset({"1", "true", "yes", "on"})
+_FALSE_VALUES = frozenset({"0", "false", "no", "off"})
 
 
 class SentinelConfig(NamedTuple):
-    """A parsed ``redis+sentinel://`` URL."""
+    """A parsed ``redis+sentinel://`` or ``rediss+sentinel://`` URL."""
 
     hosts: tuple[tuple[str, int], ...]
     master_name: str
@@ -348,6 +362,32 @@ class SentinelConfig(NamedTuple):
     password: str | None
     sentinel_username: str | None
     sentinel_password: str | None
+    ssl: bool
+    ssl_options: dict[str, str | bool]
+
+
+def _parse_ssl_options(query: dict[str, str]) -> dict[str, str | bool]:
+    """Validate the ssl_* query parameters of a rediss+sentinel:// URL."""
+    options: dict[str, str | bool] = {}
+    for key in sorted(_SENTINEL_TLS_PARAMS & set(query)):
+        value = query[key]
+        if key == "ssl_check_hostname":
+            lowered = value.strip().lower()
+            if lowered in _TRUE_VALUES:
+                options[key] = True
+            elif lowered in _FALSE_VALUES:
+                options[key] = False
+            else:
+                msg = f"REDIS_URL ssl_check_hostname must be a boolean, got `{value}`"
+                raise ValueError(msg)
+        elif key == "ssl_cert_reqs":
+            if value not in _SSL_CERT_REQS:
+                msg = f"REDIS_URL ssl_cert_reqs must be one of {sorted(_SSL_CERT_REQS)}, got `{value}`"
+                raise ValueError(msg)
+            options[key] = value
+        else:
+            options[key] = value
+    return options
 
 
 def _split_redis_url(url: str) -> SplitResult:
@@ -410,8 +450,12 @@ def _parse_sentinel_url(url: str) -> SentinelConfig:
     plain ``redis://`` URL. The sentinels' own AUTH, which is usually
     different, comes from the ``sentinel_username`` / ``sentinel_password``
     query parameters.
+
+    The ``rediss+sentinel://`` scheme wraps both the sentinel and the data
+    node connections in TLS, configured by the ``ssl_*`` query parameters.
     """
     split = _split_redis_url(url)
+    ssl_enabled = split.scheme == SENTINEL_TLS_SCHEME
 
     authority = split.netloc
     userinfo, _, hostpart = authority.rpartition("@")
@@ -441,9 +485,16 @@ def _parse_sentinel_url(url: str) -> SentinelConfig:
         db = int(segments[1])
 
     query = dict(parse_qsl(split.query, keep_blank_values=True))
-    unknown = sorted(set(query) - _SENTINEL_QUERY_PARAMS)
+    supported = _SENTINEL_AUTH_PARAMS | (_SENTINEL_TLS_PARAMS if ssl_enabled else frozenset())
+    unknown = sorted(set(query) - supported)
     if unknown:
-        msg = f"Unsupported query parameters in REDIS_URL: {unknown}. Supported: {sorted(_SENTINEL_QUERY_PARAMS)}"
+        if not ssl_enabled and set(unknown) & _SENTINEL_TLS_PARAMS:
+            msg = (
+                f"TLS options {sorted(set(unknown) & _SENTINEL_TLS_PARAMS)} need the "
+                f"{SENTINEL_TLS_SCHEME}:// scheme; {SENTINEL_SCHEME}:// does not use TLS"
+            )
+            raise ValueError(msg)
+        msg = f"Unsupported query parameters in REDIS_URL: {unknown}. Supported: {sorted(supported)}"
         raise ValueError(msg)
 
     return SentinelConfig(
@@ -454,6 +505,8 @@ def _parse_sentinel_url(url: str) -> SentinelConfig:
         password=password,
         sentinel_username=query.get("sentinel_username") or None,
         sentinel_password=query.get("sentinel_password") or None,
+        ssl=ssl_enabled,
+        ssl_options=_parse_ssl_options(query),
     )
 
 
@@ -465,9 +518,11 @@ class RedisSettings(EnvBase):
 
     REDIS_URL selects how the client connects. ``redis://`` and ``rediss://``
     dial a single endpoint, as before. ``redis+sentinel://`` instead resolves
-    the current master through Sentinel and re-resolves it after a failover:
+    the current master through Sentinel and re-resolves it after a failover,
+    and ``rediss+sentinel://`` does the same over TLS:
 
         redis+sentinel://sentinel-a:26379,sentinel-b:26379/mymaster/0
+        rediss+sentinel://sentinel-a:26379/mymaster/0?ssl_ca_certs=/certs/ca.pem
 
     Sentinel is entirely opt-in -- keep a ``redis://`` URL and nothing about
     the existing behaviour changes.
@@ -487,20 +542,14 @@ class RedisSettings(EnvBase):
     @property
     def sentinel(self) -> SentinelConfig | None:
         """The parsed sentinel URL, or None for a direct connection."""
-        if _split_redis_url(self.REDIS_URL).scheme != SENTINEL_SCHEME:
+        if _split_redis_url(self.REDIS_URL).scheme not in (SENTINEL_SCHEME, SENTINEL_TLS_SCHEME):
             return None
         return _parse_sentinel_url(self.REDIS_URL)
 
     @model_validator(mode="after")
     def _validate_redis_url(self) -> "RedisSettings":
         """Parse a sentinel URL at startup so a typo fails before first connect."""
-        scheme = _split_redis_url(self.REDIS_URL).scheme
-        if scheme == f"{SENTINEL_SCHEME}s" or scheme == "rediss+sentinel":
-            raise ValueError(
-                "TLS to Sentinel-managed nodes is not supported yet; use "
-                f"{SENTINEL_SCHEME}:// or open an issue if you need it"
-            )
-        if scheme == SENTINEL_SCHEME:
+        if _split_redis_url(self.REDIS_URL).scheme in (SENTINEL_SCHEME, SENTINEL_TLS_SCHEME):
             _parse_sentinel_url(self.REDIS_URL)
         return self
 

--- a/libs/aegra-api/tests/unit/test_core/test_redis_manager.py
+++ b/libs/aegra-api/tests/unit/test_core/test_redis_manager.py
@@ -4,8 +4,13 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import redis.asyncio as aioredis
+from redis.asyncio.connection import SSLConnection
 from redis.asyncio.retry import Retry
-from redis.asyncio.sentinel import Sentinel
+from redis.asyncio.sentinel import (
+    Sentinel,
+    SentinelManagedConnection,
+    SentinelManagedSSLConnection,
+)
 from redis.backoff import ExponentialBackoff
 from redis.exceptions import ConnectionError as RedisConnectionError
 
@@ -322,3 +327,83 @@ class TestRedisManagerSentinel:
         assert manager._sentinel is None
         assert manager._client is None
         assert manager._pool is None
+
+
+class TestRedisManagerSentinelTLS:
+    """Test that rediss+sentinel:// wraps both hops in TLS.
+
+    These build genuine redis-py objects rather than mocks: the whole point is
+    that the connection classes and ssl options come out right, and a mock
+    would assert nothing about that.
+    """
+
+    @staticmethod
+    def _connect(monkeypatch: pytest.MonkeyPatch, url: str) -> RedisManager:
+        monkeypatch.setattr(
+            redis_manager_module.settings,
+            "redis",
+            RedisSettings(_env_file=None, REDIS_URL=url),
+        )
+        manager = RedisManager()
+        config = redis_manager_module.settings.redis.sentinel
+        assert config is not None
+        manager._connect_sentinel(config)
+        return manager
+
+    def test_plaintext_sentinel_uses_no_tls_connection_classes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """redis+sentinel:// must not quietly acquire TLS."""
+        manager = self._connect(monkeypatch, "redis+sentinel://a.example:26379/mymaster")
+
+        assert manager._sentinel is not None
+        assert manager._pool is not None
+        assert manager._pool.connection_class is SentinelManagedConnection
+        assert manager._sentinel.sentinels[0].connection_pool.connection_class is not SSLConnection
+
+        manager._client = None
+        manager._pool = None
+        manager._sentinel = None
+
+    def test_tls_applies_to_sentinels_and_master(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Both hops get TLS: the sentinels and the master they point at.
+
+        Wrapping only the master would leave the discovery traffic -- and the
+        sentinel AUTH that goes with it -- in the clear.
+        """
+        manager = self._connect(
+            monkeypatch,
+            "rediss+sentinel://a.example:26379,b.example:26379/mymaster/1?ssl_ca_certs=/certs/ca.pem",
+        )
+
+        assert manager._sentinel is not None
+        assert manager._pool is not None
+        for sentinel_client in manager._sentinel.sentinels:
+            assert sentinel_client.connection_pool.connection_class is SSLConnection
+            assert sentinel_client.connection_pool.connection_kwargs["ssl_ca_certs"] == "/certs/ca.pem"
+        assert manager._pool.connection_class is SentinelManagedSSLConnection
+        assert manager._pool.connection_kwargs["ssl_ca_certs"] == "/certs/ca.pem"
+
+        manager._client = None
+        manager._pool = None
+        manager._sentinel = None
+
+    def test_tls_options_reach_a_real_connection(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Build an actual connection object off the master pool.
+
+        This is the assertion that would catch redis-py renaming or dropping
+        one of the ssl_* kwargs we forward.
+        """
+        manager = self._connect(
+            monkeypatch,
+            "rediss+sentinel://a.example:26379/mymaster?ssl_ca_certs=/certs/ca.pem&ssl_check_hostname=false",
+        )
+
+        assert manager._pool is not None
+        connection = manager._pool.make_connection()
+
+        assert isinstance(connection, SentinelManagedSSLConnection)
+        assert connection.ca_certs == "/certs/ca.pem"
+        assert connection.check_hostname is False
+
+        manager._client = None
+        manager._pool = None
+        manager._sentinel = None

--- a/libs/aegra-api/tests/unit/test_core/test_redis_manager.py
+++ b/libs/aegra-api/tests/unit/test_core/test_redis_manager.py
@@ -407,3 +407,21 @@ class TestRedisManagerSentinelTLS:
         manager._client = None
         manager._pool = None
         manager._sentinel = None
+
+    def test_hostname_verification_on_by_default_on_a_real_connection(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Without ssl_check_hostname in the URL, the connection still verifies.
+
+        redis-py's async SSLConnection defaulted check_hostname to False before
+        6.0, so inheriting the default would silently weaken this on redis 5.x.
+        """
+        manager = self._connect(monkeypatch, "rediss+sentinel://a.example:26379/mymaster?ssl_ca_certs=/certs/ca.pem")
+
+        assert manager._pool is not None
+        connection = manager._pool.make_connection()
+
+        assert isinstance(connection, SentinelManagedSSLConnection)
+        assert connection.check_hostname is True
+
+        manager._client = None
+        manager._pool = None
+        manager._sentinel = None

--- a/libs/aegra-api/tests/unit/test_core/test_redis_manager.py
+++ b/libs/aegra-api/tests/unit/test_core/test_redis_manager.py
@@ -1,15 +1,17 @@
 """Unit tests for RedisManager"""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import redis.asyncio as aioredis
 from redis.asyncio.retry import Retry
+from redis.asyncio.sentinel import Sentinel
 from redis.backoff import ExponentialBackoff
 from redis.exceptions import ConnectionError as RedisConnectionError
 
 from aegra_api.core import redis_manager as redis_manager_module
 from aegra_api.core.redis_manager import RedisManager
+from aegra_api.settings import RedisSettings
 
 
 class TestRedisManager:
@@ -158,3 +160,165 @@ class TestRedisManager:
 
         with pytest.raises(RuntimeError, match="Redis not initialized"):
             manager.get_client()
+
+
+class TestRedisManagerSentinel:
+    """Test the optional redis+sentinel:// connection path."""
+
+    @staticmethod
+    def _use_sentinel_url(monkeypatch: pytest.MonkeyPatch, url: str) -> None:
+        """Point the settings object redis_manager holds at a sentinel URL."""
+        parsed = RedisSettings(_env_file=None, REDIS_URL=url)
+        monkeypatch.setattr(redis_manager_module.settings, "redis", parsed)
+
+    @pytest.mark.asyncio
+    async def test_direct_path_is_untouched_by_default(self) -> None:
+        """The default URL still goes through ConnectionPool.from_url."""
+        manager = RedisManager()
+        mock_client = AsyncMock()
+
+        with (
+            patch("aegra_api.core.redis_manager.aioredis.ConnectionPool") as mock_pool_cls,
+            patch("aegra_api.core.redis_manager.aioredis.Redis", return_value=mock_client),
+            patch("aegra_api.core.redis_manager.Sentinel") as mock_sentinel_cls,
+        ):
+            await manager.initialize()
+
+            mock_pool_cls.from_url.assert_called_once()
+            mock_sentinel_cls.assert_not_called()
+            assert manager._sentinel is None
+
+        manager._client = None
+        manager._pool = None
+
+    @pytest.mark.asyncio
+    async def test_sentinel_url_resolves_master(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A sentinel URL builds a Sentinel and asks it for the master."""
+        self._use_sentinel_url(monkeypatch, "redis+sentinel://a.example:26379,b.example:26380/mymaster/2")
+        manager = RedisManager()
+        mock_client = AsyncMock()
+
+        with (
+            patch("aegra_api.core.redis_manager.aioredis.ConnectionPool") as mock_pool_cls,
+            patch("aegra_api.core.redis_manager.Sentinel") as mock_sentinel_cls,
+        ):
+            mock_sentinel_cls.return_value.master_for.return_value = mock_client
+
+            await manager.initialize()
+
+            # Never dials an endpoint directly on this path
+            mock_pool_cls.from_url.assert_not_called()
+
+            hosts = mock_sentinel_cls.call_args.args[0]
+            assert hosts == [("a.example", 26379), ("b.example", 26380)]
+            assert mock_sentinel_cls.call_args.kwargs["db"] == 2
+
+            mock_sentinel_cls.return_value.master_for.assert_called_once()
+            assert mock_sentinel_cls.return_value.master_for.call_args.args[0] == "mymaster"
+            mock_client.ping.assert_awaited_once()
+            # close() relies on the master pool being tracked like the direct one
+            assert manager._pool is mock_client.connection_pool
+
+        manager._client = None
+        manager._pool = None
+        manager._sentinel = None
+
+    @pytest.mark.asyncio
+    async def test_credentials_are_routed_to_the_right_servers(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Data-node auth goes to the master, sentinel auth to the sentinels."""
+        self._use_sentinel_url(
+            monkeypatch,
+            "redis+sentinel://dbuser:dbpass@a.example:26379/mymaster?sentinel_username=watcher&sentinel_password=spass",
+        )
+        manager = RedisManager()
+
+        with patch("aegra_api.core.redis_manager.Sentinel") as mock_sentinel_cls:
+            mock_sentinel_cls.return_value.master_for.return_value = AsyncMock()
+
+            await manager.initialize()
+
+            kwargs = mock_sentinel_cls.call_args.kwargs
+            assert kwargs["username"] == "dbuser"
+            assert kwargs["password"] == "dbpass"
+            assert kwargs["sentinel_kwargs"]["username"] == "watcher"
+            assert kwargs["sentinel_kwargs"]["password"] == "spass"
+            # The data-node credential must not leak onto the sentinel connections
+            assert kwargs["sentinel_kwargs"]["password"] != "dbpass"
+
+        manager._client = None
+        manager._pool = None
+        manager._sentinel = None
+
+    @pytest.mark.asyncio
+    async def test_sentinel_path_carries_retry_and_health_checks(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Both the master and the sentinel connections get the resilience settings.
+
+        A failover is precisely when a dead connection is retried, so this path
+        needs them at least as much as the direct one.
+        """
+        self._use_sentinel_url(monkeypatch, "redis+sentinel://a.example:26379/mymaster")
+        monkeypatch.setattr(redis_manager_module.settings.redis, "REDIS_HEALTH_CHECK_INTERVAL", 45)
+        monkeypatch.setattr(redis_manager_module.settings.redis, "REDIS_RETRY_ATTEMPTS", 5)
+        manager = RedisManager()
+
+        with patch("aegra_api.core.redis_manager.Sentinel") as mock_sentinel_cls:
+            mock_sentinel_cls.return_value.master_for.return_value = AsyncMock()
+
+            await manager.initialize()
+
+            kwargs = mock_sentinel_cls.call_args.kwargs
+            for scope in (kwargs, kwargs["sentinel_kwargs"]):
+                assert scope["health_check_interval"] == 45
+                assert isinstance(scope["retry"], Retry)
+                assert scope["retry"].get_retries() == 5
+                assert RedisConnectionError in scope["retry_on_error"]
+            # Separate Retry instances, not one shared between the two pools
+            assert kwargs["retry"] is not kwargs["sentinel_kwargs"]["retry"]
+
+        manager._client = None
+        manager._pool = None
+        manager._sentinel = None
+
+    @pytest.mark.asyncio
+    async def test_real_sentinel_object_accepts_our_kwargs(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Construct a genuine Sentinel, not a mock, so a bad kwarg fails here.
+
+        No server is contacted: building the object and its master pool is
+        enough to prove redis-py accepts the arguments we pass.
+        """
+        self._use_sentinel_url(monkeypatch, "redis+sentinel://a.example:26379,b.example:26380/mymaster/1")
+        manager = RedisManager()
+        config = redis_manager_module.settings.redis.sentinel
+        assert config is not None
+
+        manager._connect_sentinel(config)
+
+        assert isinstance(manager._sentinel, Sentinel)
+        assert [(s.connection_pool.connection_kwargs["host"]) for s in manager._sentinel.sentinels] == [
+            "a.example",
+            "b.example",
+        ]
+        assert manager._client is not None
+        assert manager._pool is manager._client.connection_pool
+        assert manager._pool.connection_kwargs["db"] == 1
+
+        manager._client = None
+        manager._pool = None
+        manager._sentinel = None
+
+    @pytest.mark.asyncio
+    async def test_close_disposes_sentinel_clients(self) -> None:
+        """The sentinel connections are pooled separately from the master's."""
+        manager = RedisManager()
+        manager._client = AsyncMock()
+        manager._pool = AsyncMock()
+        sentinel_a, sentinel_b = AsyncMock(), AsyncMock()
+        manager._sentinel = MagicMock(sentinels=[sentinel_a, sentinel_b])
+
+        await manager.close()
+
+        sentinel_a.aclose.assert_awaited_once()
+        sentinel_b.aclose.assert_awaited_once()
+        assert manager._sentinel is None
+        assert manager._client is None
+        assert manager._pool is None

--- a/libs/aegra-api/tests/unit/test_settings.py
+++ b/libs/aegra-api/tests/unit/test_settings.py
@@ -637,3 +637,116 @@ class TestCronSettingsValidation:
 
         with pytest.raises((ValueError, ValidationError), match="CRON_POLL_INTERVAL_SECONDS"):
             CronSettings(_env_file=None)
+
+
+class TestRedisSentinelURL:
+    """Test the optional redis+sentinel:// scheme on REDIS_URL."""
+
+    @pytest.mark.parametrize("url", ["redis://localhost:6379/0", "rediss://cache.example.com:6380/1"])
+    def test_direct_urls_have_no_sentinel_config(self, monkeypatch: pytest.MonkeyPatch, url: str) -> None:
+        """A non-sentinel scheme leaves the direct path completely untouched."""
+        monkeypatch.setenv("REDIS_URL", url)
+
+        assert RedisSettings(_env_file=None).sentinel is None
+
+    def test_default_url_has_no_sentinel_config(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Sentinel is opt-in: the default REDIS_URL does not enable it."""
+        monkeypatch.delenv("REDIS_URL", raising=False)
+
+        assert RedisSettings(_env_file=None).sentinel is None
+
+    def test_parses_hosts_and_master_name(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Comma-separated endpoints and the master name come off the URL."""
+        monkeypatch.setenv("REDIS_URL", "redis+sentinel://a.example:26379,b.example:26380/mymaster")
+
+        sentinel = RedisSettings(_env_file=None).sentinel
+
+        assert sentinel is not None
+        assert sentinel.hosts == (("a.example", 26379), ("b.example", 26380))
+        assert sentinel.master_name == "mymaster"
+        assert sentinel.db == 0
+
+    def test_host_without_port_defaults_to_26379(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A bare host takes the standard sentinel port."""
+        monkeypatch.setenv("REDIS_URL", "redis+sentinel://a.example,b.example:26380/mymaster")
+
+        sentinel = RedisSettings(_env_file=None).sentinel
+
+        assert sentinel is not None
+        assert sentinel.hosts == (("a.example", 26379), ("b.example", 26380))
+
+    def test_parses_database_index(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The second path segment is the database index."""
+        monkeypatch.setenv("REDIS_URL", "redis+sentinel://a.example:26379/mymaster/3")
+
+        sentinel = RedisSettings(_env_file=None).sentinel
+
+        assert sentinel is not None
+        assert sentinel.db == 3
+
+    def test_parses_bracketed_ipv6(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """IPv6 literals need brackets to disambiguate the port separator."""
+        monkeypatch.setenv("REDIS_URL", "redis+sentinel://[::1]:26379,[fd00::2]/mymaster")
+
+        sentinel = RedisSettings(_env_file=None).sentinel
+
+        assert sentinel is not None
+        assert sentinel.hosts == (("::1", 26379), ("fd00::2", 26379))
+
+    def test_userinfo_is_the_data_node_credential(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Userinfo means what it means in a plain redis:// URL, and is decoded."""
+        password = quote_plus("p@ss:word")
+        monkeypatch.setenv("REDIS_URL", f"redis+sentinel://someuser:{password}@a.example:26379/mymaster")
+
+        sentinel = RedisSettings(_env_file=None).sentinel
+
+        assert sentinel is not None
+        assert sentinel.username == "someuser"
+        assert sentinel.password == "p@ss:word"
+        assert sentinel.sentinel_username is None
+        assert sentinel.sentinel_password is None
+
+    def test_password_only_userinfo(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The common `:password@` form leaves the username unset."""
+        monkeypatch.setenv("REDIS_URL", "redis+sentinel://:secret@a.example:26379/mymaster")
+
+        sentinel = RedisSettings(_env_file=None).sentinel
+
+        assert sentinel is not None
+        assert sentinel.username is None
+        assert sentinel.password == "secret"
+
+    def test_sentinel_credentials_come_from_query_params(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Sentinels usually have their own AUTH, distinct from the data nodes'."""
+        monkeypatch.setenv(
+            "REDIS_URL",
+            "redis+sentinel://:datapass@a.example:26379/mymaster?sentinel_username=watcher&sentinel_password=spass",
+        )
+
+        sentinel = RedisSettings(_env_file=None).sentinel
+
+        assert sentinel is not None
+        assert sentinel.password == "datapass"
+        assert sentinel.sentinel_username == "watcher"
+        assert sentinel.sentinel_password == "spass"
+
+    @pytest.mark.parametrize(
+        ("url", "expected"),
+        [
+            ("redis+sentinel://a.example:26379", "missing the master name"),
+            ("redis+sentinel://a.example:26379/", "missing the master name"),
+            ("redis+sentinel://a.example:abc/mymaster", "Non-integer port"),
+            ("redis+sentinel://a.example:26379/mymaster/xyz", "Non-integer database index"),
+            ("redis+sentinel://a.example:26379/mymaster/0/extra", "too many path segments"),
+            ("redis+sentinel:///mymaster", "no sentinel endpoints"),
+            ("redis+sentinel://[::1:26379/mymaster", "REDIS_URL is not a valid URL"),
+            ("redis+sentinel://a.example:26379/mymaster?db=2", "Unsupported query parameters"),
+            ("rediss+sentinel://a.example:26379/mymaster", "TLS to Sentinel-managed nodes is not supported"),
+        ],
+    )
+    def test_malformed_urls_fail_at_startup(self, monkeypatch: pytest.MonkeyPatch, url: str, expected: str) -> None:
+        """A typo raises when settings are built, not at the first connection."""
+        monkeypatch.setenv("REDIS_URL", url)
+
+        with pytest.raises(ValidationError, match=expected):
+            RedisSettings(_env_file=None)

--- a/libs/aegra-api/tests/unit/test_settings.py
+++ b/libs/aegra-api/tests/unit/test_settings.py
@@ -741,7 +741,9 @@ class TestRedisSentinelURL:
             ("redis+sentinel:///mymaster", "no sentinel endpoints"),
             ("redis+sentinel://[::1:26379/mymaster", "REDIS_URL is not a valid URL"),
             ("redis+sentinel://a.example:26379/mymaster?db=2", "Unsupported query parameters"),
-            ("rediss+sentinel://a.example:26379/mymaster", "TLS to Sentinel-managed nodes is not supported"),
+            ("rediss+sentinel://a.example:26379/mymaster?ssl_cert_reqs=bogus", "ssl_cert_reqs must be one of"),
+            ("rediss+sentinel://a.example:26379/mymaster?ssl_check_hostname=maybe", "must be a boolean"),
+            ("redis+sentinel://a.example:26379/mymaster?ssl_ca_certs=/ca.pem", "need the rediss\\+sentinel:// scheme"),
         ],
     )
     def test_malformed_urls_fail_at_startup(self, monkeypatch: pytest.MonkeyPatch, url: str, expected: str) -> None:
@@ -749,4 +751,68 @@ class TestRedisSentinelURL:
         monkeypatch.setenv("REDIS_URL", url)
 
         with pytest.raises(ValidationError, match=expected):
+            RedisSettings(_env_file=None)
+
+
+class TestRedisSentinelTLS:
+    """Test the rediss+sentinel:// scheme."""
+
+    def test_plain_sentinel_scheme_has_tls_off(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """redis+sentinel:// stays plaintext, with no ssl options."""
+        monkeypatch.setenv("REDIS_URL", "redis+sentinel://a.example:26379/mymaster")
+
+        sentinel = RedisSettings(_env_file=None).sentinel
+
+        assert sentinel is not None
+        assert sentinel.ssl is False
+        assert sentinel.ssl_options == {}
+
+    def test_tls_scheme_enables_ssl(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """rediss+sentinel:// turns TLS on for both hops."""
+        monkeypatch.setenv("REDIS_URL", "rediss+sentinel://a.example:26379/mymaster/2")
+
+        sentinel = RedisSettings(_env_file=None).sentinel
+
+        assert sentinel is not None
+        assert sentinel.ssl is True
+        assert sentinel.db == 2
+
+    def test_tls_options_are_collected(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The ssl_* parameters use redis-py's own names and reach the config."""
+        monkeypatch.setenv(
+            "REDIS_URL",
+            "rediss+sentinel://a.example:26379/mymaster"
+            "?ssl_ca_certs=/certs/ca.pem&ssl_certfile=/certs/c.pem&ssl_keyfile=/certs/k.pem"
+            "&ssl_cert_reqs=required&ssl_check_hostname=true",
+        )
+
+        sentinel = RedisSettings(_env_file=None).sentinel
+
+        assert sentinel is not None
+        assert sentinel.ssl_options == {
+            "ssl_ca_certs": "/certs/ca.pem",
+            "ssl_cert_reqs": "required",
+            "ssl_certfile": "/certs/c.pem",
+            "ssl_check_hostname": True,
+            "ssl_keyfile": "/certs/k.pem",
+        }
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [("true", True), ("1", True), ("yes", True), ("false", False), ("0", False), ("off", False)],
+    )
+    def test_ssl_check_hostname_boolean_forms(self, monkeypatch: pytest.MonkeyPatch, raw: str, expected: bool) -> None:
+        """Hostname verification is a boolean, spelled the usual several ways."""
+        monkeypatch.setenv("REDIS_URL", f"rediss+sentinel://a.example:26379/mymaster?ssl_check_hostname={raw}")
+
+        sentinel = RedisSettings(_env_file=None).sentinel
+
+        assert sentinel is not None
+        assert sentinel.ssl_options["ssl_check_hostname"] is expected
+
+    def test_tls_options_rejected_on_plaintext_scheme(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Asking for TLS options without the TLS scheme is a misconfiguration."""
+        monkeypatch.setenv("REDIS_URL", "redis+sentinel://a.example:26379/mymaster?ssl_ca_certs=/ca.pem")
+
+        with pytest.raises(ValidationError, match=r"need the rediss\+sentinel:// scheme"):
             RedisSettings(_env_file=None)

--- a/libs/aegra-api/tests/unit/test_settings.py
+++ b/libs/aegra-api/tests/unit/test_settings.py
@@ -761,6 +761,8 @@ class TestRedisSentinelURL:
             ("redis+sentinel://a.example:26379", "missing the master name"),
             ("redis+sentinel://a.example:26379/", "missing the master name"),
             ("redis+sentinel://a.example:abc/mymaster", "Non-integer port"),
+            ("redis+sentinel://a.example:65536/mymaster", "Port out of range"),
+            ("redis+sentinel://a.example:0/mymaster", "Port out of range"),
             ("redis+sentinel://a.example:26379/mymaster/xyz", "Non-integer database index"),
             ("redis+sentinel://a.example:26379/mymaster/0/extra", "too many path segments"),
             ("redis+sentinel:///mymaster", "no sentinel endpoints"),
@@ -801,6 +803,24 @@ class TestRedisSentinelTLS:
         assert sentinel is not None
         assert sentinel.ssl is True
         assert sentinel.db == 2
+
+    def test_hostname_verification_defaults_on(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Pinned, not inherited: redis-py's async default was False before 6.0."""
+        monkeypatch.setenv("REDIS_URL", "rediss+sentinel://a.example:26379/mymaster")
+
+        sentinel = RedisSettings(_env_file=None).sentinel
+
+        assert sentinel is not None
+        assert sentinel.ssl_options["ssl_check_hostname"] is True
+
+    def test_explicit_hostname_verification_wins_over_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The operator can still turn it off deliberately."""
+        monkeypatch.setenv("REDIS_URL", "rediss+sentinel://a.example:26379/mymaster?ssl_check_hostname=false")
+
+        sentinel = RedisSettings(_env_file=None).sentinel
+
+        assert sentinel is not None
+        assert sentinel.ssl_options["ssl_check_hostname"] is False
 
     def test_tls_options_are_collected(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """The ssl_* parameters use redis-py's own names and reach the config."""

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.10.5"
+version = "0.10.6"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-cli/src/aegra_cli/templates/env.example.template
+++ b/libs/aegra-cli/src/aegra_cli/templates/env.example.template
@@ -59,6 +59,9 @@ LOG_VERBOSITY=standard # standard, verbose (verbose outputs request-id)
 # executed by concurrent worker tasks with lease-based crash recovery.
 # When disabled (dev mode), runs execute as in-process asyncio tasks.
 REDIS_BROKER_ENABLED=false
+# For a Sentinel-managed HA Redis, use the redis+sentinel:// scheme instead of an
+# endpoint (rediss+sentinel:// for TLS). See docs/reference/environment-variables.
+# REDIS_URL=redis+sentinel://sentinel-a:26379,sentinel-b:26379/mymaster/0
 REDIS_URL=redis://localhost:6379/0
 # REDIS_CHANNEL_PREFIX=aegra:run:
 # REDIS_MAX_CONNECTIONS=250

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.10.5"
+version = "0.10.6"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -100,7 +100,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.10.5"
+version = "0.10.6"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
Closes #560.

`RedisManager` only ever dialled a single endpoint, so a Sentinel-managed Redis could not be addressed at all. This adds `redis+sentinel://` and `rediss+sentinel://` schemes for `REDIS_URL`.

```bash
REDIS_URL=redis+sentinel://sentinel-a:26379,sentinel-b:26379,sentinel-c:26379/mymaster/0
REDIS_URL=rediss+sentinel://sentinel-a:26379,sentinel-b:26379/mymaster/0?ssl_ca_certs=/certs/ca.pem
```

## Why it matters more here than for a typical cache client

Every Redis operation on the worker path is a **write to the master** — `RPUSH` onto `aegra:jobs`, `BLPOP` off it, `PUBLISH` for SSE, `RPUSH` to the replay buffer, `INCR` on the sequence counter, `SET` for the done key. There is no read traffic to spread across replicas, so a connection that lands on one fails with `READONLY You can't write against a read only replica` on essentially everything. "Point it at any node" isn't an option, which leaves operators either fronting the master with a proxy or pinning to a node that stops being the master the moment it fails over.

## Opt-in, and it stays that way

This was the explicit requirement I set myself, so it's worth being concrete about how it holds:

- **No new settings.** The scheme is the entire API surface. `RedisSettings` gains one property, not five environment variables.
- **`redis://` and `rediss://` take the identical code path they did before** — same `ConnectionPool.from_url` call, same kwargs. The direct path is refactored into `_connect_direct()` but not otherwise altered.
- **Every pre-existing test passes unchanged.** I added a `test_direct_path_is_untouched_by_default` that asserts `Sentinel` is never constructed on the default URL, so a future refactor can't quietly make Sentinel mandatory.

## URL format

```text
redis+sentinel://[username:password@]host[:port][,host[:port]...]/<master_name>[/<db>][?sentinel_username=&sentinel_password=]
rediss+sentinel://...same...[&ssl_ca_certs=&ssl_cert_reqs=&ssl_check_hostname=&...]
```

| Part | Meaning |
|------|---------|
| host list | Comma-separated sentinel endpoints; port defaults to `26379`; IPv6 needs brackets (`[::1]:26379`) |
| `master_name` | The monitored master's name. Required |
| `db` | Database index on the data nodes. Defaults to `0` |
| userinfo | Credentials for the **data nodes** — same meaning as in a plain `redis://` URL |
| `sentinel_username` / `sentinel_password` | Credentials for the **sentinels**, which are usually different |

Splitting the credentials that way is the one design decision I'd most like a second opinion on. Keeping userinfo meaning "the Redis I'm about to talk to" preserves the plain-URL intuition, and sentinel auth is the genuinely extra thing — but the opposite convention exists in the wild, so say the word if you'd rather flip it.

## Failing early rather than at first connect

- A malformed sentinel URL raises during settings validation, not on the first connection: missing master name, non-integer port or db, unknown query parameter, unparseable authority.
- **Unknown query parameters are rejected** rather than ignored. For a brand-new scheme, silently dropping `?db=2` misconfigures the client without a word.
- TLS options are accepted only on `rediss+sentinel://`. Passing `ssl_ca_certs` to the plaintext scheme raises an error naming the scheme you probably meant, rather than silently ignoring it.

## TLS

`rediss+sentinel://` wraps **both** hops — the sentinel discovery traffic and the master connection it yields. Wrapping only the master would leave discovery, and the sentinel AUTH travelling with it, in the clear, which would not be a meaningful "TLS supported". redis-py has both halves already: `ssl=True` makes `Redis` select `SSLConnection` for the sentinels, and `SentinelConnectionPool` select `SentinelManagedSSLConnection` for the master.

Certificate options use redis-py's own `ssl_*` names, so a `rediss+sentinel://` URL is configured exactly like a `rediss://` one: `ssl_cert_reqs`, `ssl_ca_certs`, `ssl_ca_path`, `ssl_certfile`, `ssl_keyfile`, `ssl_password`, `ssl_check_hostname`.

### The part that will catch people

**Sentinels report the master's IP, not its hostname.** With redis-py's defaults (`ssl_cert_reqs=required`, `ssl_check_hostname=True`) verification then compares the certificate against an IP and fails — `certificate verify failed: IP address mismatch`.

I deliberately did **not** paper over this by defaulting `ssl_check_hostname` to false on this path. Silently weakening verification because it is inconvenient is how TLS ends up decorative. The defaults stay redis-py's, and the docs give the three ways out, best first:

1. `sentinel announce-hostnames yes` + `sentinel resolve-hostnames yes` (Redis 6.2+), so sentinels report names the certificate covers.
2. Issue data-node certificates with IP SANs.
3. `ssl_check_hostname=false`, relying on CA verification alone — still proves the peer holds a certificate your CA signed, but not that it is the host you meant.

Happy to be argued out of that if you would rather the sentinel path default differently, but it felt like the operator's call.

## Implementation notes

- The sentinels and the data nodes are separate servers, so they get separate connection kwargs.
- Both paths carry the existing retry, health-check and decode settings. The sentinel connections get **their own `Retry` instance** rather than sharing the master's — a failover is precisely when retries matter, and sharing mutable retry state across two pools is asking for trouble.
- The master pool is tracked on `self._pool` so `close()` tears it down exactly as it does for the direct path, and the sentinel clients' own pools are closed alongside.

## Testing

- 25 settings tests over the URL grammar: hosts, default port, IPv6, db index, credential routing, TLS options and boolean forms, and 10 malformed-URL cases.
- 9 manager tests: direct path untouched, master resolution, credential routing to the right servers, retry/health settings on both pools, sentinel pool disposal on close, and TLS on both hops.
- Several build **genuine redis-py objects rather than mocks** — including calling `make_connection()` on the master pool and asserting it comes back a `SentinelManagedSSLConnection` carrying the right `ca_certs` and `check_hostname`. A mock would assert nothing about which connection class redis-py actually picks, which is the entire question on the TLS path.
- There is also a negative test that `redis+sentinel://` yields `SentinelManagedConnection`, so TLS cannot leak onto the plaintext scheme.
- `1564 passed`, `ruff check`/`format` clean, `bandit` clean, and `ty check libs/*/src/` reports nothing in the changed files.

## What this does not do

**It does not make failover transparent to in-flight work, and I don't want to overclaim here.** `master_for()` re-resolves on new connections, but the worker loops sit blocked in `BLPOP` and the broker holds a pub/sub subscription — both hold established connections that die when the master moves. Whether those reconnect cleanly or wedge is a separate question from addressing, and it deserves an e2e failover test under `tests/e2e/multi_instance/` that I have not written.

#556 looks like the same territory: a dead transport raising `RuntimeError` past the `RedisError`-only guards is exactly what a failover produces. Worth treating them together.

## Unrelated observation

`main.py`'s Redis connection-failure branch logs `redis_url=settings.redis.REDIS_URL` in full, while `redis_manager` deliberately logs only host and port because the URL "may contain credentials". The former will happily log a password on a failed connect. Left alone as out of scope, but you may want it.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Redis Sentinel support for high-availability Redis deployments.
  - `REDIS_URL` supports multiple Sentinel endpoints, master selection, database indexes, separate credentials, and IPv6 addresses.
  - Added TLS support for Sentinel discovery and Redis master connections via `rediss+sentinel://`.
  - Invalid Sentinel URLs and unsupported TLS options are rejected during startup.
  - TLS hostname verification is enabled by default.
  - Added a configurable maximum search limit, defaulting to 1,000.

- **Documentation**
  - Added configuration examples and guidance for Sentinel-managed Redis deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds opt-in Redis Sentinel discovery, including separate Sentinel/data-node credentials, TLS for both connection hops, startup URL validation, and coordinated documentation and release artifacts.
- Supports `redis+sentinel://` and `rediss+sentinel://` URLs with multiple Sentinel endpoints.
- Preserves the existing direct Redis connection path.
- Adds focused settings, connection, TLS, credential-routing, cleanup, and malformed-URL tests.
- Updates environment templates, documentation, package versions, and lock metadata.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/settings.py | Adds validated parsing for Sentinel endpoints, credentials, database selection, and TLS options; the previously reported port-range issue is fixed. |
| libs/aegra-api/src/aegra_api/core/redis_manager.py | Adds Sentinel-managed master discovery while retaining the existing direct connection path and closing both master and Sentinel pools. |
| libs/aegra-api/tests/unit/test_settings.py | Covers Sentinel URL grammar, malformed configurations, port-range rejection, credential parsing, and TLS options. |
| libs/aegra-api/tests/unit/test_core/test_redis_manager.py | Verifies direct-path isolation, Sentinel resolution, credential routing, retry settings, cleanup, and TLS connection classes. |
| libs/aegra-cli/src/aegra_cli/templates/env.example.template | Adds the Sentinel URL example required by the previously reported release-artifact concern. |
| .env.example | Adds a matching Sentinel URL example and remains aligned with the CLI-generated environment template. |
| uv.lock | Aligns workspace package metadata with the updated 0.10.6 package versions. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    URL[REDIS_URL] --> Scheme{Sentinel scheme?}
    Scheme -->|No| Direct[Direct Redis connection pool]
    Scheme -->|Yes| Parse[Validate Sentinel URL]
    Parse --> Sentinels[Connect to Sentinel endpoints]
    Sentinels --> Master[Resolve current Redis master]
    Master --> Pool[Sentinel-managed master pool]
    Direct --> Client[Async Redis client]
    Pool --> Client
```
</details>

<sub>Reviews (3): Last reviewed commit: ["chore: bump aegra-api and aegra-cli to 0..."](https://github.com/aegra/aegra/commit/12d8621c1f7ab7f9483afd0e1c128ce7182e3066) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58757769)</sub>

<!-- /greptile_comment -->