### PR TITLE
fix(api): serialize Alembic upgrades with a session advisory lock

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,8 +6,8 @@ DEBUG=true
 # [MANDATORY] Path to the main agent configuration file
 AEGRA_CONFIG=aegra.json
 
-# Auto-run migrations on startup. Set false for multi-pod K8s; run
-# `aegra db upgrade` out-of-band instead. See docs/guides/deployment.mdx.
+# Auto-run migrations on startup. Set false for multi-pod K8s so replicas
+# don't queue on Aegra's session advisory lock; run `aegra db upgrade` instead.
 # RUN_MIGRATIONS_ON_STARTUP=true
 
 # --- Database ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,7 +228,7 @@ Aegra runs against user-managed Postgres including multi-host HA (PR #299). DB c
 
 - **Two URLs, do not cross drivers.**
   - `settings.db.database_url` → asyncpg query-param form. SQLAlchemy only.
-  - `settings.db.database_url_sync` → raw libpq, comma-host preserved. psycopg only (LangGraph pool, migrations precheck).
+  - `settings.db.database_url_sync` → raw libpq, comma-host preserved. psycopg only (LangGraph pool, migrations precheck, advisory lock).
   - Feeding `database_url_sync` to SQLAlchemy (`create_engine`, `async_engine_from_config`) silently breaks HA — SQLAlchemy's URL parser doesn't grok libpq comma-hosts. For sync DBAPI, use `psycopg.connect(database_url_sync)` directly.
 
 - **Pool ownership.** Long-lived pools belong in `db_manager` only. Short-lived helpers must close deterministically (`with` or `try/finally`). Code running before `db_manager.initialize()` cannot assume pools exist.
@@ -237,6 +237,7 @@ Aegra runs against user-managed Postgres including multi-host HA (PR #299). DB c
   - Schema changes go through alembic, never raw DDL from app code.
   - Linear `down_revision` chain. Idempotent + resumable.
   - Lifespan uses `run_migrations_if_needed()` (lock-free precheck). `run_migrations()` is for `aegra db upgrade` only. Don't regress the precheck.
+  - Online upgrades (`alembic/env.py`) take a session `pg_advisory_lock` via psycopg on `database_url_sync`. Alembic itself does not take an advisory lock — there is one lock, in `env.py`. Do not wrap `command.upgrade` with the same lock — nested acquire deadlocks. Precheck stays lock-free.
   - Multi-pod path: `RUN_MIGRATIONS_ON_STARTUP=false` + `aegra db upgrade` out-of-band. Changing startup behavior needs both `.env.example` files + `docs/guides/deployment.mdx` updated.
 
 - **SQL-layer authorization.** Every tenant-scoped read/write needs `user_id == user.identity` in the WHERE, even with `@auth.on` registered (default-allow when no handler — see GHSA-m98r-6667-4wq7). Routes taking `thread_id`/`assistant_id`/`cron_id` path params verify ownership + 404 at handler entry, not deeper.

--- a/docs/guides/contributing.mdx
+++ b/docs/guides/contributing.mdx
@@ -140,7 +140,7 @@ Visit `http://localhost:2026/docs` to see the API.
 
 ## Database migrations
 
-Aegra uses Alembic for database migrations. Migrations apply automatically on server startup — you only need these commands when creating or debugging migrations.
+Aegra uses Alembic for database migrations. In local and single-pod setups, migrations apply automatically on server startup — you only need these commands when creating or debugging migrations, or when operating a multi-pod deployment.
 
 ```bash
 # Create a new migration
@@ -158,6 +158,8 @@ aegra db history -v
 # Show current version
 aegra db current
 ```
+
+Multi-pod deployments should run `aegra db upgrade` from a single operator/Job before rolling a new version, even when `RUN_MIGRATIONS_ON_STARTUP=false`. Do not let every replica run the upgrade independently. See [Migrations](/guides/deployment#migrations).
 
 ### Making database changes
 

--- a/docs/guides/contributing.mdx
+++ b/docs/guides/contributing.mdx
@@ -146,17 +146,17 @@ Aegra uses Alembic for database migrations. Migrations apply automatically on se
 # Create a new migration
 uv run --package aegra-api alembic revision --autogenerate -m "Add user preferences"
 
-# Apply migrations manually
-uv run --package aegra-api alembic upgrade head
+# Apply pending migrations (operator path; session lock is in alembic/env.py)
+aegra db upgrade
 
 # Rollback last migration
-uv run --package aegra-api alembic downgrade -1
+aegra db downgrade -1
 
 # Show migration history
-uv run --package aegra-api alembic history
+aegra db history -v
 
 # Show current version
-uv run --package aegra-api alembic current
+aegra db current
 ```
 
 ### Making database changes
@@ -169,7 +169,7 @@ uv run --package aegra-api alembic current
 ### Testing migrations
 
 ```bash
-# Test full upgrade/downgrade cycle
+# Test full upgrade/downgrade cycle (single process; online env.py still serializes)
 uv run --package aegra-api alembic downgrade base
 uv run --package aegra-api alembic upgrade head
 ```

--- a/docs/guides/deployment.mdx
+++ b/docs/guides/deployment.mdx
@@ -192,13 +192,13 @@ Two ways to configure the database connection:
 
 ## Migrations
 
-By default, Aegra runs `alembic upgrade head` during FastAPI's lifespan startup. The fast path is lock-free: each pod first reads the current revision and skips the upgrade entirely if the database is already at head.
+By default, Aegra runs `alembic upgrade head` during FastAPI's lifespan startup. The fast path is lock-free: each pod first reads the current revision and skips the upgrade entirely if the database is already at head. When an upgrade does run (`aegra db upgrade`, startup when the database is behind head, or `alembic upgrade`), Aegra holds a PostgreSQL session advisory lock in `alembic/env.py` so concurrent upgrades serialize. Alembic itself does not take this lock.
 
 For single-pod and dev setups (`aegra dev`, `aegra up`, single docker-compose service) this is what you want and you do not need to run migrations manually.
 
 ### Multi-pod (Kubernetes, etc.)
 
-When several replicas boot at the same time and a real upgrade is pending, every pod queues on Alembic's advisory lock. Liveness or readiness probes can time out before pods finish startup, causing restart loops. To avoid this, run migrations out-of-band and disable the startup hook on app pods:
+When several replicas boot at the same time and a real upgrade is pending, every pod queues on Aegra's PostgreSQL session advisory lock (`alembic/env.py`, not an Alembic built-in). Liveness or readiness probes can time out before pods finish startup, causing restart loops. To avoid this, run migrations out-of-band and disable the startup hook on app pods:
 
 ```bash
 # .env (or pod env)
@@ -246,9 +246,9 @@ The generated `docker-compose.yml` uses `/health` to monitor the API container. 
     Migrations haven't been applied. This usually means the server couldn't connect to PostgreSQL during startup. Check the logs for connection errors, fix the connection, and restart.
   </Accordion>
   <Accordion title="Migrations hang on startup">
-    Check if another process holds a lock on the database, if the database is reachable but slow, or check server logs for specific migration errors.
+    A full upgrade waits on Aegra's PostgreSQL session advisory lock in `alembic/env.py` (not an Alembic built-in). Check whether another `aegra db upgrade` or starting replica still holds it, whether the database is reachable but slow, or server logs for a specific migration error.
   </Accordion>
   <Accordion title="Pods restart-loop on rolling deploy (Kubernetes)">
-    All replicas race for Alembic's advisory lock on boot. As fleet size grows, later pods queue past their probe deadline and the kubelet kills them. Set `RUN_MIGRATIONS_ON_STARTUP=false` and run `aegra db upgrade` once per release from a Helm pre-upgrade Job or init container.
+    All replicas race for Aegra's PostgreSQL session advisory lock on boot. As fleet size grows, later pods queue past their probe deadline and the kubelet kills them. Set `RUN_MIGRATIONS_ON_STARTUP=false` and run `aegra db upgrade` once per release from a Helm pre-upgrade Job or init container. The lock is session-level on a dedicated psycopg connection; transaction-mode PgBouncer cannot hold it — use session pooling or a direct Postgres connection for the upgrade Job.
   </Accordion>
 </AccordionGroup>

--- a/docs/reference/cli.mdx
+++ b/docs/reference/cli.mdx
@@ -118,6 +118,21 @@ aegra down --volumes    # Stop and remove data volumes
 
 ---
 
+### `aegra db`
+
+Out-of-band database migrations. Use this for multi-pod deploys when `RUN_MIGRATIONS_ON_STARTUP=false`.
+
+```bash
+aegra db upgrade        # apply pending migrations (session advisory lock in alembic/env.py)
+aegra db current        # show current revision
+aegra db history -v     # show migration history
+aegra db downgrade -1   # roll back one revision
+```
+
+See [Migrations](/guides/deployment#migrations) in the deployment guide.
+
+---
+
 ### `aegra version`
 
 Show version information.

--- a/docs/reference/environment-variables.mdx
+++ b/docs/reference/environment-variables.mdx
@@ -17,6 +17,7 @@ cp .env.example .env
 | `VERSION` | `0.1.0` | Application version |
 | `DEBUG` | `false` | Enable debug mode |
 | `AEGRA_CONFIG` | `aegra.json` | Path to the configuration file |
+| `RUN_MIGRATIONS_ON_STARTUP` | `true` | Run Alembic on FastAPI startup (lock-free skip when already at head). Set `false` for multi-pod so replicas don't block on the session advisory lock; run `aegra db upgrade` out-of-band. |
 
 ## Database
 

--- a/libs/aegra-api/README.md
+++ b/libs/aegra-api/README.md
@@ -55,8 +55,8 @@ export POSTGRES_PASSWORD=aegra_secret
 export POSTGRES_HOST=localhost
 export POSTGRES_DB=aegra
 
-# Run migrations
-alembic upgrade head
+# Run migrations (session lock in alembic/env.py; prefer this helper)
+python -c "from aegra_api.core.migrations import run_migrations; run_migrations()"
 
 # Start server
 uvicorn aegra_api.main:app --port 2026 --reload

--- a/libs/aegra-api/alembic/env.py
+++ b/libs/aegra-api/alembic/env.py
@@ -9,6 +9,7 @@ from sqlalchemy.engine import Connection
 from sqlalchemy.ext.asyncio import async_engine_from_config
 
 # Import your SQLAlchemy models here
+from aegra_api.core.migrations import migration_advisory_lock
 from aegra_api.core.orm import Base
 from aegra_api.settings import settings
 from alembic import context
@@ -78,7 +79,7 @@ def run_migrations_offline() -> None:
 
 
 def do_run_migrations(connection: Connection) -> None:
-    """Run migrations with the given connection."""
+    """Apply revisions; the session lock is held by ``run_migrations_online``."""
     context.configure(connection=connection, target_metadata=target_metadata)
 
     with context.begin_transaction():
@@ -106,8 +107,9 @@ async def run_async_migrations() -> None:
 
 
 def run_migrations_online() -> None:
-    """Run migrations in 'online' mode."""
-    asyncio.run(run_async_migrations())
+    """Run migrations in 'online' mode under a session advisory lock."""
+    with migration_advisory_lock():
+        asyncio.run(run_async_migrations())
 
 
 if context.is_offline_mode():

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.10.4"
+version = "0.10.5"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-api/src/aegra_api/core/migrations.py
+++ b/libs/aegra-api/src/aegra_api/core/migrations.py
@@ -1,14 +1,18 @@
 """Alembic migration helpers.
 
 Resolves the bundled alembic.ini from the installed package. Two entry points:
-- ``run_migrations()``: unconditional upgrade, takes advisory lock. Use for
-  out-of-band runs (``aegra db upgrade``, init container, Helm Job).
+- ``run_migrations()``: unconditional upgrade. Online ``env.py`` holds a
+  session ``pg_advisory_lock`` so concurrent upgrades serialize. Alembic itself
+  does not take this lock. For ``aegra db upgrade``.
 - ``run_migrations_if_needed()``: lock-free precheck, skips upgrade when
   already at head. FastAPI startup uses this to avoid multi-pod lock contention.
 """
 
 import asyncio
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
+from typing import LiteralString
 
 import psycopg
 import structlog
@@ -19,6 +23,13 @@ from aegra_api.settings import settings
 from alembic import command
 
 logger = structlog.get_logger(__name__)
+
+# Session-level pair (not pg_advisory_xact_lock): GIN rebuilds use
+# autocommit_block() / CREATE INDEX CONCURRENTLY, which would drop an xact lock.
+_AEGRA_MIGRATION_LOCK_KEY1: int = 0xAE6A
+_AEGRA_MIGRATION_LOCK_KEY2: int = 1
+_ADVISORY_LOCK_SQL: LiteralString = "SELECT pg_advisory_lock(%s, %s)"
+_ADVISORY_UNLOCK_SQL: LiteralString = "SELECT pg_advisory_unlock(%s, %s)"
 
 
 def find_alembic_ini() -> Path:
@@ -105,8 +116,27 @@ def _is_database_up_to_date(cfg: Config) -> bool:
     return current == head
 
 
+@contextmanager
+def migration_advisory_lock() -> Iterator[None]:
+    """Hold a session ``pg_advisory_lock`` on a dedicated psycopg connection.
+
+    Uses ``database_url_sync`` so SQLAlchemy never parses libpq comma-hosts.
+    """
+    lock_keys = (_AEGRA_MIGRATION_LOCK_KEY1, _AEGRA_MIGRATION_LOCK_KEY2)
+    with psycopg.connect(settings.db.database_url_sync, autocommit=True) as conn:
+        with conn.cursor() as cur:
+            cur.execute(_ADVISORY_LOCK_SQL, lock_keys)
+            cur.fetchone()
+        try:
+            yield
+        finally:
+            with conn.cursor() as cur:
+                cur.execute(_ADVISORY_UNLOCK_SQL, lock_keys)
+                cur.fetchone()
+
+
 def run_migrations() -> None:
-    """Unconditional upgrade to head. Takes advisory lock."""
+    """Unconditional upgrade to head. Online env.py takes the session advisory lock."""
     cfg = get_alembic_config()
     logger.info("running database migrations")
     command.upgrade(cfg, "head")

--- a/libs/aegra-api/src/aegra_api/core/migrations.py
+++ b/libs/aegra-api/src/aegra_api/core/migrations.py
@@ -123,16 +123,32 @@ def migration_advisory_lock() -> Iterator[None]:
     Uses ``database_url_sync`` so SQLAlchemy never parses libpq comma-hosts.
     """
     lock_keys = (_AEGRA_MIGRATION_LOCK_KEY1, _AEGRA_MIGRATION_LOCK_KEY2)
-    with psycopg.connect(settings.db.database_url_sync, autocommit=True) as conn:
+    conn = psycopg.connect(settings.db.database_url_sync, autocommit=True)
+    try:
         with conn.cursor() as cur:
             cur.execute(_ADVISORY_LOCK_SQL, lock_keys)
             cur.fetchone()
+        body_error: BaseException | None = None
         try:
             yield
+        except BaseException as exc:
+            body_error = exc
+            raise
         finally:
-            with conn.cursor() as cur:
-                cur.execute(_ADVISORY_UNLOCK_SQL, lock_keys)
-                cur.fetchone()
+            try:
+                with conn.cursor() as cur:
+                    cur.execute(_ADVISORY_UNLOCK_SQL, lock_keys)
+                    cur.fetchone()
+            except Exception:
+                if body_error is None:
+                    raise
+                logger.warning("failed to release migration advisory lock after upgrade error")
+    finally:
+        # Best-effort: a close error must not replace an upgrade or unlock error.
+        try:
+            conn.close()
+        except Exception:
+            logger.warning("failed to close migration lock connection")
 
 
 def run_migrations() -> None:

--- a/libs/aegra-api/src/aegra_api/settings.py
+++ b/libs/aegra-api/src/aegra_api/settings.py
@@ -97,9 +97,8 @@ class AppSettings(EnvBase):
     ENV_MODE: UpperStr = "LOCAL"
     DEBUG: bool = False
 
-    # Run alembic upgrade head on startup. Default True (dev / single-pod).
-    # Set False for multi-pod K8s to avoid advisory-lock probe timeouts;
-    # run migrations out-of-band via `aegra db upgrade`.
+    # Default True. Set False in multi-pod so replicas skip Aegra's session advisory
+    # lock (alembic/env.py; not an Alembic built-in) and run `aegra db upgrade` out-of-band.
     RUN_MIGRATIONS_ON_STARTUP: bool = True
 
     # Logging

--- a/libs/aegra-api/tests/unit/test_migrations.py
+++ b/libs/aegra-api/tests/unit/test_migrations.py
@@ -1,12 +1,20 @@
 """Tests for aegra_api.core.migrations module."""
 
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from aegra_api.core import migrations as migrations_mod
-from aegra_api.core.migrations import find_alembic_ini, get_alembic_config
+from aegra_api.core.migrations import (
+    _ADVISORY_LOCK_SQL,
+    _ADVISORY_UNLOCK_SQL,
+    _AEGRA_MIGRATION_LOCK_KEY1,
+    _AEGRA_MIGRATION_LOCK_KEY2,
+    find_alembic_ini,
+    get_alembic_config,
+)
 
 
 class TestFindAlembicIni:
@@ -129,6 +137,27 @@ class TestRunMigrations:
             args = mock_command.upgrade.call_args
             assert args[0][1] == "head"  # Second positional arg is "head"
 
+    def test_run_migrations_does_not_take_the_lock_itself(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Lock lives in env.py; wrapping command.upgrade would nested-deadlock."""
+        ini_file = tmp_path / "alembic.ini"
+        ini_file.write_text("[alembic]\nscript_location = alembic\n")
+        (tmp_path / "alembic").mkdir()
+        monkeypatch.setattr(migrations_mod, "find_alembic_ini", lambda: ini_file)
+
+        with (
+            patch("aegra_api.core.migrations.command"),
+            patch("aegra_api.core.migrations.migration_advisory_lock") as mock_lock,
+            patch("aegra_api.core.migrations.psycopg.connect") as mock_connect,
+        ):
+            from aegra_api.core.migrations import run_migrations
+
+            run_migrations()
+
+        mock_lock.assert_not_called()
+        mock_connect.assert_not_called()
+
     @pytest.mark.asyncio
     async def test_run_migrations_async_dispatches_to_lockfree_path(self):
         """run_migrations_async should hand off to the lock-free helper."""
@@ -151,13 +180,17 @@ class TestRunMigrationsIfNeeded:
         (tmp_path / "alembic").mkdir()
         monkeypatch.setattr(migrations_mod, "find_alembic_ini", lambda: ini_file)
 
-    def test_skips_upgrade_when_database_at_head(self, tmp_path, monkeypatch):
-        """When current revision matches head, no upgrade is invoked."""
+    def test_skips_upgrade_when_database_at_head(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When current revision matches head, no upgrade and no advisory lock."""
         self._setup_alembic_ini(tmp_path, monkeypatch)
 
         with (
             patch("aegra_api.core.migrations._is_database_up_to_date", return_value=True) as mock_check,
             patch("aegra_api.core.migrations.command") as mock_command,
+            patch("aegra_api.core.migrations.migration_advisory_lock") as mock_lock,
+            patch("aegra_api.core.migrations.psycopg.connect") as mock_connect,
         ):
             from aegra_api.core.migrations import run_migrations_if_needed
 
@@ -165,14 +198,20 @@ class TestRunMigrationsIfNeeded:
 
             mock_check.assert_called_once()
             mock_command.upgrade.assert_not_called()
+            mock_lock.assert_not_called()
+            mock_connect.assert_not_called()
 
-    def test_runs_upgrade_when_database_behind_head(self, tmp_path, monkeypatch):
-        """When the precheck reports drift, upgrade is invoked."""
+    def test_runs_upgrade_when_database_behind_head(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Precheck drift falls through to upgrade; the helper itself does not lock."""
         self._setup_alembic_ini(tmp_path, monkeypatch)
 
         with (
             patch("aegra_api.core.migrations._is_database_up_to_date", return_value=False),
             patch("aegra_api.core.migrations.command") as mock_command,
+            patch("aegra_api.core.migrations.migration_advisory_lock") as mock_lock,
+            patch("aegra_api.core.migrations.psycopg.connect") as mock_connect,
         ):
             from aegra_api.core.migrations import run_migrations_if_needed
 
@@ -180,8 +219,12 @@ class TestRunMigrationsIfNeeded:
 
             mock_command.upgrade.assert_called_once()
             assert mock_command.upgrade.call_args[0][1] == "head"
+            mock_lock.assert_not_called()
+            mock_connect.assert_not_called()
 
-    def test_falls_back_to_upgrade_when_precheck_fails(self, tmp_path, monkeypatch):
+    def test_falls_back_to_upgrade_when_precheck_fails(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """If the precheck raises (e.g. alembic_version missing on first install)
         the upgrade still runs so a fresh database can bootstrap.
         """
@@ -193,12 +236,16 @@ class TestRunMigrationsIfNeeded:
                 side_effect=RuntimeError("alembic_version table missing"),
             ),
             patch("aegra_api.core.migrations.command") as mock_command,
+            patch("aegra_api.core.migrations.migration_advisory_lock") as mock_lock,
+            patch("aegra_api.core.migrations.psycopg.connect") as mock_connect,
         ):
             from aegra_api.core.migrations import run_migrations_if_needed
 
             run_migrations_if_needed()
 
             mock_command.upgrade.assert_called_once()
+            mock_lock.assert_not_called()
+            mock_connect.assert_not_called()
 
 
 class TestIsDatabaseUpToDate:
@@ -327,3 +374,123 @@ class TestIsDatabaseUpToDate:
         from aegra_api.settings import settings
 
         assert passed_url == settings.db.database_url_sync
+
+    def test_precheck_does_not_take_advisory_lock(self) -> None:
+        """Startup precheck is a revision SELECT, never pg_advisory_lock."""
+        from aegra_api.core.migrations import _is_database_up_to_date
+
+        cfg = MagicMock()
+        connection, connect_cm = self._patch_psycopg("abc123")
+        script = MagicMock()
+        script.get_current_head.return_value = "abc123"
+
+        with (
+            patch("aegra_api.core.migrations.psycopg.connect", return_value=connect_cm),
+            patch("aegra_api.core.migrations.ScriptDirectory.from_config", return_value=script),
+        ):
+            assert _is_database_up_to_date(cfg) is True
+
+        cursor = connection.cursor.return_value.__enter__.return_value
+        sql = cursor.execute.call_args.args[0]
+        assert "alembic_version" in sql
+        assert "pg_advisory" not in sql
+
+
+def _advisory_lock_connect_cm() -> tuple[MagicMock, MagicMock]:
+    """Context-managed psycopg.connect mock for the session advisory lock."""
+    cursor = MagicMock()
+    cursor_cm = MagicMock()
+    cursor_cm.__enter__.return_value = cursor
+    cursor_cm.__exit__.return_value = False
+
+    connection = MagicMock()
+    connection.cursor.return_value = cursor_cm
+
+    connect_cm = MagicMock()
+    connect_cm.__enter__.return_value = connection
+    connect_cm.__exit__.return_value = False
+    return connect_cm, cursor
+
+
+class TestMigrationAdvisoryLock:
+    """Session advisory lock used by alembic/env.py around online upgrades."""
+
+    def test_uses_libpq_url_and_autocommit(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Lock connection is psycopg + database_url_sync, never SQLAlchemy."""
+        libpq_url = "postgresql://u:p@h1:5432,h2:5432/db"
+        monkeypatch.setattr(
+            migrations_mod.settings,
+            "db",
+            SimpleNamespace(database_url_sync=libpq_url),
+        )
+        connect_cm, _cursor = _advisory_lock_connect_cm()
+
+        with (
+            patch("aegra_api.core.migrations.psycopg.connect", return_value=connect_cm) as mock_connect,
+            patch("sqlalchemy.create_engine") as mock_create_engine,
+            patch("sqlalchemy.ext.asyncio.async_engine_from_config") as mock_async_engine,
+            migrations_mod.migration_advisory_lock(),
+        ):
+            pass
+
+        assert mock_connect.call_count == 1
+        assert mock_connect.call_args.args[0] == libpq_url
+        assert "h1:5432,h2:5432" in mock_connect.call_args.args[0]
+        assert mock_connect.call_args.kwargs["autocommit"] is True
+        mock_create_engine.assert_not_called()
+        mock_async_engine.assert_not_called()
+
+    def test_lock_then_body_then_unlock(self) -> None:
+        """pg_advisory_lock is taken before the body and released after."""
+        connect_cm, cursor = _advisory_lock_connect_cm()
+        order: list[str] = []
+
+        def execute_side_effect(sql: str, _params: object = None) -> MagicMock:
+            if sql == _ADVISORY_LOCK_SQL:
+                order.append("lock")
+            elif sql == _ADVISORY_UNLOCK_SQL:
+                order.append("unlock")
+            return cursor
+
+        cursor.execute.side_effect = execute_side_effect
+
+        with (
+            patch("aegra_api.core.migrations.psycopg.connect", return_value=connect_cm),
+            migrations_mod.migration_advisory_lock(),
+        ):
+            order.append("body")
+
+        assert order == ["lock", "body", "unlock"]
+        assert (_AEGRA_MIGRATION_LOCK_KEY1, _AEGRA_MIGRATION_LOCK_KEY2) == (0xAE6A, 1)
+        assert cursor.execute.call_args_list[0].args[1] == (0xAE6A, 1)
+        assert cursor.execute.call_args_list[0].args[0] == "SELECT pg_advisory_lock(%s, %s)"
+        assert "pg_advisory_xact_lock" not in cursor.execute.call_args_list[0].args[0]
+
+    def test_unlocks_when_body_raises(self) -> None:
+        """A failed upgrade still releases the session lock."""
+        connect_cm, cursor = _advisory_lock_connect_cm()
+        sqls: list[str] = []
+
+        def execute_side_effect(sql: str, _params: object = None) -> MagicMock:
+            sqls.append(sql)
+            return cursor
+
+        cursor.execute.side_effect = execute_side_effect
+
+        with (
+            patch("aegra_api.core.migrations.psycopg.connect", return_value=connect_cm),
+            pytest.raises(RuntimeError, match="boom"),
+            migrations_mod.migration_advisory_lock(),
+        ):
+            raise RuntimeError("boom")
+
+        assert sqls == [_ADVISORY_LOCK_SQL, _ADVISORY_UNLOCK_SQL]
+
+    def test_online_env_wraps_upgrade_with_advisory_lock(self) -> None:
+        """Regression: #548 — lock must live in env.py so CLI and startup share it."""
+        env_path = Path(__file__).resolve().parents[2] / "alembic" / "env.py"
+        source = env_path.read_text()
+        assert "from aegra_api.core.migrations import migration_advisory_lock" in source
+        assert "with migration_advisory_lock():" in source
+        assert "pg_advisory_xact_lock" not in source
+        assert "database_url_sync" not in source

--- a/libs/aegra-api/tests/unit/test_migrations.py
+++ b/libs/aegra-api/tests/unit/test_migrations.py
@@ -180,9 +180,7 @@ class TestRunMigrationsIfNeeded:
         (tmp_path / "alembic").mkdir()
         monkeypatch.setattr(migrations_mod, "find_alembic_ini", lambda: ini_file)
 
-    def test_skips_upgrade_when_database_at_head(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_skips_upgrade_when_database_at_head(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """When current revision matches head, no upgrade and no advisory lock."""
         self._setup_alembic_ini(tmp_path, monkeypatch)
 
@@ -201,9 +199,7 @@ class TestRunMigrationsIfNeeded:
             mock_lock.assert_not_called()
             mock_connect.assert_not_called()
 
-    def test_runs_upgrade_when_database_behind_head(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_runs_upgrade_when_database_behind_head(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Precheck drift falls through to upgrade; the helper itself does not lock."""
         self._setup_alembic_ini(tmp_path, monkeypatch)
 
@@ -222,9 +218,7 @@ class TestRunMigrationsIfNeeded:
             mock_lock.assert_not_called()
             mock_connect.assert_not_called()
 
-    def test_falls_back_to_upgrade_when_precheck_fails(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_falls_back_to_upgrade_when_precheck_fails(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """If the precheck raises (e.g. alembic_version missing on first install)
         the upgrade still runs so a fresh database can bootstrap.
         """
@@ -396,8 +390,8 @@ class TestIsDatabaseUpToDate:
         assert "pg_advisory" not in sql
 
 
-def _advisory_lock_connect_cm() -> tuple[MagicMock, MagicMock]:
-    """Context-managed psycopg.connect mock for the session advisory lock."""
+def _advisory_lock_connection() -> tuple[MagicMock, MagicMock]:
+    """psycopg.connect mock for the dedicated session advisory-lock connection."""
     cursor = MagicMock()
     cursor_cm = MagicMock()
     cursor_cm.__enter__.return_value = cursor
@@ -405,11 +399,35 @@ def _advisory_lock_connect_cm() -> tuple[MagicMock, MagicMock]:
 
     connection = MagicMock()
     connection.cursor.return_value = cursor_cm
+    return connection, cursor
 
-    connect_cm = MagicMock()
-    connect_cm.__enter__.return_value = connection
-    connect_cm.__exit__.return_value = False
-    return connect_cm, cursor
+
+def _lock_connection(
+    *,
+    unlock_error: Exception | None = None,
+    close_error: Exception | None = None,
+) -> tuple[MagicMock, list[str]]:
+    """Connection mock that records lock → unlock → close order."""
+    order: list[str] = []
+    connection, cursor = _advisory_lock_connection()
+
+    def execute_side_effect(sql: str, _params: object = None) -> MagicMock:
+        if sql == _ADVISORY_LOCK_SQL:
+            order.append("lock")
+        elif sql == _ADVISORY_UNLOCK_SQL:
+            order.append("unlock")
+            if unlock_error is not None:
+                raise unlock_error
+        return cursor
+
+    def close_side_effect() -> None:
+        order.append("close")
+        if close_error is not None:
+            raise close_error
+
+    cursor.execute.side_effect = execute_side_effect
+    connection.close.side_effect = close_side_effect
+    return connection, order
 
 
 class TestMigrationAdvisoryLock:
@@ -423,10 +441,10 @@ class TestMigrationAdvisoryLock:
             "db",
             SimpleNamespace(database_url_sync=libpq_url),
         )
-        connect_cm, _cursor = _advisory_lock_connect_cm()
+        connection, _cursor = _advisory_lock_connection()
 
         with (
-            patch("aegra_api.core.migrations.psycopg.connect", return_value=connect_cm) as mock_connect,
+            patch("aegra_api.core.migrations.psycopg.connect", return_value=connection) as mock_connect,
             patch("sqlalchemy.create_engine") as mock_create_engine,
             patch("sqlalchemy.ext.asyncio.async_engine_from_config") as mock_async_engine,
             migrations_mod.migration_advisory_lock(),
@@ -439,52 +457,109 @@ class TestMigrationAdvisoryLock:
         assert mock_connect.call_args.kwargs["autocommit"] is True
         mock_create_engine.assert_not_called()
         mock_async_engine.assert_not_called()
+        connection.close.assert_called_once()
 
     def test_lock_then_body_then_unlock(self) -> None:
         """pg_advisory_lock is taken before the body and released after."""
-        connect_cm, cursor = _advisory_lock_connect_cm()
-        order: list[str] = []
-
-        def execute_side_effect(sql: str, _params: object = None) -> MagicMock:
-            if sql == _ADVISORY_LOCK_SQL:
-                order.append("lock")
-            elif sql == _ADVISORY_UNLOCK_SQL:
-                order.append("unlock")
-            return cursor
-
-        cursor.execute.side_effect = execute_side_effect
+        connection, order = _lock_connection()
 
         with (
-            patch("aegra_api.core.migrations.psycopg.connect", return_value=connect_cm),
+            patch("aegra_api.core.migrations.psycopg.connect", return_value=connection),
             migrations_mod.migration_advisory_lock(),
         ):
             order.append("body")
 
-        assert order == ["lock", "body", "unlock"]
+        assert order == ["lock", "body", "unlock", "close"]
         assert (_AEGRA_MIGRATION_LOCK_KEY1, _AEGRA_MIGRATION_LOCK_KEY2) == (0xAE6A, 1)
+        cursor = connection.cursor.return_value.__enter__.return_value
         assert cursor.execute.call_args_list[0].args[1] == (0xAE6A, 1)
         assert cursor.execute.call_args_list[0].args[0] == "SELECT pg_advisory_lock(%s, %s)"
         assert "pg_advisory_xact_lock" not in cursor.execute.call_args_list[0].args[0]
+        connection.close.assert_called_once()
 
     def test_unlocks_when_body_raises(self) -> None:
         """A failed upgrade still releases the session lock."""
-        connect_cm, cursor = _advisory_lock_connect_cm()
-        sqls: list[str] = []
-
-        def execute_side_effect(sql: str, _params: object = None) -> MagicMock:
-            sqls.append(sql)
-            return cursor
-
-        cursor.execute.side_effect = execute_side_effect
+        connection, order = _lock_connection()
 
         with (
-            patch("aegra_api.core.migrations.psycopg.connect", return_value=connect_cm),
+            patch("aegra_api.core.migrations.psycopg.connect", return_value=connection),
             pytest.raises(RuntimeError, match="boom"),
             migrations_mod.migration_advisory_lock(),
         ):
+            order.append("body")
             raise RuntimeError("boom")
 
-        assert sqls == [_ADVISORY_LOCK_SQL, _ADVISORY_UNLOCK_SQL]
+        assert order == ["lock", "body", "unlock", "close"]
+        connection.close.assert_called_once()
+
+    def test_upgrade_and_unlock_failure_keeps_upgrade_error(self) -> None:
+        """Unlock failure after a failed upgrade must not replace the upgrade error."""
+        unlock_error = RuntimeError("postgresql://user:supersecret@host/db unlock failed")
+        connection, order = _lock_connection(unlock_error=unlock_error)
+
+        with (
+            patch("aegra_api.core.migrations.psycopg.connect", return_value=connection),
+            patch.object(migrations_mod.logger, "warning") as mock_warning,
+            pytest.raises(RuntimeError, match="upgrade boom"),
+            migrations_mod.migration_advisory_lock(),
+        ):
+            order.append("body")
+            raise RuntimeError("upgrade boom")
+
+        assert order == ["lock", "body", "unlock", "close"]
+        connection.close.assert_called_once()
+        mock_warning.assert_called()
+        logged = str(mock_warning.call_args)
+        assert "supersecret" not in logged
+        assert "postgresql://" not in logged
+
+    def test_unlock_failure_after_successful_upgrade_is_raised(self) -> None:
+        """A successful upgrade must not report success if unlock fails."""
+        connection, order = _lock_connection(unlock_error=RuntimeError("unlock boom"))
+
+        with (
+            patch("aegra_api.core.migrations.psycopg.connect", return_value=connection),
+            pytest.raises(RuntimeError, match="unlock boom"),
+            migrations_mod.migration_advisory_lock(),
+        ):
+            order.append("body")
+
+        assert order == ["lock", "body", "unlock", "close"]
+        connection.close.assert_called_once()
+
+    def test_close_failure_after_upgrade_failure_keeps_upgrade_error(self) -> None:
+        """Connection close is best-effort and must not hide the upgrade error."""
+        connection, order = _lock_connection(close_error=RuntimeError("close boom"))
+
+        with (
+            patch("aegra_api.core.migrations.psycopg.connect", return_value=connection),
+            patch.object(migrations_mod.logger, "warning") as mock_warning,
+            pytest.raises(RuntimeError, match="upgrade boom"),
+            migrations_mod.migration_advisory_lock(),
+        ):
+            order.append("body")
+            raise RuntimeError("upgrade boom")
+
+        assert order == ["lock", "body", "unlock", "close"]
+        connection.close.assert_called_once()
+        mock_warning.assert_called()
+
+    def test_close_failure_does_not_replace_unlock_failure(self) -> None:
+        """Close errors must not hide an unlock failure on the success path."""
+        connection, order = _lock_connection(
+            unlock_error=RuntimeError("unlock boom"),
+            close_error=RuntimeError("close boom"),
+        )
+
+        with (
+            patch("aegra_api.core.migrations.psycopg.connect", return_value=connection),
+            pytest.raises(RuntimeError, match="unlock boom"),
+            migrations_mod.migration_advisory_lock(),
+        ):
+            order.append("body")
+
+        assert order == ["lock", "body", "unlock", "close"]
+        connection.close.assert_called_once()
 
     def test_online_env_wraps_upgrade_with_advisory_lock(self) -> None:
         """Regression: #548 — lock must live in env.py so CLI and startup share it."""

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.10.4"
+version = "0.10.5"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-cli/src/aegra_cli/commands/db.py
+++ b/libs/aegra-cli/src/aegra_cli/commands/db.py
@@ -109,17 +109,11 @@ def upgrade() -> None:
         )
     )
 
-    from aegra_api.core.migrations import get_alembic_config
-    from alembic import command
-
-    cfg = get_alembic_config()
-
-    def run() -> None:
-        command.upgrade(cfg, "head")
+    from aegra_api.core.migrations import run_migrations
 
     _run_alembic(
         "upgrade",
-        run,
+        run_migrations,
         success_msg="Database upgraded successfully!",
         error_prefix="Alembic upgrade",
     )

--- a/libs/aegra-cli/src/aegra_cli/commands/db.py
+++ b/libs/aegra-cli/src/aegra_cli/commands/db.py
@@ -109,6 +109,7 @@ def upgrade() -> None:
         )
     )
 
+    # After load_env_file; a top-level import would freeze settings. See module docstring.
     from aegra_api.core.migrations import run_migrations
 
     _run_alembic(

--- a/libs/aegra-cli/src/aegra_cli/templates/env.example.template
+++ b/libs/aegra-cli/src/aegra_cli/templates/env.example.template
@@ -6,8 +6,8 @@ DEBUG=true
 # [MANDATORY] Path to the main agent configuration file
 AEGRA_CONFIG=aegra.json
 
-# Auto-run migrations on startup. Set false for multi-pod K8s; run
-# `aegra db upgrade` out-of-band instead. See docs/guides/deployment.mdx.
+# Auto-run migrations on startup. Set false for multi-pod K8s so replicas
+# don't queue on Aegra's session advisory lock; run `aegra db upgrade` instead.
 # RUN_MIGRATIONS_ON_STARTUP=true
 
 # --- Database ---

--- a/libs/aegra-cli/tests/test_db.py
+++ b/libs/aegra-cli/tests/test_db.py
@@ -1,0 +1,22 @@
+"""Tests for ``aegra db`` commands."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from aegra_cli.cli import cli
+
+
+def test_upgrade_calls_run_migrations(cli_runner: CliRunner, tmp_path: Path) -> None:
+    """Operator upgrade must use the helper that goes through locked env.py."""
+    with (
+        cli_runner.isolated_filesystem(temp_dir=tmp_path),
+        patch("aegra_api.core.migrations.run_migrations") as mock_run,
+    ):
+        result = cli_runner.invoke(cli, ["db", "upgrade"])
+
+    assert result.exit_code == 0
+    mock_run.assert_called_once_with()

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.10.4"
+version = "0.10.5"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -100,7 +100,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.10.4"
+version = "0.10.5"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
## Description

Fixes #548. Concurrent Alembic upgrades (`aegra db upgrade`, FastAPI startup when the DB is behind head, or a raw `alembic upgrade`) currently race and one process dies with `UniqueViolation` on `alembic_version`. The docs claimed an advisory lock; the code never took one (`rg pg_advisory` was empty on 0.10.4).

This PR holds a **session** `pg_advisory_lock` (not `pg_advisory_xact_lock`) on a dedicated psycopg connection for the duration of an online upgrade. GIN rebuilds use `autocommit_block()` / `CREATE INDEX CONCURRENTLY`, which would drop a transaction-scoped lock.

Startup precheck stays **lock-free**: `run_migrations_if_needed()` only SELECTs `alembic_version` and skips when already at head. The lock lives in online `alembic/env.py`, so the operator path and the startup fall-through share one lock without wrapping `command.upgrade` (nested acquire would deadlock).

The lock connection uses **psycopg + `settings.db.database_url_sync`**. That URL is raw libpq with comma-host preserved (PR #299). It is never fed to `create_engine` / SQLAlchemy's URL parser.

`aegra-api` and `aegra-cli` are at **0.10.5**. That patch collides with #549, #552, and the upcoming #471 search-limit PR (and any other open PRs claiming the same number); whoever merges first takes `0.10.5`.

## Type of Change
- [x] `fix`: Bug fix
- [ ] `feat`: New feature
- [x] `docs`: Documentation changes
- [ ] `style`: Code style/formatting
- [ ] `refactor`: Code refactoring
- [ ] `perf`: Performance improvement
- [x] `test`: Tests added/updated
- [ ] `chore`: Maintenance (dependencies, build, etc.)
- [ ] `ci`: CI/CD changes

## Related Issues
Fixes #548

## Changes Made
- Add `migration_advisory_lock()` in `migrations.py`: session `pg_advisory_lock` / `pg_advisory_unlock` on a dedicated autocommit psycopg connection.
- Take that lock in online `alembic/env.py` around `asyncio.run(run_async_migrations())`. Unlock in `finally`.
- Keep `run_migrations_if_needed()` lock-free; `run_migrations()` (used by `aegra db upgrade`) does not take the lock itself — env.py does.
- Route the CLI upgrade through `run_migrations()` so it hits the locked env.py path.
- Use `database_url_sync` only with `psycopg.connect`; tests assert the comma-host URL is passed through unchanged.
- Document the lock (session vs xact, CONCURRENTLY, multi-pod / PgBouncer) in CLAUDE.md, deployment, contributing, CLI, env examples, and settings comments.

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing performed

- `uv run ruff check` on the touched files: pass
- `uv run --package aegra-api pytest libs/aegra-api/tests/unit/test_migrations.py -v`: **24 passed**
- `uv run --package aegra-cli pytest libs/aegra-cli/tests/test_db.py -v`: **1 passed**

Coverage includes: precheck does not take the lock; lock then body then unlock; unlock on raise; HA comma-host URL goes to `psycopg.connect` as-is; env.py wraps the online upgrade with the session lock (and does not use `pg_advisory_xact_lock`).

## Checklist
- [x] Code follows project style (Ruff formatting)
- [x] All linting checks pass (`make lint`)
- [ ] Type checking passes (`make type-check`)
- [x] All tests pass (`make test`)
- [x] Documentation updated (if needed)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] PR title follows Conventional Commits format

## Additional Notes

Not in this PR: wrapping `command.upgrade` with the same lock (nested deadlock), `pg_advisory_xact_lock`, or making the startup precheck block on the lock when already at head.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the `aegra db` command reference for upgrading, downgrading, viewing history, and checking the current database revision.
  - Database upgrades now use a PostgreSQL session lock to prevent concurrent migration runs.

- **Documentation**
  - Clarified migration procedures for multi-pod deployments, including disabling startup migrations and running `aegra db upgrade` separately.
  - Documented lock behavior, deployment considerations, and connection-pooling requirements.

- **Bug Fixes**
  - Prevented multiple application replicas from running database migrations concurrently.
  - Improved migration error handling so cleanup failures do not hide the original upgrade error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR serializes online Alembic upgrades using a PostgreSQL session advisory lock while retaining the lock-free startup revision precheck.
- Adds deterministic lock acquisition and release around online migrations.
- Routes CLI upgrades through the shared migration helper.
- Documents multi-pod deployment and PgBouncer considerations.
- Adds migration-lock and CLI regression tests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/core/migrations.py | Adds the dedicated psycopg session-lock context manager and preserves migration errors across cleanup failures. |
| libs/aegra-api/alembic/env.py | Wraps online Alembic execution with the shared session advisory lock. |
| libs/aegra-cli/src/aegra_cli/commands/db.py | Routes the upgrade command through the API migration helper. |
| libs/aegra-api/tests/unit/test_migrations.py | Covers lock ordering, HA URL passthrough, cleanup exception precedence, and lock-free prechecks. |
| libs/aegra-cli/tests/test_db.py | Verifies that the CLI upgrade command invokes the shared migration helper. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Caller as CLI or API startup
  participant Alembic as Alembic env.py
  participant Lock as Dedicated psycopg connection
  participant DB as PostgreSQL
  Caller->>Alembic: upgrade head
  Alembic->>Lock: connect(database_url_sync)
  Lock->>DB: pg_advisory_lock(key)
  DB-->>Lock: lock acquired
  Alembic->>DB: apply migrations
  Alembic->>Lock: pg_advisory_unlock(key)
  Lock-->>Alembic: close connection
  Alembic-->>Caller: success or migration error
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(api): preserve migration failures du..."](https://github.com/aegra/aegra/commit/11cdfea50aa0a56f453bdd709ccb554b52644a20) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59469589)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://github.com/aegra/aegra/blob/main/CLAUDE.md))
- Knowledge Base — [Persistence and distributed coordination](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/persistence-and-coordination.md)
- Knowledge Base — [CLI environment and database operations](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/cli-operations.md)
</details>


<!-- /greptile_comment -->