### PR TITLE
fix(api): forward update, goto and context on v2 input.respond

### DIFF
--- a/docs/feature-support.mdx
+++ b/docs/feature-support.mdx
@@ -62,6 +62,7 @@ description: "What Aegra supports today, what's coming soon, and what's not yet 
 | Interrupt before / after | Supported | Pause execution at specific nodes. |
 | User approval gates | Supported | Resume or reject interrupted runs. |
 | State editing | Supported | Modify thread state before resuming. |
+| Resume with `update` / `goto` | Supported | `input.respond` folds a state update or directed jump into the resume, one checkpoint. Also available as `command` on v1 run creation. |
 
 ### Storage
 

--- a/docs/guides/streaming.mdx
+++ b/docs/guides/streaming.mdx
@@ -311,7 +311,11 @@ curl -X POST http://localhost:8000/threads/$THREAD/commands \
 # → {"type": "success", "id": 1, "result": {"run_id": "..."}}
 ```
 
-`context` is forwarded to both the graph factory through `ServerRuntime[T]` and graph nodes through `Runtime[T]`.
+`context` is forwarded to both the graph factory through `ServerRuntime[T]` and graph nodes through `Runtime[T]`. It is an Aegra extension: the Agent Protocol `run.start` params are `assistant_id`, `input`, `config`, `metadata`, and `langsmith_tracer`. For a payload that also works against LangGraph Platform, put the same values under `config.configurable`; when `context` is absent the server copies `configurable` into it.
+
+`langsmith_tracer` is accepted and ignored. Aegra traces through OpenTelemetry, see [Observability](/guides/observability).
+
+Params outside the documented set are logged at warning level with their key names and otherwise ignored.
 
 ### Streaming events
 
@@ -359,6 +363,37 @@ When you subscribe to the `input` channel, a graph interrupt arrives as an `inpu
 ```
 
 `payload` is the Agent Protocol field consumed by the JavaScript SDK and Vue/React `useStream()` integrations. `value` mirrors it for current Python SDKs, including `ts.interrupts[].value`. If the source interrupt has no value, both content fields are omitted; explicit `null`, empty, and falsy values are preserved under both fields.
+
+### Responding to an interrupt
+
+`input.respond` resumes the interrupted run. Only `response` is required; `interrupt_id` targets one interrupt when several are pending.
+
+```bash
+curl -X POST http://localhost:8000/threads/$THREAD/commands   -H "Content-Type: application/json"   -d '{
+        "id": 2,
+        "method": "input.respond",
+        "params": {
+          "interrupt_id": "interrupt-id",
+          "namespace": [],
+          "response": {"action": "approve"},
+          "update": {"reviewed_by": "alice"},
+          "goto": "finalize"
+        }
+      }'
+```
+
+| Param | Effect |
+|:--|:--|
+| `response` | The value returned from `interrupt()` inside the graph. |
+| `interrupt_id` | Targets one pending interrupt. Omit it only when a single interrupt is pending. |
+| `responses` | Batch form: a list of `{interrupt_id, response}` entries resumed in one run. Replaces `response` and `interrupt_id`. |
+| `update` | State update applied in the same superstep as the resume, as `Command(update=...)`. Must be an object. |
+| `goto` | Node name, `{node, input}` object, or a list of those, applied as `Command(goto=...)`. |
+| `config`, `metadata` | Per-run overrides, same as `run.start`. |
+| `context` | Aegra extension, same semantics as on `run.start`. |
+| `namespace` | Accepted for protocol compatibility. Interrupt ids already encode the subgraph namespace, so the server does not read it. |
+
+`update` and `goto` fold into the same `Command` as the resume, so the resumed run writes a single checkpoint.
 
 <Note>
   This first release covers the HTTP SSE + commands path the JS/Python SDKs use, verified end-to-end against the stock `langgraph-sdk`. The WebSocket transport and the `agent.getTree` / `state.fork` / `subscription.*` commands are not yet implemented; SSE filtering via the POST body covers the `useStream()` path without them.

--- a/docs/guides/streaming.mdx
+++ b/docs/guides/streaming.mdx
@@ -388,7 +388,7 @@ curl -X POST http://localhost:8000/threads/$THREAD/commands   -H "Content-Type: 
 | `interrupt_id` | Targets one pending interrupt. Omit it only when a single interrupt is pending. |
 | `responses` | Batch form: a list of `{interrupt_id, response}` entries resumed in one run. Replaces `response` and `interrupt_id`. |
 | `update` | State update applied in the same superstep as the resume, as `Command(update=...)`. Must be an object. |
-| `goto` | Node name, `{node, input}` object, or a list of those, applied as `Command(goto=...)`. |
+| `goto` | Node name, `{node}` or `{node, input}` object, or a list of those, applied as `Command(goto=...)`. `input` is optional. |
 | `config`, `metadata` | Per-run overrides, same as `run.start`. |
 | `context` | Aegra extension, same semantics as on `run.start`. |
 | `namespace` | Accepted for protocol compatibility. Interrupt ids already encode the subgraph namespace, so the server does not read it. |

--- a/libs/aegra-api/src/aegra_api/services/event_streaming/commands.py
+++ b/libs/aegra-api/src/aegra_api/services/event_streaming/commands.py
@@ -85,6 +85,54 @@ async def handle_command(
 
 _MULTITASK_STRATEGIES = frozenset({"reject", "rollback", "interrupt", "enqueue"})
 
+# Every key the protocol spec defines for each command, plus the aegra
+# extensions the handlers read. Anything outside these sets is logged, never
+# silently dropped (#452). tests/unit pins these against the spec key list.
+RUN_START_KEYS: frozenset[str] = frozenset(
+    {
+        "assistant_id",
+        "input",
+        "config",
+        "metadata",
+        "langsmith_tracer",
+        "context",
+        "interrupt_before",
+        "interrupt_after",
+        "multitaskStrategy",
+        "multitask_strategy",
+    }
+)
+INPUT_RESPOND_KEYS: frozenset[str] = frozenset(
+    {
+        "interrupt_id",
+        "namespace",
+        "response",
+        "responses",
+        "update",
+        "goto",
+        "config",
+        "metadata",
+        "context",
+        "assistant_id",
+    }
+)
+
+
+def _warn_unknown_keys(method: str, params: dict[str, Any], known: frozenset[str]) -> None:
+    unknown = sorted(set(params) - known)
+    if unknown:
+        logger.warning("Ignoring unknown v2 command params", method=method, keys=unknown)
+
+
+def _context_from_params(params: dict[str, Any]) -> tuple[dict[str, Any] | None, str | None]:
+    """Returns ``(context, None)`` or ``(None, error_message)``."""
+    context = params.get("context")
+    if context is None:
+        return {}, None
+    if not isinstance(context, dict):
+        return None, "context must be an object."
+    return context, None
+
 
 async def _run_start(
     command_id: int,
@@ -95,6 +143,7 @@ async def _run_start(
     user: User,
 ) -> tuple[dict[str, Any], str | None]:
     """Start a run on the thread from ``RunStartParams``."""
+    _warn_unknown_keys("run.start", params, RUN_START_KEYS)
     assistant_id = params.get("assistant_id")
     if not isinstance(assistant_id, str) or not assistant_id:
         return build_error(command_id, "invalid_argument", "run.start requires a string assistant_id."), None
@@ -103,11 +152,9 @@ async def _run_start(
     if multitask is not None and multitask not in _MULTITASK_STRATEGIES:
         return build_error(command_id, "invalid_argument", f"Unknown multitaskStrategy {multitask!r}."), None
 
-    context = params.get("context")
+    context, error_message = _context_from_params(params)
     if context is None:
-        context = {}
-    elif not isinstance(context, dict):
-        return build_error(command_id, "invalid_argument", "context must be an object."), None
+        return build_error(command_id, "invalid_argument", error_message or "invalid params"), None
 
     # run.start with input on an interrupted thread means "answer the pending
     # interrupt" — resume with the input instead of starting a fresh turn that
@@ -166,10 +213,19 @@ async def _input_respond(
     form that works with multiple pending interrupts); the batch ``responses``
     form merges several targets into one resume.
     """
+    _warn_unknown_keys("input.respond", params, INPUT_RESPOND_KEYS)
     resume, error = _build_resume(params)
     if error is not None:
         code, message = error
         return build_error(command_id, code, message), None
+
+    command, error_message = _build_resume_command(params, resume)
+    if command is None:
+        return build_error(command_id, "invalid_argument", error_message or "invalid params"), None
+
+    context, error_message = _context_from_params(params)
+    if context is None:
+        return build_error(command_id, "invalid_argument", error_message or "invalid params"), None
 
     assistant_id = params.get("assistant_id")
     if not isinstance(assistant_id, str) or not assistant_id:
@@ -180,11 +236,38 @@ async def _input_respond(
     request = RunCreate(
         assistant_id=assistant_id,
         config=params.get("config") or {},
+        context=context,
         metadata=params.get("metadata"),
-        command={"resume": resume},
+        command=command,
     )
     run_id = await _start(session, thread_id, request, user)
     return build_success(command_id, {"run_id": run_id}, applied_through_seq=0), run_id
+
+
+def _build_resume_command(params: dict[str, Any], resume: Any) -> tuple[dict[str, Any] | None, str | None]:
+    """Fold ``update`` / ``goto`` into the resume so the run writes one checkpoint.
+
+    Returns ``(command, None)`` or ``(None, error_message)``.
+    """
+    command: dict[str, Any] = {"resume": resume}
+    update = params.get("update")
+    if update is not None:
+        if not isinstance(update, dict):
+            return None, "update must be an object."
+        command["update"] = update
+    goto = params.get("goto")
+    if goto is not None:
+        targets = goto if isinstance(goto, list) else [goto]
+        if not all(_is_goto_target(target) for target in targets):
+            return None, "goto must be a node name, a {node, input} object, or a list of those."
+        command["goto"] = goto
+    return command, None
+
+
+def _is_goto_target(target: Any) -> bool:
+    if isinstance(target, str):
+        return bool(target)
+    return isinstance(target, dict) and isinstance(target.get("node"), str)
 
 
 def _build_resume(params: dict[str, Any]) -> tuple[Any, tuple[ErrorCode, str] | None]:

--- a/libs/aegra-api/src/aegra_api/services/event_streaming/commands.py
+++ b/libs/aegra-api/src/aegra_api/services/event_streaming/commands.py
@@ -85,9 +85,8 @@ async def handle_command(
 
 _MULTITASK_STRATEGIES = frozenset({"reject", "rollback", "interrupt", "enqueue"})
 
-# Every key the protocol spec defines for each command, plus the aegra
-# extensions the handlers read. Anything outside these sets is logged, never
-# silently dropped (#452). tests/unit pins these against the spec key list.
+# Protocol keys plus Aegra extensions per handler. Unknown keys are logged, never
+# silently dropped (#452); test_spec_params.py pins these against the spec.
 RUN_START_KEYS: frozenset[str] = frozenset(
     {
         "assistant_id",
@@ -267,7 +266,7 @@ def _build_resume_command(params: dict[str, Any], resume: Any) -> tuple[dict[str
 def _is_goto_target(target: Any) -> bool:
     if isinstance(target, str):
         return bool(target)
-    return isinstance(target, dict) and isinstance(target.get("node"), str)
+    return isinstance(target, dict) and isinstance(target.get("node"), str) and bool(target["node"])
 
 
 def _build_resume(params: dict[str, Any]) -> tuple[Any, tuple[ErrorCode, str] | None]:

--- a/libs/aegra-api/src/aegra_api/utils/run_utils.py
+++ b/libs/aegra-api/src/aegra_api/utils/run_utils.py
@@ -30,7 +30,7 @@ def map_command_to_langgraph(cmd: dict[str, Any]) -> Command:
 
     return Command(
         update=cmd_update,
-        goto=([it if isinstance(it, str) else Send(it["node"], it["input"]) for it in goto] if goto else None),
+        goto=([it if isinstance(it, str) else Send(it["node"], it.get("input")) for it in goto] if goto else None),
         resume=cmd.get("resume"),
     )
 

--- a/libs/aegra-api/tests/e2e/test_event_streaming/test_sdk_v2_e2e.py
+++ b/libs/aegra-api/tests/e2e/test_event_streaming/test_sdk_v2_e2e.py
@@ -10,6 +10,7 @@ Uses the ``stress_test`` graph (no LLM) so the run is hermetic.
 
 import asyncio
 import json
+import uuid
 from typing import Any
 
 import httpx
@@ -70,6 +71,63 @@ async def test_sdk_thread_stream_run_start_and_events() -> None:
     elog("sdk thread stream methods", methods)
     assert "lifecycle" in methods, f"no lifecycle event received; got {methods}"
     assert "completed" in lifecycle_events, f"run did not complete; lifecycle={lifecycle_events}"
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_input_respond_update_lands_in_thread_state() -> None:
+    """``input.respond`` with ``update`` writes state in the same superstep as the resume.
+
+    The stock SDK's ``respond()`` sends only the response, so the wire body is
+    posted directly. An ``ignore`` response ends the run without another model
+    call, which keeps the assertion on the update alone.
+    """
+    if not await _v2_enabled():
+        pytest.skip("FF_V2_EVENT_STREAMING is disabled on the server under test")
+
+    assistant_id = await _ensure_graph("agent_hitl")
+    client = get_client(url=_base_url())
+    marker = f"resume-marker-{uuid.uuid4()}"
+
+    lifecycle_after_resume: list[str] = []
+    resumed = False
+    async with client.threads.stream(assistant_id=assistant_id) as ts:
+        await ts.run.start(
+            input={"messages": [{"role": "user", "content": "Search the web for the latest LangGraph release."}]}
+        )
+        async for event in ts.events:
+            method = event.get("method")
+            data = event.get("params", {}).get("data") or {}
+            if method == "input.requested" and not resumed:
+                async with httpx.AsyncClient(base_url=_base_url(), timeout=10.0) as http:
+                    response = await http.post(
+                        f"/threads/{ts.thread_id}/commands",
+                        json={
+                            "id": 7,
+                            "method": "input.respond",
+                            "params": {
+                                "interrupt_id": data["interrupt_id"],
+                                "namespace": [],
+                                "response": [{"type": "ignore"}],
+                                "update": {"messages": [{"role": "system", "content": marker}]},
+                            },
+                        },
+                    )
+                assert response.status_code == 200
+                assert response.json()["type"] == "success", response.json()
+                resumed = True
+                continue
+            if resumed and method == "lifecycle":
+                lifecycle_after_resume.append(data.get("event"))
+                if data.get("event") in ("completed", "failed"):
+                    break
+        thread_id = ts.thread_id
+
+    elog("input.respond update lifecycle", lifecycle_after_resume)
+    assert "completed" in lifecycle_after_resume, lifecycle_after_resume
+    state = await client.threads.get_state(thread_id)
+    contents = [message.get("content") for message in state["values"]["messages"]]
+    assert marker in contents, contents
 
 
 @pytest.mark.e2e

--- a/libs/aegra-api/tests/e2e/test_event_streaming/test_sdk_v2_e2e.py
+++ b/libs/aegra-api/tests/e2e/test_event_streaming/test_sdk_v2_e2e.py
@@ -78,9 +78,7 @@ async def test_sdk_thread_stream_run_start_and_events() -> None:
 async def test_input_respond_update_lands_in_thread_state() -> None:
     """``input.respond`` with ``update`` writes state in the same superstep as the resume.
 
-    The stock SDK's ``respond()`` sends only the response, so the wire body is
-    posted directly. An ``ignore`` response ends the run without another model
-    call, which keeps the assertion on the update alone.
+    Raw wire body because the SDK's ``respond()`` has no ``update`` argument.
     """
     if not await _v2_enabled():
         pytest.skip("FF_V2_EVENT_STREAMING is disabled on the server under test")
@@ -108,6 +106,7 @@ async def test_input_respond_update_lands_in_thread_state() -> None:
                             "params": {
                                 "interrupt_id": data["interrupt_id"],
                                 "namespace": [],
+                                # ignore ends the run without another model call.
                                 "response": [{"type": "ignore"}],
                                 "update": {"messages": [{"role": "system", "content": marker}]},
                             },

--- a/libs/aegra-api/tests/integration/test_api/test_event_streaming.py
+++ b/libs/aegra-api/tests/integration/test_api/test_event_streaming.py
@@ -8,6 +8,7 @@ import uuid
 from collections.abc import Iterator
 from functools import partial
 from typing import Any
+from unittest.mock import AsyncMock
 
 import pytest
 from fastapi import FastAPI
@@ -112,6 +113,60 @@ class TestCommandRoute:
             "meta": {"applied_through_seq": 0},
         }
         assert captured_requests[0].context == {"tenant_id": "acme"}
+
+    def test_input_respond_forwards_update_goto_and_context(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured_requests: list[RunCreate] = []
+
+        async def fake_prepare(*_args: Any, **_kwargs: Any) -> tuple[str, object, object]:
+            captured_requests.append(_args[2])
+            return "run-2", object(), object()
+
+        monkeypatch.setattr(cmd_module, "_prepare_run", fake_prepare)
+        client = TestClient(_make_app(monkeypatch))
+
+        resp = client.post(
+            "/threads/t1/commands",
+            json={
+                "id": 2,
+                "method": "input.respond",
+                "params": {
+                    "assistant_id": "agent",
+                    "interrupt_id": "a" * 32,
+                    "namespace": [],
+                    "response": {"approved": True},
+                    "update": {"reviewed_by": "alice"},
+                    "goto": "finalize",
+                    "context": {"reasoning_effort": "high"},
+                },
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.json()["type"] == "success"
+        request = captured_requests[0]
+        assert request.command == {
+            "resume": {"a" * 32: {"approved": True}},
+            "update": {"reviewed_by": "alice"},
+            "goto": "finalize",
+        }
+        assert request.context == {"reasoning_effort": "high"}
+
+    def test_input_respond_rejects_non_object_update(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        prepare = AsyncMock()
+        monkeypatch.setattr(cmd_module, "_prepare_run", prepare)
+        client = TestClient(_make_app(monkeypatch))
+
+        resp = client.post(
+            "/threads/t1/commands",
+            json={
+                "id": 3,
+                "method": "input.respond",
+                "params": {"assistant_id": "agent", "response": 1, "update": ["not", "an", "object"]},
+            },
+        )
+        assert resp.status_code == 200
+        assert resp.json()["type"] == "error"
+        assert resp.json()["error"] == "invalid_argument"
+        prepare.assert_not_called()
 
     def test_unknown_command_returns_error_envelope_on_200(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Protocol errors ride HTTP 200 so envelope-parsing clients see the code."""

--- a/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_commands.py
+++ b/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_commands.py
@@ -1,7 +1,7 @@
 """Tests for v2 command dispatch (run.start, input.respond, errors)."""
 
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -245,6 +245,123 @@ class TestInputRespond:
         )
         assert resp["error"] == "invalid_argument"
         prepared_run.assert_not_called()
+
+
+class TestInputRespondCommandFields:
+    """update / goto / context ride along with the resume (protocol InputRespondParams)."""
+
+    async def test_input_respond_folds_update_and_goto_into_command(self, prepared_run: AsyncMock, user: User) -> None:
+        resp, _ = await _dispatch(
+            {
+                "id": 2,
+                "method": "input.respond",
+                "params": {
+                    "assistant_id": "agent",
+                    "response": "approve",
+                    "update": {"approved": True},
+                    "goto": "finalize",
+                },
+            },
+            user,
+        )
+        assert resp["type"] == "success"
+        assert prepared_run.call_args.args[2].command == {
+            "resume": "approve",
+            "update": {"approved": True},
+            "goto": "finalize",
+        }
+
+    async def test_input_respond_accepts_send_objects_in_goto(self, prepared_run: AsyncMock, user: User) -> None:
+        goto = [{"node": "tool", "input": {"call": 1}}, {"node": "summarize"}]
+        resp, _ = await _dispatch(
+            {"id": 2, "method": "input.respond", "params": {"assistant_id": "agent", "response": 1, "goto": goto}},
+            user,
+        )
+        assert resp["type"] == "success"
+        assert prepared_run.call_args.args[2].command["goto"] == goto
+
+    async def test_input_respond_omits_update_and_goto_when_absent(self, prepared_run: AsyncMock, user: User) -> None:
+        await _dispatch({"id": 2, "method": "input.respond", "params": {"assistant_id": "agent", "response": 1}}, user)
+        assert prepared_run.call_args.args[2].command == {"resume": 1}
+
+    async def test_input_respond_non_object_update_is_invalid(self, prepared_run: AsyncMock, user: User) -> None:
+        resp, run_id = await _dispatch(
+            {"id": 2, "method": "input.respond", "params": {"assistant_id": "agent", "response": 1, "update": "x"}},
+            user,
+        )
+        assert resp["error"] == "invalid_argument"
+        assert run_id is None
+        prepared_run.assert_not_called()
+
+    @pytest.mark.parametrize("goto", [42, "", {"input": {}}, ["ok", 7]])
+    async def test_input_respond_malformed_goto_is_invalid(
+        self, prepared_run: AsyncMock, user: User, goto: Any
+    ) -> None:
+        resp, _ = await _dispatch(
+            {"id": 2, "method": "input.respond", "params": {"assistant_id": "agent", "response": 1, "goto": goto}},
+            user,
+        )
+        assert resp["error"] == "invalid_argument"
+        prepared_run.assert_not_called()
+
+    async def test_input_respond_forwards_context(self, prepared_run: AsyncMock, user: User) -> None:
+        await _dispatch(
+            {
+                "id": 2,
+                "method": "input.respond",
+                "params": {"assistant_id": "agent", "response": 1, "context": {"reasoning_effort": "high"}},
+            },
+            user,
+        )
+        assert prepared_run.call_args.args[2].context == {"reasoning_effort": "high"}
+
+    async def test_input_respond_omitted_context_is_empty(self, prepared_run: AsyncMock, user: User) -> None:
+        await _dispatch({"id": 2, "method": "input.respond", "params": {"assistant_id": "agent", "response": 1}}, user)
+        assert prepared_run.call_args.args[2].context == {}
+
+    async def test_input_respond_non_object_context_is_invalid(self, prepared_run: AsyncMock, user: User) -> None:
+        resp, _ = await _dispatch(
+            {"id": 2, "method": "input.respond", "params": {"assistant_id": "agent", "response": 1, "context": "x"}},
+            user,
+        )
+        assert resp["error"] == "invalid_argument"
+        prepared_run.assert_not_called()
+
+
+class TestUnknownParamKeys:
+    """Keys outside the handler's declared set are logged, never dropped in silence."""
+
+    @pytest.mark.parametrize(
+        ("method", "params"),
+        [
+            ("run.start", {"assistant_id": "agent", "input": {}, "webhook": "https://x", "durability": "sync"}),
+            ("input.respond", {"assistant_id": "agent", "response": 1, "webhook": "https://x", "durability": "sync"}),
+        ],
+    )
+    async def test_unknown_keys_are_logged_with_names(
+        self, prepared_run: AsyncMock, user: User, monkeypatch: pytest.MonkeyPatch, method: str, params: dict
+    ) -> None:
+        warning = MagicMock()
+        monkeypatch.setattr(cmd.logger, "warning", warning)
+        resp, _ = await _dispatch({"id": 1, "method": method, "params": params}, user)
+        assert resp["type"] == "success"
+        warning.assert_called_once()
+        assert warning.call_args.kwargs == {"method": method, "keys": ["durability", "webhook"]}
+
+    async def test_declared_keys_are_not_logged(
+        self, prepared_run: AsyncMock, user: User, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        warning = MagicMock()
+        monkeypatch.setattr(cmd.logger, "warning", warning)
+        await _dispatch(
+            {
+                "id": 1,
+                "method": "input.respond",
+                "params": {"interrupt_id": "a" * 32, "namespace": [], "response": 1, "assistant_id": "agent"},
+            },
+            user,
+        )
+        warning.assert_not_called()
 
 
 class TestErrors:

--- a/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_commands.py
+++ b/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_commands.py
@@ -293,7 +293,7 @@ class TestInputRespondCommandFields:
         assert run_id is None
         prepared_run.assert_not_called()
 
-    @pytest.mark.parametrize("goto", [42, "", {"input": {}}, ["ok", 7]])
+    @pytest.mark.parametrize("goto", [42, "", {"input": {}}, {"node": ""}, ["ok", 7]])
     async def test_input_respond_malformed_goto_is_invalid(
         self, prepared_run: AsyncMock, user: User, goto: Any
     ) -> None:

--- a/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_spec_params.py
+++ b/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_spec_params.py
@@ -1,0 +1,124 @@
+"""Pin v2 command handlers to the Agent Protocol param shapes.
+
+The key sets below are copied from ``RunStartParams`` / ``InputRespondOne`` /
+``InputRespondMany`` in the public protocol spec (langchain-ai/agent-protocol,
+``streaming/js/protocol.ts``). When the spec grows a key, add it here first;
+the tests then fail until the handler forwards it or lists it as a no-op.
+"""
+
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from aegra_api.models import User
+from aegra_api.services.event_streaming import commands as cmd
+
+SPEC_RUN_START_KEYS: frozenset[str] = frozenset({"assistant_id", "input", "config", "metadata", "langsmith_tracer"})
+SPEC_INPUT_RESPOND_ONE_KEYS: frozenset[str] = frozenset(
+    {"namespace", "interrupt_id", "response", "update", "goto", "config", "metadata"}
+)
+SPEC_INPUT_RESPOND_MANY_KEYS: frozenset[str] = frozenset({"responses", "update", "goto", "config", "metadata"})
+
+# Spec keys the server reads for validation only or has no backend for.
+# Each one is documented in docs/guides/streaming.mdx.
+DOCUMENTED_NOOP_KEYS: frozenset[str] = frozenset(
+    {
+        "langsmith_tracer",  # LangSmith-side routing; tracing here is OpenTelemetry.
+        "namespace",  # interrupt ids are namespace hashes, so the id alone targets the resume.
+    }
+)
+
+
+@pytest.fixture
+def prepared_run(monkeypatch: pytest.MonkeyPatch) -> AsyncMock:
+    mock = AsyncMock(return_value=("run-1", object(), object()))
+    monkeypatch.setattr(cmd, "_prepare_run", mock)
+    return mock
+
+
+async def _dispatch(method: str, params: dict[str, Any]) -> tuple[dict[str, Any], str | None]:
+    return await cmd.handle_command(
+        {"id": 1, "method": method, "params": params}, session=AsyncMock(), thread_id="t1", user=User(identity="u1")
+    )
+
+
+class TestDeclaredKeysCoverSpec:
+    def test_run_start_declares_every_spec_key(self) -> None:
+        assert SPEC_RUN_START_KEYS <= cmd.RUN_START_KEYS
+
+    def test_input_respond_declares_every_spec_key(self) -> None:
+        assert SPEC_INPUT_RESPOND_ONE_KEYS | SPEC_INPUT_RESPOND_MANY_KEYS <= cmd.INPUT_RESPOND_KEYS
+
+
+class TestEverySpecKeyChangesTheRun:
+    """A spec key must either land on the RunCreate or be an explicit no-op."""
+
+    async def test_run_start_forwards_all_spec_keys(self, prepared_run: AsyncMock) -> None:
+        params: dict[str, Any] = {
+            "assistant_id": "agent",
+            "input": {"messages": [1]},
+            "config": {"recursion_limit": 7},
+            "metadata": {"source": "spec"},
+            "langsmith_tracer": {"project_name": "p"},
+        }
+        assert set(params) == SPEC_RUN_START_KEYS
+
+        resp, _ = await _dispatch("run.start", params)
+
+        assert resp["type"] == "success"
+        request = prepared_run.call_args.args[2]
+        assert request.assistant_id == "agent"
+        assert request.input == {"messages": [1]}
+        assert request.config == {"recursion_limit": 7}
+        assert request.metadata == {"source": "spec"}
+        assert SPEC_RUN_START_KEYS - set(request.model_fields) <= DOCUMENTED_NOOP_KEYS
+
+    async def test_input_respond_one_forwards_all_spec_keys(self, prepared_run: AsyncMock) -> None:
+        params: dict[str, Any] = {
+            "namespace": ["child"],
+            "interrupt_id": "a" * 32,
+            "response": {"ok": True},
+            "update": {"flag": 1},
+            "goto": "next",
+            "config": {"recursion_limit": 7},
+            "metadata": {"source": "spec"},
+            "assistant_id": "agent",
+        }
+        assert set(params) - {"assistant_id"} == SPEC_INPUT_RESPOND_ONE_KEYS
+
+        resp, _ = await _dispatch("input.respond", params)
+
+        assert resp["type"] == "success"
+        request = prepared_run.call_args.args[2]
+        assert request.command == {"resume": {"a" * 32: {"ok": True}}, "update": {"flag": 1}, "goto": "next"}
+        assert request.config == {"recursion_limit": 7}
+        assert request.metadata == {"source": "spec"}
+
+    async def test_input_respond_many_forwards_all_spec_keys(self, prepared_run: AsyncMock) -> None:
+        id_a, id_b = "a" * 32, "b" * 32
+        params: dict[str, Any] = {
+            "responses": [{"interrupt_id": id_a, "response": 1}, {"interrupt_id": id_b, "response": 2}],
+            "update": {"flag": 1},
+            "goto": [{"node": "n", "input": {}}],
+            "config": {"recursion_limit": 7},
+            "metadata": {"source": "spec"},
+            "assistant_id": "agent",
+        }
+        assert set(params) - {"assistant_id"} == SPEC_INPUT_RESPOND_MANY_KEYS
+
+        resp, _ = await _dispatch("input.respond", params)
+
+        assert resp["type"] == "success"
+        request = prepared_run.call_args.args[2]
+        assert request.command == {
+            "resume": {id_a: 1, id_b: 2},
+            "update": {"flag": 1},
+            "goto": [{"node": "n", "input": {}}],
+        }
+        assert request.config == {"recursion_limit": 7}
+        assert request.metadata == {"source": "spec"}
+
+    def test_noop_keys_are_spec_keys(self) -> None:
+        all_spec = SPEC_RUN_START_KEYS | SPEC_INPUT_RESPOND_ONE_KEYS | SPEC_INPUT_RESPOND_MANY_KEYS
+        assert all_spec >= DOCUMENTED_NOOP_KEYS

--- a/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_spec_params.py
+++ b/libs/aegra-api/tests/unit/test_services/test_event_streaming/test_spec_params.py
@@ -1,9 +1,7 @@
 """Pin v2 command handlers to the Agent Protocol param shapes.
 
-The key sets below are copied from ``RunStartParams`` / ``InputRespondOne`` /
-``InputRespondMany`` in the public protocol spec (langchain-ai/agent-protocol,
-``streaming/js/protocol.ts``). When the spec grows a key, add it here first;
-the tests then fail until the handler forwards it or lists it as a no-op.
+Key sets mirror langchain-ai/agent-protocol ``streaming/js/protocol.ts``; a new
+spec key added here fails until the handler forwards it or lists it as a no-op.
 """
 
 from typing import Any

--- a/libs/aegra-api/tests/unit/test_utils/test_run_utils.py
+++ b/libs/aegra-api/tests/unit/test_utils/test_run_utils.py
@@ -81,3 +81,24 @@ async def test_filter_with_empty_properties_returns_context():
     result = await run_utils._filter_context_by_schema(context, schema)
     # no properties defined -> do not filter
     assert result == context
+
+
+class TestMapCommandToLangGraph:
+    def test_goto_send_without_input_maps_to_none_input(self) -> None:
+        from langgraph.types import Send
+
+        from aegra_api.utils.run_utils import map_command_to_langgraph
+
+        command = map_command_to_langgraph({"resume": 1, "goto": [{"node": "tool"}, "plain"]})
+
+        assert command.resume == 1
+        assert command.goto == [Send("tool", None), "plain"]
+
+    def test_goto_send_with_input_keeps_input(self) -> None:
+        from langgraph.types import Send
+
+        from aegra_api.utils.run_utils import map_command_to_langgraph
+
+        command = map_command_to_langgraph({"goto": {"node": "tool", "input": {"k": 1}}})
+
+        assert command.goto == [Send("tool", {"k": 1})]

--- a/libs/aegra-api/tests/unit/test_utils/test_run_utils.py
+++ b/libs/aegra-api/tests/unit/test_utils/test_run_utils.py
@@ -1,4 +1,7 @@
 import pytest
+from langgraph.types import Send
+
+from aegra_api.utils.run_utils import map_command_to_langgraph
 
 
 def test_merge_jsonb_and_should_skip_event():
@@ -85,20 +88,12 @@ async def test_filter_with_empty_properties_returns_context():
 
 class TestMapCommandToLangGraph:
     def test_goto_send_without_input_maps_to_none_input(self) -> None:
-        from langgraph.types import Send
-
-        from aegra_api.utils.run_utils import map_command_to_langgraph
-
         command = map_command_to_langgraph({"resume": 1, "goto": [{"node": "tool"}, "plain"]})
 
         assert command.resume == 1
         assert command.goto == [Send("tool", None), "plain"]
 
     def test_goto_send_with_input_keeps_input(self) -> None:
-        from langgraph.types import Send
-
-        from aegra_api.utils.run_utils import map_command_to_langgraph
-
         command = map_command_to_langgraph({"goto": {"node": "tool", "input": {"k": 1}}})
 
         assert command.goto == [Send("tool", {"k": 1})]


### PR DESCRIPTION
## Description

`input.respond` built its resume `Command` from the response alone. The Agent Protocol `InputRespondParams` also carry `update` and `goto`, and #498 added `context` to `run.start` but not here. All three were dropped without a trace, the same failure class as #452.

Changes:

- `update` and `goto` fold into the same `Command` as the resume, so the resumed run writes a single checkpoint. Malformed shapes (`update` not an object, `goto` not a node name / `{node, input}` / list of those) return `invalid_argument`.
- `context` on `input.respond` gets the same treatment as on `run.start`, through a shared helper.
- Both handlers now declare their accepted key set. Any other key is logged at warning level with its name instead of vanishing.
- `goto` `Send` targets no longer require `input`, matching the spec where it is optional.

## Guard against recurrence

`tests/unit/test_services/test_event_streaming/test_spec_params.py` vendors the key lists from the public protocol spec (`RunStartParams`, `InputRespondOne`, `InputRespondMany`) and asserts each key is either forwarded onto `RunCreate` or listed as a documented no-op (`langsmith_tracer`, `namespace`). Adding a key to the spec list without handling it fails CI.

## Related Issues

- Follow-up to #452 / #498 (the `input.respond` half the reporter called out)
- Part of the compatibility work discussed in #503

## Testing

- Unit: field forwarding, each invalid shape, unknown-key logging, spec coverage, `Send` mapping.
- Integration: `POST /threads/{id}/commands` forwards `update` / `goto` / `context`; non-object `update` returns an error envelope.
- E2E: new `test_input_respond_update_lands_in_thread_state` resumes a real HITL interrupt with `update` and asserts the value in thread state. Full v2 e2e module green against a live server in both prod mode (Redis workers) and dev mode.
- Full non-e2e suite: 1990 passed.

## Docs

- `docs/guides/streaming.mdx`: new "Responding to an interrupt" section with the param table, plus a note that `context` is an Aegra extension and `config.configurable` is the portable form.
- `docs/feature-support.mdx`: resume with `update` / `goto` row.

No version bump, releases are batched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `input.respond` supports applying state updates and directed jumps while resuming interrupted runs.
  * Resume requests support forwarding context and handling multiple responses.
  * Directed jumps can target nodes with or without input data.
  * Added documentation covering human-in-the-loop resume options and streaming behavior.

* **Bug Fixes**
  * Invalid update, context, and jump parameters are now rejected.
  * Unknown command parameters are logged and ignored.
  * Directed jumps without input no longer cause errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->







<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR corrects v2 `input.respond` command construction and improves protocol compatibility.
- Forwards `update`, `goto`, and `context` while resuming interrupted runs.
- Validates malformed state updates, contexts, and directed-jump targets.
- Supports `Send` targets whose optional input is omitted.
- Warns when unsupported command parameters would otherwise be silently ignored.
- Adds unit, integration, end-to-end, protocol-coverage, and documentation updates.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; the previous actionable findings are resolved and no new defects remain.

Object-form jump targets now reject empty node names, explanatory comments comply with the line limit, and test imports are at module scope. The version-bump concern was correctly withdrawn after ibbybuilds explained that maintainers batch version updates at release time.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/services/event_streaming/commands.py | Validates and forwards resume updates, directed jumps, context, and recognized protocol keys. |
| libs/aegra-api/src/aegra_api/utils/run_utils.py | Maps object-form jump targets without input to `Send(node, None)`. |
| libs/aegra-api/tests/unit/test_services/test_event_streaming/test_commands.py | Covers forwarding, invalid inputs, empty node rejection, context handling, and unknown-key warnings. |
| libs/aegra-api/tests/unit/test_services/test_event_streaming/test_spec_params.py | Pins supported command keys to the public protocol parameter sets. |
| libs/aegra-api/tests/integration/test_api/test_event_streaming.py | Verifies HTTP-level forwarding and invalid-update rejection. |
| libs/aegra-api/tests/e2e/test_event_streaming/test_sdk_v2_e2e.py | Verifies that an update supplied during interrupt response reaches persisted thread state. |
| docs/guides/streaming.mdx | Documents interrupt-response parameters, context behavior, and unknown-key handling. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Commands as v2 Command Handler
    participant Run as RunCreate
    participant Graph as LangGraph

    Client->>Commands: input.respond(response, update, goto, context)
    Commands->>Commands: Validate resume fields and context
    Commands->>Run: "command={resume, update, goto}, context=context"
    Run->>Graph: Resume interrupted run
    Graph-->>Client: Updated state and lifecycle events
```
</details>

<sub>Reviews (4): Last reviewed commit: ["test: tighten docstrings to two lines"](https://github.com/aegra/aegra/commit/3127467cf1a4fdfa6de5700214cdcab99982bf39) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60723716)</sub>

<!-- /greptile_comment -->