### PR TITLE
fix(api): enforce a shared max search page size so threads/store cannot unbounded-scan

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,9 @@ AEGRA_CONFIG=aegra.json
 # `aegra db upgrade` out-of-band instead. See docs/guides/deployment.mdx.
 # RUN_MIGRATIONS_ON_STARTUP=true
 
+# Max page size for POST /threads/search and POST /store/items/search (default 1000).
+# MAX_SEARCH_LIMIT=1000
+
 # --- Database ---
 # Option 1: Single connection string (standard for containers/cloud)
 # If your password contains special characters (@, /, #, %, +, etc.),

--- a/docs/guides/store.mdx
+++ b/docs/guides/store.mdx
@@ -65,7 +65,7 @@ for item in results["items"]:
     print(f"{item['namespace']}/{item['key']}: {item['value']}")
 ```
 
-`limit` uses the same `MAX_SEARCH_LIMIT` cap as thread search (default 1000).
+`limit` uses the same `MAX_SEARCH_LIMIT` cap as thread search (default 1000). Omitted or null `limit` uses `min(20, MAX_SEARCH_LIMIT)`.
 
 ## Namespaces
 

--- a/docs/guides/store.mdx
+++ b/docs/guides/store.mdx
@@ -65,6 +65,8 @@ for item in results["items"]:
     print(f"{item['namespace']}/{item['key']}: {item['value']}")
 ```
 
+`limit` uses the same `MAX_SEARCH_LIMIT` cap as thread search (default 1000).
+
 ## Namespaces
 
 Namespaces organize your data hierarchically. They work like directory paths:

--- a/docs/guides/threads-and-state.mdx
+++ b/docs/guides/threads-and-state.mdx
@@ -136,7 +136,7 @@ threads = await client.threads.search(
 )
 ```
 
-`limit` accepts 1 through `MAX_SEARCH_LIMIT` (default 1000, matching LangGraph Platform). Values above the cap return 422.
+`limit` accepts 1 through `MAX_SEARCH_LIMIT` (default 1000, matching LangGraph Platform). Omitted or null `limit` uses `min(20, MAX_SEARCH_LIMIT)`. Values above the cap return 422.
 
 ## Listing threads
 

--- a/docs/guides/threads-and-state.mdx
+++ b/docs/guides/threads-and-state.mdx
@@ -136,6 +136,8 @@ threads = await client.threads.search(
 )
 ```
 
+`limit` accepts 1 through `MAX_SEARCH_LIMIT` (default 1000, matching LangGraph Platform). Values above the cap return 422.
+
 ## Listing threads
 
 ```python

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Aegra",
     "description": "Production-ready Agent Protocol server",
-    "version": "0.10.4"
+    "version": "0.10.5"
   },
   "paths": {
     "/info": {
@@ -5135,7 +5135,7 @@
             "anyOf": [
               {
                 "type": "integer",
-                "maximum": 100.0,
+                "maximum": 1000.0,
                 "minimum": 1.0
               },
               {
@@ -5572,7 +5572,7 @@
             "anyOf": [
               {
                 "type": "integer",
-                "maximum": 100.0,
+                "maximum": 1000.0,
                 "minimum": 1.0
               },
               {

--- a/docs/reference/environment-variables.mdx
+++ b/docs/reference/environment-variables.mdx
@@ -14,10 +14,10 @@ cp .env.example .env
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `PROJECT_NAME` | `Aegra` | Application name |
-| `VERSION` | `0.1.0` | Application version |
+| `VERSION` | `0.10.5` | Application version |
 | `DEBUG` | `false` | Enable debug mode |
 | `AEGRA_CONFIG` | `aegra.json` | Path to the configuration file |
-| `MAX_SEARCH_LIMIT` | `1000` | Max `limit` for `POST /threads/search` and `POST /store/items/search`. Default matches LangGraph Platform threads.search (`1..1000`). |
+| `MAX_SEARCH_LIMIT` | `1000` | Max `limit` for `POST /threads/search` and `POST /store/items/search`. Omitted or null `limit` uses `min(20, MAX_SEARCH_LIMIT)`. Default cap matches LangGraph Platform threads.search (`1..1000`). |
 
 ## Database
 

--- a/docs/reference/environment-variables.mdx
+++ b/docs/reference/environment-variables.mdx
@@ -17,6 +17,7 @@ cp .env.example .env
 | `VERSION` | `0.1.0` | Application version |
 | `DEBUG` | `false` | Enable debug mode |
 | `AEGRA_CONFIG` | `aegra.json` | Path to the configuration file |
+| `MAX_SEARCH_LIMIT` | `1000` | Max `limit` for `POST /threads/search` and `POST /store/items/search`. Default matches LangGraph Platform threads.search (`1..1000`). |
 
 ## Database
 

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.10.4"
+version = "0.10.5"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-api/src/aegra_api/api/store.py
+++ b/libs/aegra-api/src/aegra_api/api/store.py
@@ -23,6 +23,7 @@ from aegra_api.models import (
     User,
 )
 from aegra_api.models.errors import BAD_REQUEST, NOT_FOUND
+from aegra_api.models.search_limit import effective_search_limit
 
 logger = structlog.get_logger(__name__)
 
@@ -172,6 +173,8 @@ async def search_store_items(
     scoped_prefix = apply_namespace_scoping(request.namespace_prefix, user)
 
     store = db_manager.get_store()
+    limit = request.limit if request.limit is not None else effective_search_limit()
+    offset = request.offset or 0
 
     # Search with LangGraph store
     # asearch takes namespace_prefix as a positional-only argument
@@ -179,8 +182,8 @@ async def search_store_items(
         tuple(scoped_prefix),
         query=request.query,
         filter=request.filter,
-        limit=request.limit or 20,
-        offset=request.offset or 0,
+        limit=limit,
+        offset=offset,
     )
 
     items = [StoreItem(key=r.key, value=r.value, namespace=list(r.namespace)) for r in results]
@@ -188,8 +191,8 @@ async def search_store_items(
     return StoreSearchResponse(
         items=items,
         total=len(items),  # LangGraph store doesn't provide total count
-        limit=request.limit or 20,
-        offset=request.offset or 0,
+        limit=limit,
+        offset=offset,
     )
 
 

--- a/libs/aegra-api/src/aegra_api/api/threads.py
+++ b/libs/aegra-api/src/aegra_api/api/threads.py
@@ -40,6 +40,7 @@ from aegra_api.models import (
     User,
 )
 from aegra_api.models.errors import CONFLICT, NOT_FOUND, AgentProtocolError
+from aegra_api.models.search_limit import effective_search_limit
 from aegra_api.services.streaming_service import streaming_service
 from aegra_api.services.thread_state_service import ThreadStateService
 from aegra_api.services.thread_ttl import get_thread_ttl_config, prune_expired_threads_for_user
@@ -980,7 +981,7 @@ async def search_threads(
         stmt = stmt.where(ThreadORM.metadata_json.op("@>")(request.metadata))
 
     offset = request.offset or 0
-    limit = request.limit or 20
+    limit = request.limit if request.limit is not None else effective_search_limit()
     column, asc = _resolve_sort(request)
     direction = column.asc() if asc else column.desc()
     # Secondary sort on thread_id keeps offset pagination stable when the

--- a/libs/aegra-api/src/aegra_api/models/search_limit.py
+++ b/libs/aegra-api/src/aegra_api/models/search_limit.py
@@ -1,0 +1,33 @@
+"""Shared search pagination cap for protocol search request models.
+
+Read at validation time so MAX_SEARCH_LIMIT can change without reimporting models.
+"""
+
+from typing import Any
+
+from pydantic_core import PydanticKnownError
+
+from aegra_api.settings import settings
+
+DEFAULT_SEARCH_LIMIT: int = 20
+
+
+def enforce_search_limit(value: int | None) -> int | None:
+    """Reject page sizes above the configured server cap."""
+    if value is None:
+        return value
+    cap = settings.app.MAX_SEARCH_LIMIT
+    if value > cap:
+        # Same type/msg/ctx as Field(le=cap) so 422 payloads stay Pydantic-shaped.
+        raise PydanticKnownError("less_than_equal", {"le": cap})
+    return value
+
+
+def search_limit_json_schema_extra(schema: dict[str, Any]) -> None:
+    """Advertise the live cap on the integer branch of the OpenAPI schema."""
+    cap = settings.app.MAX_SEARCH_LIMIT
+    for option in schema.get("anyOf", []):
+        if isinstance(option, dict) and option.get("type") == "integer":
+            option["maximum"] = cap
+            return
+    schema["maximum"] = cap

--- a/libs/aegra-api/src/aegra_api/models/search_limit.py
+++ b/libs/aegra-api/src/aegra_api/models/search_limit.py
@@ -12,10 +12,14 @@ from aegra_api.settings import settings
 DEFAULT_SEARCH_LIMIT: int = 20
 
 
-def enforce_search_limit(value: int | None) -> int | None:
-    """Reject page sizes above the configured server cap."""
+def effective_search_limit() -> int:
+    return min(DEFAULT_SEARCH_LIMIT, settings.app.MAX_SEARCH_LIMIT)
+
+
+def resolve_search_limit(value: int | None) -> int:
+    # Omitted fields and JSON null both arrive as None.
     if value is None:
-        return value
+        return effective_search_limit()
     cap = settings.app.MAX_SEARCH_LIMIT
     if value > cap:
         # Same type/msg/ctx as Field(le=cap) so 422 payloads stay Pydantic-shaped.
@@ -24,8 +28,8 @@ def enforce_search_limit(value: int | None) -> int | None:
 
 
 def search_limit_json_schema_extra(schema: dict[str, Any]) -> None:
-    """Advertise the live cap on the integer branch of the OpenAPI schema."""
     cap = settings.app.MAX_SEARCH_LIMIT
+    schema["default"] = effective_search_limit()
     for option in schema.get("anyOf", []):
         if isinstance(option, dict) and option.get("type") == "integer":
             option["maximum"] = cap

--- a/libs/aegra-api/src/aegra_api/models/store.py
+++ b/libs/aegra-api/src/aegra_api/models/store.py
@@ -5,8 +5,7 @@ from typing import Any
 from pydantic import BaseModel, Field, field_validator
 
 from aegra_api.models.search_limit import (
-    DEFAULT_SEARCH_LIMIT,
-    enforce_search_limit,
+    resolve_search_limit,
     search_limit_json_schema_extra,
 )
 
@@ -45,9 +44,11 @@ class StoreSearchRequest(BaseModel):
     namespace_prefix: list[str] = Field(..., description="Namespace prefix to search")
     filter: dict[str, Any] | None = Field(None, description="Optional dictionary of key-value pairs to filter results.")
     query: str | None = Field(None, description="Search query")
+    # None default + validate_default so omitted and JSON null share one resolver.
     limit: int | None = Field(
-        DEFAULT_SEARCH_LIMIT,
+        default=None,
         ge=1,
+        validate_default=True,
         description="Maximum results",
         json_schema_extra=search_limit_json_schema_extra,
     )
@@ -55,8 +56,8 @@ class StoreSearchRequest(BaseModel):
 
     @field_validator("limit")
     @classmethod
-    def validate_limit(cls, v: int | None) -> int | None:
-        return enforce_search_limit(v)
+    def validate_limit(cls: type["StoreSearchRequest"], v: int | None) -> int:
+        return resolve_search_limit(v)
 
 
 class StoreItem(BaseModel):

--- a/libs/aegra-api/src/aegra_api/models/store.py
+++ b/libs/aegra-api/src/aegra_api/models/store.py
@@ -4,6 +4,12 @@ from typing import Any
 
 from pydantic import BaseModel, Field, field_validator
 
+from aegra_api.models.search_limit import (
+    DEFAULT_SEARCH_LIMIT,
+    enforce_search_limit,
+    search_limit_json_schema_extra,
+)
+
 
 class StorePutRequest(BaseModel):
     """Request model for storing items"""
@@ -39,8 +45,18 @@ class StoreSearchRequest(BaseModel):
     namespace_prefix: list[str] = Field(..., description="Namespace prefix to search")
     filter: dict[str, Any] | None = Field(None, description="Optional dictionary of key-value pairs to filter results.")
     query: str | None = Field(None, description="Search query")
-    limit: int | None = Field(20, le=100, ge=1, description="Maximum results")
+    limit: int | None = Field(
+        DEFAULT_SEARCH_LIMIT,
+        ge=1,
+        description="Maximum results",
+        json_schema_extra=search_limit_json_schema_extra,
+    )
     offset: int | None = Field(0, ge=0, description="Results offset")
+
+    @field_validator("limit")
+    @classmethod
+    def validate_limit(cls, v: int | None) -> int | None:
+        return enforce_search_limit(v)
 
 
 class StoreItem(BaseModel):

--- a/libs/aegra-api/src/aegra_api/models/threads.py
+++ b/libs/aegra-api/src/aegra_api/models/threads.py
@@ -6,8 +6,7 @@ from typing import Any, Literal
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator
 
 from aegra_api.models.search_limit import (
-    DEFAULT_SEARCH_LIMIT,
-    enforce_search_limit,
+    resolve_search_limit,
     search_limit_json_schema_extra,
 )
 from aegra_api.utils.status_compat import validate_thread_status
@@ -112,9 +111,11 @@ class ThreadSearchRequest(BaseModel):
 
     metadata: dict[str, Any] | None = Field(None, description="Metadata filters")
     status: str | None = Field(None, description="Thread status filter (idle, busy, interrupted, error)")
+    # None default + validate_default so omitted and JSON null share one resolver.
     limit: int | None = Field(
-        DEFAULT_SEARCH_LIMIT,
+        default=None,
         ge=1,
+        validate_default=True,
         description="Maximum results",
         json_schema_extra=search_limit_json_schema_extra,
     )
@@ -135,8 +136,8 @@ class ThreadSearchRequest(BaseModel):
 
     @field_validator("limit")
     @classmethod
-    def validate_limit(cls, v: int | None) -> int | None:
-        return enforce_search_limit(v)
+    def validate_limit(cls: type["ThreadSearchRequest"], v: int | None) -> int:
+        return resolve_search_limit(v)
 
     @field_validator("status")
     @classmethod

--- a/libs/aegra-api/src/aegra_api/models/threads.py
+++ b/libs/aegra-api/src/aegra_api/models/threads.py
@@ -5,6 +5,11 @@ from typing import Any, Literal
 
 from pydantic import AliasChoices, BaseModel, ConfigDict, Field, field_validator
 
+from aegra_api.models.search_limit import (
+    DEFAULT_SEARCH_LIMIT,
+    enforce_search_limit,
+    search_limit_json_schema_extra,
+)
 from aegra_api.utils.status_compat import validate_thread_status
 
 # Upper bound keeping now + timedelta(minutes=ttl) finite and timedelta-safe
@@ -107,7 +112,12 @@ class ThreadSearchRequest(BaseModel):
 
     metadata: dict[str, Any] | None = Field(None, description="Metadata filters")
     status: str | None = Field(None, description="Thread status filter (idle, busy, interrupted, error)")
-    limit: int | None = Field(20, le=100, ge=1, description="Maximum results")
+    limit: int | None = Field(
+        DEFAULT_SEARCH_LIMIT,
+        ge=1,
+        description="Maximum results",
+        json_schema_extra=search_limit_json_schema_extra,
+    )
     offset: int | None = Field(0, ge=0, description="Results offset")
     order_by: str | None = Field(
         "created_at DESC",
@@ -122,6 +132,11 @@ class ThreadSearchRequest(BaseModel):
         None,
         description="Sort direction (SDK-compatible). Defaults to 'desc' when sort_by is set.",
     )
+
+    @field_validator("limit")
+    @classmethod
+    def validate_limit(cls, v: int | None) -> int | None:
+        return enforce_search_limit(v)
 
     @field_validator("status")
     @classmethod

--- a/libs/aegra-api/src/aegra_api/settings.py
+++ b/libs/aegra-api/src/aegra_api/settings.py
@@ -96,6 +96,8 @@ class AppSettings(EnvBase):
     AUTH_TYPE: LowerStr = "noop"
     ENV_MODE: UpperStr = "LOCAL"
     DEBUG: bool = False
+    # Default 1000 matches LangGraph Platform threads.search (Agent Server OpenAPI max).
+    MAX_SEARCH_LIMIT: int = Field(default=1000, ge=1)
 
     # Run alembic upgrade head on startup. Default True (dev / single-pod).
     # Set False for multi-pod K8s to avoid advisory-lock probe timeouts;

--- a/libs/aegra-api/tests/e2e/test_store/test_store.py
+++ b/libs/aegra-api/tests/e2e/test_store/test_store.py
@@ -1,6 +1,8 @@
 import pytest
+from httpx import AsyncClient
 from langgraph_sdk.errors import PermissionDeniedError
 
+from aegra_api.settings import settings
 from tests.e2e._utils import elog, get_e2e_client
 
 
@@ -39,6 +41,37 @@ async def test_store_endpoints_via_sdk():
     # Ensure deleted
     with pytest.raises(Exception):  # noqa: B017 - SDK doesn't expose specific exception type
         await client.store.get_item(ns, key=key)
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_store_search_accepts_sdk_page_size_500() -> None:
+    """LangGraph SDK clients page store search with limit=500; must not 422."""
+    client = get_e2e_client()
+    ns = ["notes"]
+    key = "e2e-limit-500"
+    await client.store.put_item(ns, key=key, value={"title": "limit-500"})
+    try:
+        search = await client.store.search_items(["notes"], limit=500)
+        elog("store.search_items limit=500", search)
+        assert isinstance(search, dict)
+        assert "items" in search
+        assert any(item.get("key") == key for item in search["items"])
+    finally:
+        await client.store.delete_item(ns, key=key)
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_store_search_returns_422_when_limit_exceeds_cap() -> None:
+    """limit above MAX_SEARCH_LIMIT is rejected before the store query."""
+    async with AsyncClient(base_url=settings.app.SERVER_URL, timeout=30.0) as http_client:
+        resp = await http_client.post(
+            "/store/items/search",
+            json={"namespace_prefix": ["notes"], "limit": settings.app.MAX_SEARCH_LIMIT + 1},
+        )
+    assert resp.status_code == 422, resp.text
+    assert "limit" in resp.text
 
 
 @pytest.mark.e2e

--- a/libs/aegra-api/tests/e2e/test_threads/test_search.py
+++ b/libs/aegra-api/tests/e2e/test_threads/test_search.py
@@ -198,3 +198,33 @@ async def test_search_malformed_order_by_falls_back_e2e() -> None:
             assert resp.status_code == 200, f"order_by={bad!r} → {resp.status_code}: {resp.text}"
             returned = {t["thread_id"] for t in resp.json()}
             assert returned == set(created), f"order_by={bad!r} dropped rows: {returned}"
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_search_accepts_sdk_page_size_500_e2e() -> None:
+    """LangGraph SDK clients page with limit=500; must not 422."""
+    tag = f"limit-500-{uuid.uuid4().hex[:8]}"
+    created = await _seed_three_threads(tag)
+
+    async with AsyncClient(base_url=settings.app.SERVER_URL, timeout=30.0) as http_client:
+        resp = await http_client.post(
+            "/threads/search",
+            json={"metadata": {"search_test_tag": tag}, "limit": 500},
+        )
+    assert resp.status_code == 200, resp.text
+    returned = {t["thread_id"] for t in resp.json()}
+    assert returned == set(created)
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_search_returns_422_when_limit_exceeds_cap_e2e() -> None:
+    """limit above MAX_SEARCH_LIMIT is rejected before the query runs."""
+    async with AsyncClient(base_url=settings.app.SERVER_URL, timeout=30.0) as http_client:
+        resp = await http_client.post(
+            "/threads/search",
+            json={"limit": settings.app.MAX_SEARCH_LIMIT + 1},
+        )
+    assert resp.status_code == 422, resp.text
+    assert "limit" in resp.text

--- a/libs/aegra-api/tests/e2e/test_threads/test_search.py
+++ b/libs/aegra-api/tests/e2e/test_threads/test_search.py
@@ -206,15 +206,19 @@ async def test_search_accepts_sdk_page_size_500_e2e() -> None:
     """LangGraph SDK clients page with limit=500; must not 422."""
     tag = f"limit-500-{uuid.uuid4().hex[:8]}"
     created = await _seed_three_threads(tag)
-
-    async with AsyncClient(base_url=settings.app.SERVER_URL, timeout=30.0) as http_client:
-        resp = await http_client.post(
-            "/threads/search",
-            json={"metadata": {"search_test_tag": tag}, "limit": 500},
-        )
-    assert resp.status_code == 200, resp.text
-    returned = {t["thread_id"] for t in resp.json()}
-    assert returned == set(created)
+    try:
+        async with AsyncClient(base_url=settings.app.SERVER_URL, timeout=30.0) as http_client:
+            resp = await http_client.post(
+                "/threads/search",
+                json={"metadata": {"search_test_tag": tag}, "limit": 500},
+            )
+        assert resp.status_code == 200, resp.text
+        returned = {t["thread_id"] for t in resp.json()}
+        assert returned == set(created)
+    finally:
+        client = get_e2e_client()
+        for thread_id in created:
+            await client.threads.delete(thread_id)
 
 
 @pytest.mark.e2e

--- a/libs/aegra-api/tests/integration/test_api/test_store_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_store_crud.py
@@ -1,7 +1,11 @@
 """Integration tests for store CRUD operations"""
 
-import pytest
+from unittest.mock import AsyncMock
 
+import pytest
+from fastapi.testclient import TestClient
+
+from aegra_api.settings import settings
 from tests.fixtures.clients import create_test_app, make_client
 from tests.fixtures.test_helpers import DummyStoreItem
 
@@ -432,6 +436,92 @@ class TestSearchStoreItems:
         mock_store.asearch.assert_called_once()
         call_args = mock_store.asearch.call_args
         assert call_args.kwargs["filter"] is None
+
+    def test_search_items_accepts_limit_500(self, client: TestClient, mock_store: AsyncMock) -> None:
+        """LangGraph SDK clients page with limit=500; must not 422."""
+        mock_store.asearch.return_value = []
+
+        resp = client.post(
+            "/store/items/search",
+            json={"namespace_prefix": ["test"], "limit": 500},
+        )
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["limit"] == 500
+        mock_store.asearch.assert_called_once()
+        assert mock_store.asearch.call_args.kwargs["limit"] == 500
+
+    def test_search_items_accepts_limit_at_cap(self, client: TestClient, mock_store: AsyncMock) -> None:
+        mock_store.asearch.return_value = []
+        cap = settings.app.MAX_SEARCH_LIMIT
+
+        resp = client.post(
+            "/store/items/search",
+            json={"namespace_prefix": ["test"], "limit": cap},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["limit"] == cap
+        mock_store.asearch.assert_called_once()
+        assert mock_store.asearch.call_args.kwargs["limit"] == cap
+
+    def test_search_items_null_limit_uses_default(self, client: TestClient, mock_store: AsyncMock) -> None:
+        mock_store.asearch.return_value = []
+
+        resp = client.post(
+            "/store/items/search",
+            json={"namespace_prefix": ["test"], "limit": None},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["limit"] == 20
+        mock_store.asearch.assert_called_once()
+        assert mock_store.asearch.call_args.kwargs["limit"] == 20
+
+    def test_search_items_returns_422_when_limit_exceeds_cap(self, client: TestClient, mock_store: AsyncMock) -> None:
+        """limit above MAX_SEARCH_LIMIT is rejected before the store query."""
+        cap = settings.app.MAX_SEARCH_LIMIT
+        resp = client.post(
+            "/store/items/search",
+            json={"namespace_prefix": ["test"], "limit": cap + 1},
+        )
+
+        assert resp.status_code == 422
+        detail = resp.json()["detail"]
+        assert any(
+            error.get("loc") == ["body", "limit"]
+            and error.get("type") == "less_than_equal"
+            and error.get("ctx", {}).get("le") == cap
+            for error in detail
+        )
+        mock_store.asearch.assert_not_called()
+
+    @pytest.mark.parametrize("limit", [0, -1])
+    def test_search_items_returns_422_when_limit_is_zero_or_negative(
+        self, client: TestClient, mock_store: AsyncMock, limit: int
+    ) -> None:
+        resp = client.post(
+            "/store/items/search",
+            json={"namespace_prefix": ["test"], "limit": limit},
+        )
+
+        assert resp.status_code == 422
+        assert "limit" in resp.text
+        mock_store.asearch.assert_not_called()
+
+    @pytest.mark.parametrize("limit", ["abc", [], {}, 20.5])
+    def test_search_items_returns_422_when_limit_is_not_an_integer(
+        self, client: TestClient, mock_store: AsyncMock, limit: object
+    ) -> None:
+        resp = client.post(
+            "/store/items/search",
+            json={"namespace_prefix": ["test"], "limit": limit},
+        )
+
+        assert resp.status_code == 422
+        assert "limit" in resp.text
+        mock_store.asearch.assert_not_called()
 
     def test_search_items_with_auth_handler_filter_merge(self, client, mock_store):
         """Test that auth handler filters are merged with request filters"""

--- a/libs/aegra-api/tests/integration/test_api/test_store_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_store_crud.py
@@ -479,6 +479,38 @@ class TestSearchStoreItems:
         mock_store.asearch.assert_called_once()
         assert mock_store.asearch.call_args.kwargs["limit"] == 20
 
+    def test_search_items_omitted_limit_honors_cap_below_default(
+        self, client: TestClient, mock_store: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(settings.app, "MAX_SEARCH_LIMIT", 10)
+        mock_store.asearch.return_value = []
+
+        resp = client.post(
+            "/store/items/search",
+            json={"namespace_prefix": ["test"], "query": None},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["limit"] == 10
+        mock_store.asearch.assert_called_once()
+        assert mock_store.asearch.call_args.kwargs["limit"] == 10
+
+    def test_search_items_null_limit_honors_cap_below_default(
+        self, client: TestClient, mock_store: AsyncMock, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(settings.app, "MAX_SEARCH_LIMIT", 10)
+        mock_store.asearch.return_value = []
+
+        resp = client.post(
+            "/store/items/search",
+            json={"namespace_prefix": ["test"], "limit": None},
+        )
+
+        assert resp.status_code == 200
+        assert resp.json()["limit"] == 10
+        mock_store.asearch.assert_called_once()
+        assert mock_store.asearch.call_args.kwargs["limit"] == 10
+
     def test_search_items_returns_422_when_limit_exceeds_cap(self, client: TestClient, mock_store: AsyncMock) -> None:
         """limit above MAX_SEARCH_LIMIT is rejected before the store query."""
         cap = settings.app.MAX_SEARCH_LIMIT

--- a/libs/aegra-api/tests/integration/test_api/test_threads_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_threads_crud.py
@@ -655,14 +655,16 @@ class TestSearchThreads:
         assert resp.status_code == 200
         assert isinstance(resp.json(), list)
 
-    def test_search_omitted_limit_honors_cap_below_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_search_omitted_limit_honors_cap_below_default(
+        self: "TestSearchThreads", monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         monkeypatch.setattr(settings.app, "MAX_SEARCH_LIMIT", 10)
         captured: list[int | None] = []
         app = create_test_app(include_runs=False, include_threads=True)
         threads = [_thread_row("thread-1")]
 
         class Session(ThreadSession):
-            async def scalars(self, stmt: Any = None) -> Any:
+            async def scalars(self: "Session", stmt: Any = None) -> Any:
                 if stmt is not None and hasattr(stmt, "_limit"):
                     captured.append(stmt._limit)
                 return await super().scalars(stmt)
@@ -673,14 +675,16 @@ class TestSearchThreads:
         assert resp.status_code == 200
         assert captured == [10]
 
-    def test_search_null_limit_honors_cap_below_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_search_null_limit_honors_cap_below_default(
+        self: "TestSearchThreads", monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         monkeypatch.setattr(settings.app, "MAX_SEARCH_LIMIT", 10)
         captured: list[int | None] = []
         app = create_test_app(include_runs=False, include_threads=True)
         threads = [_thread_row("thread-1")]
 
         class Session(ThreadSession):
-            async def scalars(self, stmt: Any = None) -> Any:
+            async def scalars(self: "Session", stmt: Any = None) -> Any:
                 if stmt is not None and hasattr(stmt, "_limit"):
                     captured.append(stmt._limit)
                 return await super().scalars(stmt)

--- a/libs/aegra-api/tests/integration/test_api/test_threads_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_threads_crud.py
@@ -13,6 +13,7 @@ from sqlalchemy.dialects import postgresql
 
 from aegra_api.api import threads as threads_module
 from aegra_api.core.orm import get_session as core_get_session
+from aegra_api.settings import settings
 from tests.fixtures.clients import create_test_app, make_client
 from tests.fixtures.database import (
     DummyScalarResult,
@@ -637,6 +638,47 @@ class TestSearchThreads:
         resp = client.post("/threads/search", json={"metadata": {"active": True}})
         assert resp.status_code == 200
         assert isinstance(resp.json(), list)
+
+    def test_search_accepts_limit_500(self, client: TestClient) -> None:
+        """LangGraph SDK clients page with limit=500; must not 422."""
+        resp = client.post("/threads/search", json={"limit": 500})
+        assert resp.status_code == 200
+        assert isinstance(resp.json(), list)
+
+    def test_search_accepts_limit_at_cap(self, client: TestClient) -> None:
+        resp = client.post("/threads/search", json={"limit": settings.app.MAX_SEARCH_LIMIT})
+        assert resp.status_code == 200
+        assert isinstance(resp.json(), list)
+
+    def test_search_accepts_null_limit(self, client: TestClient) -> None:
+        resp = client.post("/threads/search", json={"limit": None})
+        assert resp.status_code == 200
+        assert isinstance(resp.json(), list)
+
+    def test_search_returns_422_when_limit_exceeds_cap(self, client: TestClient) -> None:
+        """limit above MAX_SEARCH_LIMIT is rejected at the request model."""
+        cap = settings.app.MAX_SEARCH_LIMIT
+        resp = client.post("/threads/search", json={"limit": cap + 1})
+        assert resp.status_code == 422
+        detail = resp.json()["detail"]
+        assert any(
+            error.get("loc") == ["body", "limit"]
+            and error.get("type") == "less_than_equal"
+            and error.get("ctx", {}).get("le") == cap
+            for error in detail
+        )
+
+    @pytest.mark.parametrize("limit", [0, -1])
+    def test_search_returns_422_when_limit_is_zero_or_negative(self, client: TestClient, limit: int) -> None:
+        resp = client.post("/threads/search", json={"limit": limit})
+        assert resp.status_code == 422
+        assert "limit" in resp.text
+
+    @pytest.mark.parametrize("limit", ["abc", [], {}, 20.5])
+    def test_search_returns_422_when_limit_is_not_an_integer(self, client: TestClient, limit: object) -> None:
+        resp = client.post("/threads/search", json={"limit": limit})
+        assert resp.status_code == 422
+        assert "limit" in resp.text
 
 
 class TestThreadGetState:

--- a/libs/aegra-api/tests/integration/test_api/test_threads_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_threads_crud.py
@@ -20,7 +20,7 @@ from tests.fixtures.database import (
     DummySessionBase,
     override_get_session_dep,
 )
-from tests.fixtures.session_fixtures import BasicSession, override_session_dependency
+from tests.fixtures.session_fixtures import BasicSession, ThreadSession, override_session_dependency
 from tests.fixtures.test_helpers import DummyRun, DummyThread
 
 
@@ -654,6 +654,42 @@ class TestSearchThreads:
         resp = client.post("/threads/search", json={"limit": None})
         assert resp.status_code == 200
         assert isinstance(resp.json(), list)
+
+    def test_search_omitted_limit_honors_cap_below_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(settings.app, "MAX_SEARCH_LIMIT", 10)
+        captured: list[int | None] = []
+        app = create_test_app(include_runs=False, include_threads=True)
+        threads = [_thread_row("thread-1")]
+
+        class Session(ThreadSession):
+            async def scalars(self, stmt: Any = None) -> Any:
+                if stmt is not None and hasattr(stmt, "_limit"):
+                    captured.append(stmt._limit)
+                return await super().scalars(stmt)
+
+        override_session_dependency(app, Session, threads=threads)
+        client = make_client(app)
+        resp = client.post("/threads/search", json={})
+        assert resp.status_code == 200
+        assert captured == [10]
+
+    def test_search_null_limit_honors_cap_below_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(settings.app, "MAX_SEARCH_LIMIT", 10)
+        captured: list[int | None] = []
+        app = create_test_app(include_runs=False, include_threads=True)
+        threads = [_thread_row("thread-1")]
+
+        class Session(ThreadSession):
+            async def scalars(self, stmt: Any = None) -> Any:
+                if stmt is not None and hasattr(stmt, "_limit"):
+                    captured.append(stmt._limit)
+                return await super().scalars(stmt)
+
+        override_session_dependency(app, Session, threads=threads)
+        client = make_client(app)
+        resp = client.post("/threads/search", json={"limit": None})
+        assert resp.status_code == 200
+        assert captured == [10]
 
     def test_search_returns_422_when_limit_exceeds_cap(self, client: TestClient) -> None:
         """limit above MAX_SEARCH_LIMIT is rejected at the request model."""

--- a/libs/aegra-api/tests/unit/test_models/test_search_limit.py
+++ b/libs/aegra-api/tests/unit/test_models/test_search_limit.py
@@ -1,0 +1,204 @@
+"""Validation tests for threads/store search `limit` (issue #471)."""
+
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from aegra_api.models.search_limit import (
+    DEFAULT_SEARCH_LIMIT,
+    enforce_search_limit,
+    search_limit_json_schema_extra,
+)
+from aegra_api.models.store import StoreSearchRequest
+from aegra_api.models.threads import ThreadSearchRequest
+from aegra_api.settings import settings
+
+_DEFAULT_CAP: int = 1000
+_INVALID_LIMITS: tuple[Any, ...] = ("abc", [], {}, 20.5)
+
+
+@pytest.fixture(autouse=True)
+def _pin_default_search_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings.app, "MAX_SEARCH_LIMIT", _DEFAULT_CAP)
+
+
+def _integer_limit_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    """Return the integer branch of an optional limit field schema."""
+    for option in schema.get("anyOf", []):
+        if isinstance(option, dict) and option.get("type") == "integer":
+            return option
+    return schema
+
+
+def _limit_error(exc: ValidationError) -> dict[str, Any]:
+    errors = [item for item in exc.errors() if item["loc"][-1] == "limit"]
+    assert len(errors) == 1
+    return errors[0]
+
+
+def _store_request(**kwargs: Any) -> StoreSearchRequest:
+    return StoreSearchRequest(namespace_prefix=["notes"], **kwargs)
+
+
+class TestEnforceSearchLimit:
+    """Shared helper used by both search request models."""
+
+    def test_passes_none_through(self) -> None:
+        assert enforce_search_limit(None) is None
+
+    def test_passes_value_at_cap(self) -> None:
+        assert enforce_search_limit(_DEFAULT_CAP) == _DEFAULT_CAP
+
+    def test_schema_extra_sets_maximum_on_integer_anyof_branch(self) -> None:
+        schema: dict[str, Any] = {"anyOf": [{"type": "integer", "minimum": 1}, {"type": "null"}]}
+        search_limit_json_schema_extra(schema)
+        assert schema["anyOf"][0]["maximum"] == _DEFAULT_CAP
+        assert "maximum" not in schema
+
+    def test_schema_extra_sets_maximum_without_anyof(self) -> None:
+        schema: dict[str, Any] = {"type": "integer"}
+        search_limit_json_schema_extra(schema)
+        assert schema["maximum"] == _DEFAULT_CAP
+
+    def test_schema_extra_tracks_live_cap(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(settings.app, "MAX_SEARCH_LIMIT", 50)
+        schema: dict[str, Any] = {"anyOf": [{"type": "integer"}, {"type": "null"}]}
+        search_limit_json_schema_extra(schema)
+        assert schema["anyOf"][0]["maximum"] == 50
+
+
+class TestThreadSearchRequestLimit:
+    """ThreadSearchRequest.limit must accept LangGraph SDK page sizes."""
+
+    @pytest.mark.parametrize("limit", [1, 20, 101, 500, 1000])
+    def test_accepts_limits_within_default_cap(self, limit: int) -> None:
+        request = ThreadSearchRequest(limit=limit)
+        assert request.limit == limit
+
+    def test_accepts_limit_equal_to_cap(self) -> None:
+        request = ThreadSearchRequest(limit=settings.app.MAX_SEARCH_LIMIT)
+        assert request.limit == settings.app.MAX_SEARCH_LIMIT
+
+    def test_accepts_explicit_none_limit(self) -> None:
+        request = ThreadSearchRequest(limit=None)
+        assert request.limit is None
+
+    @pytest.mark.parametrize("limit", [0, -1])
+    def test_rejects_zero_and_negative_limits(self, limit: int) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            ThreadSearchRequest(limit=limit)
+        err = _limit_error(exc_info.value)
+        assert err["type"] == "greater_than_equal"
+
+    def test_rejects_limit_above_cap(self) -> None:
+        cap = settings.app.MAX_SEARCH_LIMIT
+        with pytest.raises(ValidationError) as exc_info:
+            ThreadSearchRequest(limit=cap + 1)
+        err = _limit_error(exc_info.value)
+        assert err["type"] == "less_than_equal"
+        assert err["ctx"] == {"le": cap}
+        assert str(cap) in err["msg"]
+
+    @pytest.mark.parametrize("limit", _INVALID_LIMITS)
+    def test_rejects_non_integer_limits(self, limit: Any) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            ThreadSearchRequest.model_validate({"limit": limit})
+        err = _limit_error(exc_info.value)
+        assert err["type"] in {"int_parsing", "int_type", "int_from_float"}
+
+    def test_default_limit_is_unchanged(self) -> None:
+        request = ThreadSearchRequest()
+        assert request.limit == DEFAULT_SEARCH_LIMIT
+        assert DEFAULT_SEARCH_LIMIT == 20
+        assert DEFAULT_SEARCH_LIMIT != settings.app.MAX_SEARCH_LIMIT
+
+    def test_honors_configured_max_search_limit(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(settings.app, "MAX_SEARCH_LIMIT", 50)
+        request = ThreadSearchRequest(limit=50)
+        assert request.limit == 50
+        with pytest.raises(ValidationError) as exc_info:
+            ThreadSearchRequest(limit=51)
+        err = _limit_error(exc_info.value)
+        assert err["type"] == "less_than_equal"
+        assert err["ctx"] == {"le": 50}
+
+    def test_openapi_schema_advertises_configured_cap(self) -> None:
+        schema = ThreadSearchRequest.model_json_schema()["properties"]["limit"]
+        integer_schema = _integer_limit_schema(schema)
+        assert integer_schema["minimum"] == 1
+        assert integer_schema["maximum"] == settings.app.MAX_SEARCH_LIMIT
+        assert schema["default"] == DEFAULT_SEARCH_LIMIT
+
+    def test_openapi_schema_tracks_live_cap(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(settings.app, "MAX_SEARCH_LIMIT", 50)
+        schema = ThreadSearchRequest.model_json_schema()["properties"]["limit"]
+        assert _integer_limit_schema(schema)["maximum"] == 50
+
+
+class TestStoreSearchRequestLimit:
+    """StoreSearchRequest.limit shares the same cap as thread search."""
+
+    @pytest.mark.parametrize("limit", [1, 20, 101, 500, 1000])
+    def test_accepts_limits_within_default_cap(self, limit: int) -> None:
+        request = _store_request(limit=limit)
+        assert request.limit == limit
+
+    def test_accepts_limit_equal_to_cap(self) -> None:
+        request = _store_request(limit=settings.app.MAX_SEARCH_LIMIT)
+        assert request.limit == settings.app.MAX_SEARCH_LIMIT
+
+    def test_accepts_explicit_none_limit(self) -> None:
+        request = _store_request(limit=None)
+        assert request.limit is None
+
+    @pytest.mark.parametrize("limit", [0, -1])
+    def test_rejects_zero_and_negative_limits(self, limit: int) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            _store_request(limit=limit)
+        err = _limit_error(exc_info.value)
+        assert err["type"] == "greater_than_equal"
+
+    def test_rejects_limit_above_cap(self) -> None:
+        cap = settings.app.MAX_SEARCH_LIMIT
+        with pytest.raises(ValidationError) as exc_info:
+            _store_request(limit=cap + 1)
+        err = _limit_error(exc_info.value)
+        assert err["type"] == "less_than_equal"
+        assert err["ctx"] == {"le": cap}
+        assert str(cap) in err["msg"]
+
+    @pytest.mark.parametrize("limit", _INVALID_LIMITS)
+    def test_rejects_non_integer_limits(self, limit: Any) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            StoreSearchRequest.model_validate({"namespace_prefix": ["notes"], "limit": limit})
+        err = _limit_error(exc_info.value)
+        assert err["type"] in {"int_parsing", "int_type", "int_from_float"}
+
+    def test_default_limit_is_unchanged(self) -> None:
+        request = _store_request()
+        assert request.limit == DEFAULT_SEARCH_LIMIT
+        assert DEFAULT_SEARCH_LIMIT == 20
+        assert DEFAULT_SEARCH_LIMIT != settings.app.MAX_SEARCH_LIMIT
+
+    def test_honors_configured_max_search_limit(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(settings.app, "MAX_SEARCH_LIMIT", 50)
+        request = _store_request(limit=50)
+        assert request.limit == 50
+        with pytest.raises(ValidationError) as exc_info:
+            _store_request(limit=51)
+        err = _limit_error(exc_info.value)
+        assert err["type"] == "less_than_equal"
+        assert err["ctx"] == {"le": 50}
+
+    def test_openapi_schema_advertises_configured_cap(self) -> None:
+        schema = StoreSearchRequest.model_json_schema()["properties"]["limit"]
+        integer_schema = _integer_limit_schema(schema)
+        assert integer_schema["minimum"] == 1
+        assert integer_schema["maximum"] == settings.app.MAX_SEARCH_LIMIT
+        assert schema["default"] == DEFAULT_SEARCH_LIMIT
+
+    def test_openapi_schema_tracks_live_cap(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(settings.app, "MAX_SEARCH_LIMIT", 50)
+        schema = StoreSearchRequest.model_json_schema()["properties"]["limit"]
+        assert _integer_limit_schema(schema)["maximum"] == 50

--- a/libs/aegra-api/tests/unit/test_models/test_search_limit.py
+++ b/libs/aegra-api/tests/unit/test_models/test_search_limit.py
@@ -7,7 +7,8 @@ from pydantic import ValidationError
 
 from aegra_api.models.search_limit import (
     DEFAULT_SEARCH_LIMIT,
-    enforce_search_limit,
+    effective_search_limit,
+    resolve_search_limit,
     search_limit_json_schema_extra,
 )
 from aegra_api.models.store import StoreSearchRequest
@@ -16,6 +17,7 @@ from aegra_api.settings import settings
 
 _DEFAULT_CAP: int = 1000
 _INVALID_LIMITS: tuple[Any, ...] = ("abc", [], {}, 20.5)
+_SearchModel = type[ThreadSearchRequest] | type[StoreSearchRequest]
 
 
 @pytest.fixture(autouse=True)
@@ -41,31 +43,54 @@ def _store_request(**kwargs: Any) -> StoreSearchRequest:
     return StoreSearchRequest(namespace_prefix=["notes"], **kwargs)
 
 
-class TestEnforceSearchLimit:
+def _build(
+    model: _SearchModel,
+    *,
+    data: dict[str, Any] | None = None,
+    **kwargs: Any,
+) -> ThreadSearchRequest | StoreSearchRequest:
+    payload: dict[str, Any] = dict(data if data is not None else kwargs)
+    if model is StoreSearchRequest:
+        payload.setdefault("namespace_prefix", ["notes"])
+    if data is not None:
+        return model.model_validate(payload)
+    return model(**payload)
+
+
+class TestResolveSearchLimit:
     """Shared helper used by both search request models."""
 
-    def test_passes_none_through(self) -> None:
-        assert enforce_search_limit(None) is None
+    def test_none_resolves_to_default_when_cap_is_higher(self) -> None:
+        assert resolve_search_limit(None) == DEFAULT_SEARCH_LIMIT
+        assert resolve_search_limit(None) == 20
+
+    def test_none_resolves_to_cap_when_cap_is_below_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(settings.app, "MAX_SEARCH_LIMIT", 10)
+        assert resolve_search_limit(None) == 10
+        assert effective_search_limit() == 10
 
     def test_passes_value_at_cap(self) -> None:
-        assert enforce_search_limit(_DEFAULT_CAP) == _DEFAULT_CAP
+        assert resolve_search_limit(_DEFAULT_CAP) == _DEFAULT_CAP
 
     def test_schema_extra_sets_maximum_on_integer_anyof_branch(self) -> None:
         schema: dict[str, Any] = {"anyOf": [{"type": "integer", "minimum": 1}, {"type": "null"}]}
         search_limit_json_schema_extra(schema)
         assert schema["anyOf"][0]["maximum"] == _DEFAULT_CAP
+        assert schema["default"] == DEFAULT_SEARCH_LIMIT
         assert "maximum" not in schema
 
     def test_schema_extra_sets_maximum_without_anyof(self) -> None:
         schema: dict[str, Any] = {"type": "integer"}
         search_limit_json_schema_extra(schema)
         assert schema["maximum"] == _DEFAULT_CAP
+        assert schema["default"] == DEFAULT_SEARCH_LIMIT
 
     def test_schema_extra_tracks_live_cap(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(settings.app, "MAX_SEARCH_LIMIT", 50)
         schema: dict[str, Any] = {"anyOf": [{"type": "integer"}, {"type": "null"}]}
         search_limit_json_schema_extra(schema)
         assert schema["anyOf"][0]["maximum"] == 50
+        assert schema["default"] == DEFAULT_SEARCH_LIMIT
 
 
 class TestThreadSearchRequestLimit:
@@ -80,9 +105,21 @@ class TestThreadSearchRequestLimit:
         request = ThreadSearchRequest(limit=settings.app.MAX_SEARCH_LIMIT)
         assert request.limit == settings.app.MAX_SEARCH_LIMIT
 
-    def test_accepts_explicit_none_limit(self) -> None:
+    def test_omitted_limit_uses_default(self) -> None:
+        request = ThreadSearchRequest()
+        assert request.limit == DEFAULT_SEARCH_LIMIT
+
+    def test_omitted_limit_via_model_validate_uses_default(self) -> None:
+        request = ThreadSearchRequest.model_validate({})
+        assert request.limit == DEFAULT_SEARCH_LIMIT
+
+    def test_explicit_none_limit_uses_default(self) -> None:
         request = ThreadSearchRequest(limit=None)
-        assert request.limit is None
+        assert request.limit == DEFAULT_SEARCH_LIMIT
+
+    def test_explicit_none_limit_via_model_validate_uses_default(self) -> None:
+        request = ThreadSearchRequest.model_validate({"limit": None})
+        assert request.limit == DEFAULT_SEARCH_LIMIT
 
     @pytest.mark.parametrize("limit", [0, -1])
     def test_rejects_zero_and_negative_limits(self, limit: int) -> None:
@@ -134,6 +171,26 @@ class TestThreadSearchRequestLimit:
         monkeypatch.setattr(settings.app, "MAX_SEARCH_LIMIT", 50)
         schema = ThreadSearchRequest.model_json_schema()["properties"]["limit"]
         assert _integer_limit_schema(schema)["maximum"] == 50
+        assert schema["default"] == DEFAULT_SEARCH_LIMIT
+
+    def test_omitted_and_null_honor_cap_below_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(settings.app, "MAX_SEARCH_LIMIT", 10)
+        assert ThreadSearchRequest().limit == 10
+        assert ThreadSearchRequest.model_validate({}).limit == 10
+        assert ThreadSearchRequest(limit=None).limit == 10
+        assert ThreadSearchRequest.model_validate({"limit": None}).limit == 10
+        assert ThreadSearchRequest(limit=10).limit == 10
+        with pytest.raises(ValidationError) as exc_info:
+            ThreadSearchRequest(limit=11)
+        err = _limit_error(exc_info.value)
+        assert err["type"] == "less_than_equal"
+        assert err["ctx"] == {"le": 10}
+
+    def test_openapi_schema_default_is_capped_when_cap_below_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(settings.app, "MAX_SEARCH_LIMIT", 10)
+        schema = ThreadSearchRequest.model_json_schema()["properties"]["limit"]
+        assert schema["default"] == 10
+        assert _integer_limit_schema(schema)["maximum"] == 10
 
 
 class TestStoreSearchRequestLimit:
@@ -148,9 +205,21 @@ class TestStoreSearchRequestLimit:
         request = _store_request(limit=settings.app.MAX_SEARCH_LIMIT)
         assert request.limit == settings.app.MAX_SEARCH_LIMIT
 
-    def test_accepts_explicit_none_limit(self) -> None:
+    def test_omitted_limit_uses_default(self) -> None:
+        request = _store_request()
+        assert request.limit == DEFAULT_SEARCH_LIMIT
+
+    def test_omitted_limit_via_model_validate_uses_default(self) -> None:
+        request = StoreSearchRequest.model_validate({"namespace_prefix": ["notes"]})
+        assert request.limit == DEFAULT_SEARCH_LIMIT
+
+    def test_explicit_none_limit_uses_default(self) -> None:
         request = _store_request(limit=None)
-        assert request.limit is None
+        assert request.limit == DEFAULT_SEARCH_LIMIT
+
+    def test_explicit_none_limit_via_model_validate_uses_default(self) -> None:
+        request = StoreSearchRequest.model_validate({"namespace_prefix": ["notes"], "limit": None})
+        assert request.limit == DEFAULT_SEARCH_LIMIT
 
     @pytest.mark.parametrize("limit", [0, -1])
     def test_rejects_zero_and_negative_limits(self, limit: int) -> None:
@@ -202,3 +271,58 @@ class TestStoreSearchRequestLimit:
         monkeypatch.setattr(settings.app, "MAX_SEARCH_LIMIT", 50)
         schema = StoreSearchRequest.model_json_schema()["properties"]["limit"]
         assert _integer_limit_schema(schema)["maximum"] == 50
+        assert schema["default"] == DEFAULT_SEARCH_LIMIT
+
+    def test_omitted_and_null_honor_cap_below_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(settings.app, "MAX_SEARCH_LIMIT", 10)
+        assert _store_request().limit == 10
+        assert StoreSearchRequest.model_validate({"namespace_prefix": ["notes"]}).limit == 10
+        assert _store_request(limit=None).limit == 10
+        assert StoreSearchRequest.model_validate({"namespace_prefix": ["notes"], "limit": None}).limit == 10
+        assert _store_request(limit=10).limit == 10
+        with pytest.raises(ValidationError) as exc_info:
+            _store_request(limit=11)
+        err = _limit_error(exc_info.value)
+        assert err["type"] == "less_than_equal"
+        assert err["ctx"] == {"le": 10}
+
+    def test_openapi_schema_default_is_capped_when_cap_below_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(settings.app, "MAX_SEARCH_LIMIT", 10)
+        schema = StoreSearchRequest.model_json_schema()["properties"]["limit"]
+        assert schema["default"] == 10
+        assert _integer_limit_schema(schema)["maximum"] == 10
+
+
+@pytest.mark.parametrize("model", [ThreadSearchRequest, StoreSearchRequest], ids=["threads", "store"])
+class TestSearchLimitParity:
+    """Thread and store search requests share one resolution table."""
+
+    def test_default_cap_omitted_and_null_are_twenty(self, model: _SearchModel) -> None:
+        omitted = _build(model, data={})
+        constructed = _build(model)
+        explicit_null = _build(model, data={"limit": None})
+        assert omitted.limit == constructed.limit == explicit_null.limit == 20
+
+    def test_cap_ten_omitted_null_and_ten_are_ten(self, model: _SearchModel, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(settings.app, "MAX_SEARCH_LIMIT", 10)
+        omitted = _build(model, data={})
+        constructed = _build(model)
+        explicit_null = _build(model, limit=None)
+        at_cap = _build(model, limit=10)
+        assert omitted.limit == constructed.limit == explicit_null.limit == at_cap.limit == 10
+
+    def test_cap_ten_rejects_eleven(self, model: _SearchModel, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(settings.app, "MAX_SEARCH_LIMIT", 10)
+        with pytest.raises(ValidationError) as exc_info:
+            _build(model, limit=11)
+        err = _limit_error(exc_info.value)
+        assert err["type"] == "less_than_equal"
+        assert err["ctx"] == {"le": 10}
+
+    def test_openapi_default_and_maximum_match_runtime(
+        self, model: _SearchModel, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(settings.app, "MAX_SEARCH_LIMIT", 10)
+        schema = model.model_json_schema()["properties"]["limit"]
+        assert schema["default"] == effective_search_limit()
+        assert _integer_limit_schema(schema)["maximum"] == settings.app.MAX_SEARCH_LIMIT

--- a/libs/aegra-api/tests/unit/test_settings.py
+++ b/libs/aegra-api/tests/unit/test_settings.py
@@ -32,6 +32,7 @@ class TestAppSettingsServerURL:
             "LOG_LEVEL",
             "LOG_VERBOSITY",
             "AEGRA_CONFIG",
+            "MAX_SEARCH_LIMIT",
         ):
             monkeypatch.delenv(var, raising=False)
 
@@ -662,3 +663,27 @@ class TestThreadTTLSettings:
         ttl = ThreadTTLSettings(_env_file=None)
 
         assert ttl.AEGRA_THREAD_TTL == '{"default_ttl": 60}'
+
+
+class TestMaxSearchLimit:
+    """MAX_SEARCH_LIMIT defaults to the LangGraph Platform threads.search max."""
+
+    def test_default_matches_langgraph_threads_search_max(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("MAX_SEARCH_LIMIT", raising=False)
+        app = AppSettings(_env_file=None)
+        assert app.MAX_SEARCH_LIMIT == 1000
+
+    def test_reads_from_environment(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MAX_SEARCH_LIMIT", "500")
+        app = AppSettings(_env_file=None)
+        assert app.MAX_SEARCH_LIMIT == 500
+
+    def test_rejects_zero(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MAX_SEARCH_LIMIT", "0")
+        with pytest.raises(ValidationError):
+            AppSettings(_env_file=None)
+
+    def test_rejects_negative(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("MAX_SEARCH_LIMIT", "-1")
+        with pytest.raises(ValidationError):
+            AppSettings(_env_file=None)

--- a/libs/aegra-api/tests/unit/test_settings.py
+++ b/libs/aegra-api/tests/unit/test_settings.py
@@ -668,22 +668,24 @@ class TestThreadTTLSettings:
 class TestMaxSearchLimit:
     """MAX_SEARCH_LIMIT defaults to the LangGraph Platform threads.search max."""
 
-    def test_default_matches_langgraph_threads_search_max(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_default_matches_langgraph_threads_search_max(
+        self: "TestMaxSearchLimit", monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         monkeypatch.delenv("MAX_SEARCH_LIMIT", raising=False)
         app = AppSettings(_env_file=None)
         assert app.MAX_SEARCH_LIMIT == 1000
 
-    def test_reads_from_environment(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_reads_from_environment(self: "TestMaxSearchLimit", monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("MAX_SEARCH_LIMIT", "500")
         app = AppSettings(_env_file=None)
         assert app.MAX_SEARCH_LIMIT == 500
 
-    def test_rejects_zero(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_rejects_zero(self: "TestMaxSearchLimit", monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("MAX_SEARCH_LIMIT", "0")
         with pytest.raises(ValidationError):
             AppSettings(_env_file=None)
 
-    def test_rejects_negative(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_rejects_negative(self: "TestMaxSearchLimit", monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("MAX_SEARCH_LIMIT", "-1")
         with pytest.raises(ValidationError):
             AppSettings(_env_file=None)

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.10.4"
+version = "0.10.5"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-cli/src/aegra_cli/templates/env.example.template
+++ b/libs/aegra-cli/src/aegra_cli/templates/env.example.template
@@ -10,6 +10,9 @@ AEGRA_CONFIG=aegra.json
 # `aegra db upgrade` out-of-band instead. See docs/guides/deployment.mdx.
 # RUN_MIGRATIONS_ON_STARTUP=true
 
+# Max page size for POST /threads/search and POST /store/items/search (default 1000).
+# MAX_SEARCH_LIMIT=1000
+
 # --- Database ---
 # Option 1: Single connection string (standard for containers/cloud)
 # If your password contains special characters (@, /, #, %, +, etc.),

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.10.4"
+version = "0.10.5"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -100,7 +100,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.10.4"
+version = "0.10.5"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
## Summary
- Fixes #471
- SDK 用 limit=500/1000，旧 le=100 会 422；默认 page size 仍 20；MAX_SEARCH_LIMIT 默认 1000
- 未做 #330/#467 select/extract
- 0.10.5 与 #549/#552/#548 碰撞：谁先合谁占这个 patch，后合的再 bump

## Test plan
- [x] `uv run ruff check .` and `uv run ruff format --check .`
- [x] unit: `test_search_limit.py` (limit=None / cap / cap+1 / default 20 / invalid types, threads + store)
- [x] unit: `MAX_SEARCH_LIMIT` default 1000, env override, reject 0 and negative
- [x] integration: `test_store_crud.py` + `test_threads_crud.py` search cap and 422 shape (`less_than_equal`)


Made with [Cursor](https://cursor.com)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Search endpoints now support page sizes up to a configurable maximum of 1,000 by default.
  * Omitted or null page sizes default to the lower of 20 or the configured maximum.
  * Requests exceeding the configured maximum or using invalid page sizes return validation errors.

* **Documentation**
  * Updated search pagination, environment-variable, and API specification documentation.
  * Updated package and API versions to 0.10.5.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR introduces a shared, configurable page-size cap for thread and store searches while preserving a capped default for omitted and null limits.
- Adds `MAX_SEARCH_LIMIT`, defaulting to 1000 with positive-value validation.
- Uses one resolver across both search request models and route implementations.
- Updates API documentation, environment templates, generated OpenAPI output, versions, and regression coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/models/search_limit.py | Centralizes the configured cap, capped default, Pydantic validation error, and generated-schema constraints. |
| libs/aegra-api/src/aegra_api/models/threads.py | Routes omitted, null, and explicit thread-search limits through the shared resolver. |
| libs/aegra-api/src/aegra_api/models/store.py | Applies the same shared limit contract to store-search requests. |
| libs/aegra-api/src/aegra_api/api/threads.py | Uses the validated resolved limit when constructing the paginated thread query. |
| libs/aegra-api/src/aegra_api/api/store.py | Passes the resolved limit to store search and reports it consistently in the response. |
| libs/aegra-api/src/aegra_api/settings.py | Adds a positive configurable `MAX_SEARCH_LIMIT` with a default of 1000. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Search request] --> B{limit supplied?}
    B -->|No or null| C[min of 20 and MAX_SEARCH_LIMIT]
    B -->|Yes| D{limit within configured cap?}
    D -->|No| E[422 validation response]
    D -->|Yes| F[Resolved page size]
    C --> F
    F --> G[Thread or store query]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["test(api): annotate self on search-limit..."](https://github.com/aegra/aegra/commit/f799ee83bd36058bc676d8c36326557b2c30fa80) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59469708)</sub>

<!-- /greptile_comment -->