### PR TITLE
feat(api): add POST /runs/cancel for bulk cancellation

### DIFF
--- a/docs/feature-support.mdx
+++ b/docs/feature-support.mdx
@@ -51,6 +51,7 @@ description: "What Aegra supports today, what's coming soon, and what's not yet 
 | Concurrent execution | Supported | Up to `N_JOBS_PER_WORKER` (default 10) concurrent runs per worker. |
 | Lease-based crash recovery | Supported | Automatic re-execution of runs from crashed workers via checkpoint resumption. |
 | Cross-instance cancel | Supported | Cancel propagates via Redis pub/sub to any instance. |
+| Bulk cancel | Supported | `POST /runs/cancel` by status or by thread and run ids; SDK `cancel_many`. |
 | Job timeout | Supported | Configurable max execution time (default 1 hour). |
 | Postgres fallback | Supported | Workers fall back to DB polling when Redis is unavailable. |
 | Multi-instance SSE | Supported | SSE streams work across instances via Redis broker. |

--- a/docs/guides/authentication.mdx
+++ b/docs/guides/authentication.mdx
@@ -166,7 +166,7 @@ as their parent, so one rule covers a whole family of endpoints:
 | Handler | Also covers |
 |---------|-------------|
 | `@auth.on.threads.read` | `GET /threads/{id}`, `/state`, `/state/{checkpoint_id}`, `/history`, `GET` a run, its `/join` and `/stream` |
-| `@auth.on.threads.update` | `PATCH /threads/{id}`, `POST /threads/{id}/state`, `PATCH` a run, `POST .../runs/{id}/cancel` |
+| `@auth.on.threads.update` | `PATCH /threads/{id}`, `POST /threads/{id}/state`, `PATCH` a run, `POST .../runs/{id}/cancel`, `POST /runs/cancel` |
 | `@auth.on.threads.delete` | `DELETE /threads/{id}`, `DELETE` a run |
 | `@auth.on.threads.create_run` | `POST /threads/{id}/runs`, `/runs/stream`, `/runs/wait`, `/threads/{id}/commands`, and the stateless `POST /runs`, `/runs/stream`, `/runs/wait` |
 | `@auth.on.threads.search` | `GET /threads`, `POST /threads/search`, `GET /threads/{id}/runs` |

--- a/docs/guides/streaming.mdx
+++ b/docs/guides/streaming.mdx
@@ -246,6 +246,20 @@ Cancellation is asynchronous while a live worker owns the run.
 The cancel response may therefore still show `pending` or `running`; poll, join, or stream the run until it reaches a terminal status.
 Use the REST endpoint with `wait=1` when the caller needs the request to wait briefly for the worker to settle.
 
+### Cancelling several runs
+
+`POST /runs/cancel` cancels many runs in one call. Select them by `thread_id` plus `run_ids`, or by status (`pending`, `running`, or `all`). The SDK exposes it as `cancel_many`:
+
+```python
+# Stop specific runs on a thread
+await client.runs.cancel_many(thread_id=thread_id, run_ids=[run_a, run_b], action="interrupt")
+
+# Stop every active run you own
+await client.runs.cancel_many(status="all")
+```
+
+Runs that already finished are skipped, and only the caller's runs are affected. `action` accepts `cancel` and `interrupt`, the same values as the per-run endpoint. The response is `204 No Content`.
+
 ## SSE reconnection
 
 Aegra stores streaming events in a replay buffer (Redis Lists when `REDIS_BROKER_ENABLED=true`, in-memory list in dev mode) for replay. If your connection drops:

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2383,6 +2383,69 @@
         }
       }
     },
+    "/runs/cancel": {
+      "post": {
+        "tags": [
+          "Thread Runs"
+        ],
+        "summary": "Cancel Runs",
+        "description": "Cancel several runs at once, by status or by thread_id plus run_ids.\n\nRuns the caller does not own or that already finished are skipped. The\nthread must exist for the run_ids form; unknown run ids are ignored.",
+        "operationId": "cancel_runs_runs_cancel_post",
+        "parameters": [
+          {
+            "name": "action",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "enum": [
+                "cancel",
+                "interrupt"
+              ],
+              "type": "string",
+              "description": "Cancellation strategy: 'cancel' for hard cancel, 'interrupt' for cooperative interrupt.",
+              "default": "interrupt",
+              "title": "Action"
+            },
+            "description": "Cancellation strategy: 'cancel' for hard cancel, 'interrupt' for cooperative interrupt."
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RunsCancel"
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentProtocolError"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/runs/wait": {
       "post": {
         "tags": [
@@ -4896,6 +4959,57 @@
         ],
         "title": "RunStatus",
         "description": "Simple run status response"
+      },
+      "RunsCancel": {
+        "properties": {
+          "status": {
+            "anyOf": [
+              {
+                "type": "string",
+                "enum": [
+                  "pending",
+                  "running",
+                  "all"
+                ]
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status",
+            "description": "Cancel every active run of the caller in this status. 'all' means pending and running."
+          },
+          "thread_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Thread Id",
+            "description": "Thread that owns the runs listed in run_ids."
+          },
+          "run_ids": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Run Ids",
+            "description": "Runs to cancel; requires thread_id."
+          }
+        },
+        "type": "object",
+        "title": "RunsCancel",
+        "description": "Selector for ``POST /runs/cancel``: a status filter, or thread_id plus run_ids."
       },
       "StoreDeleteRequest": {
         "properties": {

--- a/libs/aegra-api/src/aegra_api/api/runs.py
+++ b/libs/aegra-api/src/aegra_api/api/runs.py
@@ -20,7 +20,7 @@ from aegra_api.core.orm import Run as RunORM
 from aegra_api.core.orm import Thread as ThreadORM
 from aegra_api.core.orm import _get_session_maker, get_session
 from aegra_api.core.sse import create_end_event, get_sse_headers, make_sse_response, sse_to_bytes
-from aegra_api.models import Run, RunCreate, RunStatus, User
+from aegra_api.models import Run, RunCreate, RunsCancel, RunStatus, User
 from aegra_api.models.enums import RunCancellationAction
 from aegra_api.models.errors import CONFLICT, NOT_FOUND, SSE_RESPONSE
 from aegra_api.services.broker import broker_manager
@@ -527,6 +527,47 @@ async def cancel_run_endpoint(
 
     await session.refresh(run_orm)
     return Run.model_validate(run_orm)
+
+
+@router.post("/runs/cancel", status_code=204, responses={**NOT_FOUND})
+async def cancel_runs(
+    request: RunsCancel,
+    action: RunCancellationAction = Query(
+        "interrupt",
+        description="Cancellation strategy: 'cancel' for hard cancel, 'interrupt' for cooperative interrupt.",
+    ),
+    user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_session),
+) -> None:
+    """Cancel several runs at once, by status or by thread_id plus run_ids.
+
+    Runs the caller does not own or that already finished are skipped. The
+    thread must exist for the run_ids form; unknown run ids are ignored.
+    """
+    stmt = select(RunORM).where(RunORM.user_id == user.identity)
+    if request.status is not None:
+        active = ["pending", "running"] if request.status == "all" else [request.status]
+        stmt = stmt.where(RunORM.status.in_(active))
+    else:
+        thread_exists = await session.scalar(
+            select(ThreadORM.thread_id).where(
+                ThreadORM.thread_id == request.thread_id, ThreadORM.user_id == user.identity
+            )
+        )
+        if not thread_exists:
+            raise HTTPException(404, f"Thread '{request.thread_id}' not found")
+        stmt = stmt.where(RunORM.thread_id == request.thread_id, RunORM.run_id.in_(request.run_ids or []))
+
+    runs = (await session.scalars(stmt)).all()
+    logger.info(
+        "[cancel_runs] bulk cancel",
+        action=action,
+        user=user.identity,
+        selector=request.model_dump(exclude_none=True),
+        count=len(runs),
+    )
+    for run_orm in runs:
+        await _request_run_interruption(session, run_orm, action)
 
 
 @router.delete(

--- a/libs/aegra-api/src/aegra_api/core/auth_registry.py
+++ b/libs/aegra-api/src/aegra_api/core/auth_registry.py
@@ -67,6 +67,7 @@ ROUTE_AUTH_MAP: Final[dict[tuple[str, str], tuple[str, str]]] = {
     # These mint an ephemeral thread, so they authorize as a thread create_run
     # exactly like their threaded counterparts.
     ("POST", "/runs"): ("threads", "create_run"),
+    ("POST", "/runs/cancel"): ("threads", "update"),
     ("POST", "/runs/stream"): ("threads", "create_run"),
     ("POST", "/runs/wait"): ("threads", "create_run"),
     # --- crons --------------------------------------------------------------

--- a/libs/aegra-api/src/aegra_api/models/__init__.py
+++ b/libs/aegra-api/src/aegra_api/models/__init__.py
@@ -17,7 +17,7 @@ from aegra_api.models.crons import (
     CronUpdate,
 )
 from aegra_api.models.errors import AgentProtocolError, get_error_type
-from aegra_api.models.runs import Run, RunCreate, RunStatus
+from aegra_api.models.runs import Run, RunCreate, RunsCancel, RunStatus
 from aegra_api.models.store import (
     StoreDeleteRequest,
     StoreGetResponse,
@@ -70,6 +70,7 @@ __all__ = [
     # Runs
     "Run",
     "RunCreate",
+    "RunsCancel",
     "RunStatus",
     # Crons
     "CronCreate",

--- a/libs/aegra-api/src/aegra_api/models/runs.py
+++ b/libs/aegra-api/src/aegra_api/models/runs.py
@@ -141,6 +141,24 @@ class RunCreate(BaseModel):
         return self
 
 
+class RunsCancel(BaseModel):
+    """Selector for ``POST /runs/cancel``: a status filter, or thread_id plus run_ids."""
+
+    status: Literal["pending", "running", "all"] | None = Field(
+        None, description="Cancel every active run of the caller in this status. 'all' means pending and running."
+    )
+    thread_id: str | None = Field(None, description="Thread that owns the runs listed in run_ids.")
+    run_ids: list[str] | None = Field(None, description="Runs to cancel; requires thread_id.")
+
+    @model_validator(mode="after")
+    def validate_exactly_one_selector(self) -> Self:
+        by_status = self.status is not None
+        by_ids = self.thread_id is not None and self.run_ids is not None
+        if by_status == by_ids:
+            raise ValueError("Provide either 'status' or both 'thread_id' and 'run_ids'")
+        return self
+
+
 class Run(BaseModel):
     """Run entity model
 

--- a/libs/aegra-api/src/aegra_api/models/runs.py
+++ b/libs/aegra-api/src/aegra_api/models/runs.py
@@ -152,9 +152,12 @@ class RunsCancel(BaseModel):
 
     @model_validator(mode="after")
     def validate_exactly_one_selector(self) -> Self:
+        """Reject a half-filled selector: the handler reads one branch and would
+        ignore the rest, so {status, thread_id} would cancel every matching run."""
         by_status = self.status is not None
-        by_ids = self.thread_id is not None and self.run_ids is not None
-        if by_status == by_ids:
+        complete_ids = self.thread_id is not None and self.run_ids is not None
+        any_ids = self.thread_id is not None or self.run_ids is not None
+        if by_status == any_ids or (any_ids and not complete_ids):
             raise ValueError("Provide either 'status' or both 'thread_id' and 'run_ids'")
         return self
 

--- a/libs/aegra-api/tests/e2e/test_runs/test_cancel_run_e2e.py
+++ b/libs/aegra-api/tests/e2e/test_runs/test_cancel_run_e2e.py
@@ -314,3 +314,64 @@ async def test_cancel_with_wait_flag():
     # If the run was still running when we cancelled, it should be interrupted
     # If it already completed, it would be success
     assert final_run["status"] in ("interrupted", "error", "success")
+
+
+async def _start_slow_run(client, assistant_id: str) -> tuple[str, str]:
+    thread = await client.threads.create()
+    run = await client.runs.create(
+        thread["thread_id"],
+        assistant_id,
+        input={"messages": [{"role": "user", "content": '{"delay": 1.0, "steps": 30}'}]},
+    )
+    return thread["thread_id"], run["run_id"]
+
+
+async def _wait_terminal(client, thread_id: str, run_id: str, timeout: float = 15.0) -> str:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        run = await client.runs.get(thread_id, run_id)
+        if run["status"] not in ("pending", "running"):
+            return run["status"]
+        await asyncio.sleep(0.5)
+    return (await client.runs.get(thread_id, run_id))["status"]
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_cancel_many_by_thread_and_run_ids():
+    """``runs.cancel_many(thread_id, run_ids)`` hits POST /runs/cancel and stops the listed runs only."""
+    client = get_e2e_client()
+    assistant = await client.assistants.create(graph_id="stress_test", if_exists="do_nothing")
+    assistant_id = assistant["assistant_id"]
+
+    thread_id, run_a = await _start_slow_run(client, assistant_id)
+    other_thread, run_b = await _start_slow_run(client, assistant_id)
+    await asyncio.sleep(1.0)
+
+    await client.runs.cancel_many(thread_id=thread_id, run_ids=[run_a], action="interrupt")
+
+    status_a = await _wait_terminal(client, thread_id, run_a)
+    elog("cancel_many by ids", {"run_a": status_a})
+    assert status_a == "interrupted"
+
+    untouched = await client.runs.get(other_thread, run_b)
+    assert untouched["status"] in ("pending", "running"), untouched["status"]
+    await client.runs.cancel(other_thread, run_b, action="cancel")
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_cancel_many_by_status_cancels_all_active_runs():
+    """``runs.cancel_many(status="all")`` stops every active run the caller owns."""
+    client = get_e2e_client()
+    assistant = await client.assistants.create(graph_id="stress_test", if_exists="do_nothing")
+    assistant_id = assistant["assistant_id"]
+
+    started = [await _start_slow_run(client, assistant_id) for _ in range(2)]
+    await asyncio.sleep(1.0)
+
+    await client.runs.cancel_many(status="all", action="interrupt")
+
+    statuses = [await _wait_terminal(client, thread_id, run_id) for thread_id, run_id in started]
+    elog("cancel_many by status", statuses)
+    assert statuses == ["interrupted", "interrupted"]

--- a/libs/aegra-api/tests/e2e/test_runs/test_cancel_run_e2e.py
+++ b/libs/aegra-api/tests/e2e/test_runs/test_cancel_run_e2e.py
@@ -11,6 +11,7 @@ Addresses GitHub Issue #132: Cancel endpoint doesn't cancel asyncio task
 import asyncio
 
 import pytest
+from langgraph_sdk.client import LangGraphClient
 
 from tests.e2e._utils import check_and_skip_if_geo_blocked, elog, get_e2e_client
 
@@ -316,7 +317,7 @@ async def test_cancel_with_wait_flag():
     assert final_run["status"] in ("interrupted", "error", "success")
 
 
-async def _start_slow_run(client, assistant_id: str) -> tuple[str, str]:
+async def _start_slow_run(client: LangGraphClient, assistant_id: str) -> tuple[str, str]:
     thread = await client.threads.create()
     run = await client.runs.create(
         thread["thread_id"],
@@ -326,7 +327,7 @@ async def _start_slow_run(client, assistant_id: str) -> tuple[str, str]:
     return thread["thread_id"], run["run_id"]
 
 
-async def _wait_terminal(client, thread_id: str, run_id: str, timeout: float = 15.0) -> str:
+async def _wait_terminal(client: LangGraphClient, thread_id: str, run_id: str, timeout: float = 15.0) -> str:
     deadline = asyncio.get_running_loop().time() + timeout
     while asyncio.get_running_loop().time() < deadline:
         run = await client.runs.get(thread_id, run_id)

--- a/libs/aegra-api/tests/integration/test_api/test_runs_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_runs_crud.py
@@ -3,7 +3,7 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from tests.fixtures.clients import create_test_app, make_client
-from tests.fixtures.database import DummySessionBase
+from tests.fixtures.database import DummyScalarResult, DummySessionBase
 from tests.fixtures.session_fixtures import BasicSession, override_session_dependency
 from tests.fixtures.test_helpers import DummyRun, DummyThread
 
@@ -345,6 +345,96 @@ class TestCancelRun:
             assert resp.status_code == 200
             mock_streaming.cancel_run.assert_awaited_once_with("test-run-123", emit_end_event=False)
             mock_streaming.signal_run_cancelled.assert_awaited_once_with("test-run-123")
+
+
+class TestCancelRuns:
+    """Test POST /runs/cancel (bulk cancel used by the SDK's cancel_many)."""
+
+    @staticmethod
+    def _app_with_runs(runs, thread_exists=True):
+        app = create_test_app(include_runs=True, include_threads=False)
+
+        class Session(DummySessionBase):
+            async def scalar(self, _stmt):
+                return "test-thread-123" if thread_exists else None
+
+            async def scalars(self, _stmt=None):
+                return DummyScalarResult(runs)
+
+            async def commit(self):
+                pass
+
+        override_session_dependency(app, Session)
+        return make_client(app)
+
+    def test_cancel_runs_by_status_cancels_each_active_run(self):
+        runs = [_run_row(run_id="run-a", status="running"), _run_row(run_id="run-b", status="pending")]
+        client = self._app_with_runs(runs)
+
+        with (
+            patch("aegra_api.api.runs.streaming_service") as mock_streaming,
+            patch("aegra_api.api.runs.interrupt_unowned_run", new_callable=AsyncMock, return_value=True),
+        ):
+            mock_streaming.interrupt_run = AsyncMock()
+            mock_streaming.signal_run_cancelled = AsyncMock()
+
+            resp = client.post("/runs/cancel", json={"status": "all"}, params={"action": "interrupt"})
+
+            assert resp.status_code == 204
+            assert mock_streaming.interrupt_run.await_count == 2
+            assert mock_streaming.signal_run_cancelled.await_count == 2
+
+    def test_cancel_runs_by_ids_skips_finished_runs(self):
+        runs = [_run_row(run_id="run-a", status="running"), _run_row(run_id="run-b", status="success")]
+        client = self._app_with_runs(runs)
+
+        with (
+            patch("aegra_api.api.runs.streaming_service") as mock_streaming,
+            patch("aegra_api.api.runs.interrupt_unowned_run", new_callable=AsyncMock, return_value=True),
+        ):
+            mock_streaming.cancel_run = AsyncMock()
+            mock_streaming.signal_run_cancelled = AsyncMock()
+
+            resp = client.post(
+                "/runs/cancel",
+                json={"thread_id": "test-thread-123", "run_ids": ["run-a", "run-b"]},
+                params={"action": "cancel"},
+            )
+
+            assert resp.status_code == 204
+            mock_streaming.cancel_run.assert_awaited_once_with("run-a", emit_end_event=False)
+
+    def test_cancel_runs_by_ids_unknown_thread_is_404(self):
+        client = self._app_with_runs([], thread_exists=False)
+
+        resp = client.post("/runs/cancel", json={"thread_id": "missing", "run_ids": ["run-a"]})
+
+        assert resp.status_code == 404
+
+    def test_cancel_runs_without_selector_is_422(self):
+        client = self._app_with_runs([])
+
+        resp = client.post("/runs/cancel", json={})
+
+        assert resp.status_code == 422
+
+    def test_cancel_runs_unsupported_action_is_422(self):
+        client = self._app_with_runs([])
+
+        resp = client.post("/runs/cancel", json={"status": "all"}, params={"action": "rollback"})
+
+        assert resp.status_code == 422
+
+    def test_cancel_runs_no_matches_is_204(self):
+        client = self._app_with_runs([])
+
+        with patch("aegra_api.api.runs.streaming_service") as mock_streaming:
+            mock_streaming.interrupt_run = AsyncMock()
+
+            resp = client.post("/runs/cancel", json={"status": "pending"})
+
+            assert resp.status_code == 204
+            mock_streaming.interrupt_run.assert_not_awaited()
 
 
 class TestDeleteRun:

--- a/libs/aegra-api/tests/integration/test_api/test_runs_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_runs_crud.py
@@ -1,6 +1,9 @@
 """Integration tests for runs CRUD operations"""
 
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi.testclient import TestClient
 
 from tests.fixtures.clients import create_test_app, make_client
 from tests.fixtures.database import DummyScalarResult, DummySessionBase
@@ -351,23 +354,23 @@ class TestCancelRuns:
     """Test POST /runs/cancel (bulk cancel used by the SDK's cancel_many)."""
 
     @staticmethod
-    def _app_with_runs(runs, thread_exists=True):
+    def _app_with_runs(runs: list[Any], thread_exists: bool = True) -> TestClient:
         app = create_test_app(include_runs=True, include_threads=False)
 
         class Session(DummySessionBase):
-            async def scalar(self, _stmt):
+            async def scalar(self, _stmt: Any) -> str | None:
                 return "test-thread-123" if thread_exists else None
 
-            async def scalars(self, _stmt=None):
+            async def scalars(self, _stmt: Any = None) -> DummyScalarResult:
                 return DummyScalarResult(runs)
 
-            async def commit(self):
+            async def commit(self) -> None:
                 pass
 
         override_session_dependency(app, Session)
         return make_client(app)
 
-    def test_cancel_runs_by_status_cancels_each_active_run(self):
+    def test_cancel_runs_by_status_cancels_each_active_run(self) -> None:
         runs = [_run_row(run_id="run-a", status="running"), _run_row(run_id="run-b", status="pending")]
         client = self._app_with_runs(runs)
 
@@ -384,7 +387,7 @@ class TestCancelRuns:
             assert mock_streaming.interrupt_run.await_count == 2
             assert mock_streaming.signal_run_cancelled.await_count == 2
 
-    def test_cancel_runs_by_ids_skips_finished_runs(self):
+    def test_cancel_runs_by_ids_skips_finished_runs(self) -> None:
         runs = [_run_row(run_id="run-a", status="running"), _run_row(run_id="run-b", status="success")]
         client = self._app_with_runs(runs)
 
@@ -404,28 +407,28 @@ class TestCancelRuns:
             assert resp.status_code == 204
             mock_streaming.cancel_run.assert_awaited_once_with("run-a", emit_end_event=False)
 
-    def test_cancel_runs_by_ids_unknown_thread_is_404(self):
+    def test_cancel_runs_by_ids_unknown_thread_is_404(self) -> None:
         client = self._app_with_runs([], thread_exists=False)
 
         resp = client.post("/runs/cancel", json={"thread_id": "missing", "run_ids": ["run-a"]})
 
         assert resp.status_code == 404
 
-    def test_cancel_runs_without_selector_is_422(self):
+    def test_cancel_runs_without_selector_is_422(self) -> None:
         client = self._app_with_runs([])
 
         resp = client.post("/runs/cancel", json={})
 
         assert resp.status_code == 422
 
-    def test_cancel_runs_unsupported_action_is_422(self):
+    def test_cancel_runs_unsupported_action_is_422(self) -> None:
         client = self._app_with_runs([])
 
         resp = client.post("/runs/cancel", json={"status": "all"}, params={"action": "rollback"})
 
         assert resp.status_code == 422
 
-    def test_cancel_runs_no_matches_is_204(self):
+    def test_cancel_runs_no_matches_is_204(self) -> None:
         client = self._app_with_runs([])
 
         with patch("aegra_api.api.runs.streaming_service") as mock_streaming:

--- a/libs/aegra-api/tests/unit/test_core/test_auth_registry.py
+++ b/libs/aegra-api/tests/unit/test_core/test_auth_registry.py
@@ -209,6 +209,7 @@ _SPEC_TUPLES: dict[tuple[str, str], tuple[str, str]] = {
     ("DELETE", "/threads/{thread_id}/runs/{run_id}"): ("threads", "delete"),
     # stateless runs
     ("POST", "/runs"): ("threads", "create_run"),
+    ("POST", "/runs/cancel"): ("threads", "update"),
     ("POST", "/runs/stream"): ("threads", "create_run"),
     ("POST", "/runs/wait"): ("threads", "create_run"),
     # crons

--- a/libs/aegra-api/tests/unit/test_models/test_runs_cancel_validation.py
+++ b/libs/aegra-api/tests/unit/test_models/test_runs_cancel_validation.py
@@ -1,0 +1,36 @@
+"""RunsCancel accepts exactly one selector: status, or thread_id plus run_ids."""
+
+import pytest
+from pydantic import ValidationError
+
+from aegra_api.models.runs import RunsCancel
+
+
+class TestRunsCancelSelector:
+    def test_status_selector_alone_is_valid(self) -> None:
+        request = RunsCancel(status="pending")
+
+        assert request.status == "pending"
+        assert request.thread_id is None
+
+    def test_thread_and_run_ids_selector_is_valid(self) -> None:
+        request = RunsCancel(thread_id="t1", run_ids=["r1", "r2"])
+
+        assert request.run_ids == ["r1", "r2"]
+
+    def test_empty_body_is_invalid(self) -> None:
+        with pytest.raises(ValidationError, match="either 'status' or both"):
+            RunsCancel()
+
+    def test_run_ids_without_thread_is_invalid(self) -> None:
+        with pytest.raises(ValidationError, match="either 'status' or both"):
+            RunsCancel(run_ids=["r1"])
+
+    def test_both_selectors_is_invalid(self) -> None:
+        with pytest.raises(ValidationError, match="either 'status' or both"):
+            RunsCancel(status="all", thread_id="t1", run_ids=["r1"])
+
+    @pytest.mark.parametrize("status", ["success", "interrupted", "bogus"])
+    def test_non_active_status_is_invalid(self, status: str) -> None:
+        with pytest.raises(ValidationError):
+            RunsCancel(status=status)

--- a/libs/aegra-api/tests/unit/test_models/test_runs_cancel_validation.py
+++ b/libs/aegra-api/tests/unit/test_models/test_runs_cancel_validation.py
@@ -30,6 +30,17 @@ class TestRunsCancelSelector:
         with pytest.raises(ValidationError, match="either 'status' or both"):
             RunsCancel(status="all", thread_id="t1", run_ids=["r1"])
 
+    @pytest.mark.parametrize("extra", [{"thread_id": "t1"}, {"run_ids": ["r1"]}])
+    def test_status_with_a_partial_id_selector_is_invalid(self, extra: dict[str, object]) -> None:
+        """The handler reads the status branch and ignores thread_id, so accepting
+        this would cancel every matching run instead of the ones asked for."""
+        with pytest.raises(ValidationError, match="either 'status' or both"):
+            RunsCancel(status="pending", **extra)
+
+    def test_thread_id_without_run_ids_is_invalid(self) -> None:
+        with pytest.raises(ValidationError, match="either 'status' or both"):
+            RunsCancel(thread_id="t1")
+
     @pytest.mark.parametrize("status", ["success", "interrupted", "bogus"])
     def test_non_active_status_is_invalid(self, status: str) -> None:
         with pytest.raises(ValidationError):


### PR DESCRIPTION
## Description

`langgraph-sdk` implements `runs.cancel_many()` as `POST /runs/cancel`. Aegra only had the per-run route, so every bulk cancel returned 404 and the runs kept executing (#537).

This adds the route with the selector contract the SDK sends:

- `{"status": "pending" | "running" | "all"}` cancels every active run the caller owns in that status.
- `{"thread_id": ..., "run_ids": [...]}` cancels the listed runs on that thread. 404 if the thread does not exist for the caller; unknown run ids are ignored.
- Exactly one selector is required, otherwise 422.
- `?action=cancel|interrupt` uses the same values and the same `_request_run_interruption` path as the per-run endpoint, so ownership checks, terminal-state skips and the reconciliation of unowned runs are identical. `rollback` returns 422 like it does on the per-run route.
- Response is `204 No Content`.

The route is registered in the auth map as `threads.update`, matching the per-run cancel.

## Related Issues

Closes #537

## Testing

- Unit: `RunsCancel` selector validation (exactly one selector, active statuses only).
- Integration: status form cancels each active run, ids form skips finished runs, unknown thread 404, missing selector 422, unsupported action 422, no matches 204. Auth registry snapshot updated.
- E2E: two new tests drive the real SDK `cancel_many` against the `stress_test` graph, by ids (asserts the other thread's run is untouched) and by status. Green in both prod mode (Redis workers) and dev mode.
- Full non-e2e suite: 1976 passed. OpenAPI regenerated.

## Docs

- `docs/guides/streaming.mdx`: "Cancelling several runs" section.
- `docs/guides/authentication.mdx`: route added to the `threads.update` row.
- `docs/feature-support.mdx`: bulk cancel row.

No version bump, releases are batched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added bulk run cancellation through `POST /runs/cancel`.
  * Select runs by status or by thread and run IDs.
  * Added SDK support through `cancel_many`, with `cancel` and `interrupt` actions.
  * Completed runs are skipped, and only the caller’s runs are affected.
  * Successful requests return no content and validate selection criteria.

* **Documentation**
  * Updated feature support, authentication, streaming, and API reference documentation with bulk cancellation details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->









<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds SDK-compatible bulk run cancellation through `POST /runs/cancel`.
- Supports selection by active status or by thread and run IDs.
- Reuses existing interruption coordination and tenant-scoped run queries.
- Registers the route under `threads.update` authorization.
- Adds unit, integration, and end-to-end coverage.
- Updates authentication, streaming, feature-support, and generated OpenAPI documentation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no outstanding correctness or security findings.

The only change since the previous review documents rollback behavior consistently with the current action validation. The prior authorization concern was correctly conceded, the annotation issue was fixed, and the version-bump finding was withdrawn after clarification of the batched release process. ibbybuilds accepted the bounded-latency risk of sequential bulk cancellation because the active set is constrained by caller workload and deployment capacity, with batching deferred unless it becomes necessary in practice.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/api/runs.py | Implements tenant-scoped bulk run selection and delegates each match to the existing interruption path. |
| libs/aegra-api/src/aegra_api/models/runs.py | Defines and validates the mutually exclusive status and thread/run-ID selectors. |
| libs/aegra-api/src/aegra_api/core/auth_registry.py | Registers bulk cancellation under the existing threads.update authorization action. |
| libs/aegra-api/tests/integration/test_api/test_runs_crud.py | Covers selector behavior, terminal-run skipping, missing threads, unsupported actions, and empty matches. |
| libs/aegra-api/tests/e2e/test_runs/test_cancel_run_e2e.py | Exercises SDK bulk cancellation by IDs and status against real execution paths. |
| docs/feature-support.mdx | Documents current bulk cancellation support and explicitly marks rollback cancellation as unavailable. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant SDK as LangGraph SDK
  participant API as POST /runs/cancel
  participant DB as PostgreSQL
  participant Worker as Run executor
  SDK->>API: cancel_many(selector, action)
  API->>DB: Select caller-owned matching runs
  alt thread and run IDs
    API->>DB: Verify caller owns thread
  end
  loop Each active matching run
    API->>DB: Request ownership-safe interruption
    API->>Worker: Publish cancel or interrupt
  end
  API-->>SDK: 204 No Content
```
</details>

<sub>Reviews (5): Last reviewed commit: ["docs: state that cancel action=rollback ..."](https://github.com/aegra/aegra/commit/2dc2feaf0af60c2e9cb4e712f286240199623a5d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60724786)</sub>

**Context used:**

- Knowledge Base — [HTTP API contracts](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/api-contracts.md)
- Knowledge Base — [Agent run execution](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/run-execution.md)

<!-- /greptile_comment -->