### PR TITLE
docs: add API compatibility rule and move version bumps to the release PR

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,9 +256,9 @@ Aegra runs against user-managed Postgres including multi-host HA (PR #299). DB c
 Aegra is a drop-in replacement for LangSmith Deployments, so every request field the LangGraph SDK can send must be handled explicitly. Silent drops are the most common compatibility bug (see #452, #503, #537).
 
 - **Every field the SDK can send either changes behavior or returns 422.** Never accept a field and ignore it. If a feature is not implemented, declare the field and reject any value that differs from current behavior with a clear error.
-- **Declare accepted keys.** Request models list every SDK field. Command handlers (Agent Protocol v2) keep an explicit key set and log unknown keys at warning level. Do not use `extra="forbid"`: the Python SDK always sends default-valued booleans, so a new SDK field would break every client.
-- **Pin the contract with a drift test.** When you add a route or field, extend the test that compares the accepted key set against the SDK request body (v1) or the protocol param shapes (v2). A new SDK field must fail CI, not reach a user.
-- **Document no-ops.** A field that is accepted for wire compatibility but has no effect (for example LangSmith-only routing) is listed in `docs/feature-support.mdx` with the reason.
+- **One exception: fields that configure a system outside Aegra.** A field whose only effect is on a LangSmith-side service (for example `langsmith_tracer`, `feedback_keys`) may be accepted and left inert. Each such field is listed in `docs/feature-support.mdx` with the reason. Nothing else may be inert.
+- **Declare accepted keys.** Request models list every SDK field. Agent Protocol v2 handlers keep an explicit key set (`RUN_START_KEYS`, `INPUT_RESPOND_KEYS` in `services/event_streaming/commands.py`) and log unknown keys at warning level. Do not use `extra="forbid"`: the Python SDK always sends default-valued booleans, so a new SDK field would break every client.
+- **Pin the contract with a drift test.** v2: `tests/unit/test_services/test_event_streaming/test_spec_params.py` vendors the protocol param shapes and asserts the handler key sets cover them. v1: the request-model drift test against the SDK request body is tracked in #503; until it lands, add explicit field tests with each new field. A new SDK field must fail CI, not reach a user.
 - **Match public names and defaults.** Config keys, env vars and enum values follow the public LangGraph Platform docs where one exists, so users can move between deployments without changing payloads.
 
 ## Architecture

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,6 +252,15 @@ Aegra runs against user-managed Postgres including multi-host HA (PR #299). DB c
 - NEVER use `eval()`, `exec()`, or `pickle` on user input.
 - Use `subprocess.run([...], shell=False)` — never `shell=True` with user input.
 
+### API Compatibility (STRICT)
+Aegra is a drop-in replacement for LangSmith Deployments, so every request field the LangGraph SDK can send must be handled explicitly. Silent drops are the most common compatibility bug (see #452, #503, #537).
+
+- **Every field the SDK can send either changes behavior or returns 422.** Never accept a field and ignore it. If a feature is not implemented, declare the field and reject any value that differs from current behavior with a clear error.
+- **Declare accepted keys.** Request models list every SDK field. Command handlers (Agent Protocol v2) keep an explicit key set and log unknown keys at warning level. Do not use `extra="forbid"`: the Python SDK always sends default-valued booleans, so a new SDK field would break every client.
+- **Pin the contract with a drift test.** When you add a route or field, extend the test that compares the accepted key set against the SDK request body (v1) or the protocol param shapes (v2). A new SDK field must fail CI, not reach a user.
+- **Document no-ops.** A field that is accepted for wire compatibility but has no effect (for example LangSmith-only routing) is listed in `docs/feature-support.mdx` with the reason.
+- **Match public names and defaults.** Config keys, env vars and enum values follow the public LangGraph Platform docs where one exists, so users can move between deployments without changing payloads.
+
 ## Architecture
 
 ### Database Architecture

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,7 +253,7 @@ Aegra runs against user-managed Postgres including multi-host HA (PR #299). DB c
 - Use `subprocess.run([...], shell=False)` — never `shell=True` with user input.
 
 ### API Compatibility (STRICT)
-Aegra is a drop-in replacement for LangSmith Deployments, so every request field the LangGraph SDK can send must be handled explicitly. Silent drops are the most common compatibility bug (see #452, #503, #537).
+Aegra is a drop-in replacement for LangSmith Deployments, so every request field the LangGraph SDK can send must be handled explicitly. A field that is accepted and quietly ignored is the most common compatibility bug: the client sees success and the behavior it asked for never happens.
 
 - **Every field the SDK can send either changes behavior or returns 422.** Never accept a field and ignore it. If a feature is not implemented, declare the field and reject any value that differs from current behavior with a clear error.
 - **One exception: fields that configure a system outside Aegra.** A field whose only effect is on a LangSmith-side service (for example `langsmith_tracer`, `feedback_keys`) may be accepted and left inert. Each such field is listed in `docs/feature-support.mdx` with the reason. Nothing else may be inert.
@@ -346,14 +346,15 @@ Supported factory signatures: 0-arg (called once at startup), config-only (`dict
 - **`aegra-api` and `aegra-cli` MUST always have the same version.** Both versions live in their respective `pyproject.toml` files (`libs/aegra-api/pyproject.toml` and `libs/aegra-cli/pyproject.toml`).
 - **`aegra-cli` depends on `aegra-api~=X.Y.Z`** (compatible release). This allows patch updates (X.Y.Z+1) without changing the constraint, but a **minor bump requires updating the constraint** in `aegra-cli/pyproject.toml`.
 - **Pre-1.0.0 versioning (current):** While in beta (`0.x.y`), the version scheme is `0.MAJOR.PATCH`:
-  - **Patch** (0.5.1 → 0.5.2): Bug fixes, small improvements, new features, non-breaking additions. Update `version` in BOTH `pyproject.toml` files.
-  - **Minor** (0.5.x → 0.6.0): Breaking changes (removed/renamed endpoints, changed behavior, schema migrations). Update `version` in BOTH `pyproject.toml` files AND update the `aegra-api~=` constraint in `aegra-cli/pyproject.toml`.
+  - **Patch** (0.5.1 → 0.5.2): Bug fixes, small improvements, new features, non-breaking additions.
+  - **Minor** (0.5.x → 0.6.0): Breaking changes (removed/renamed endpoints, changed behavior, schema migrations). The release PR also updates the `aegra-api~=` constraint in `aegra-cli/pyproject.toml`.
   - **1.0.0**: Reserved for when the public API is considered stable and we commit to full SemVer guarantees. This is a deliberate decision, not triggered by a single change.
 - **Post-1.0.0 versioning (future):** Standard SemVer applies:
   - **Patch** (1.0.0 → 1.0.1): Bug fixes only.
   - **Minor** (1.0.x → 1.1.0): New features, non-breaking additions.
   - **Major** (1.x.y → 2.0.0): Breaking changes.
-- **Always bump the version before creating a PR.** Determine the bump type from the changes:
-  - Bug fix, small improvement, or new non-breaking feature → patch bump
-  - Breaking change (removed/renamed API, changed defaults, schema migration) → minor bump
+- **Do NOT bump the version in a feature or fix PR.** Releases are batched: several PRs merge, then one release PR bumps everything at once. A bump inside a normal PR conflicts with every other PR in the batch and has to be rebased away.
+- **The release PR bumps four things together:** `version` in BOTH `pyproject.toml` files, `uv.lock`, and `docs/openapi.json`. Determine the bump type from everything in the batch:
+  - Bug fixes, small improvements, new non-breaking features → patch bump
+  - Any breaking change (removed/renamed API, changed defaults, schema migration) → minor bump
 - **`aegra` meta-package** (on PyPI, not in this repo) is a name reservation that points to `aegra-cli`. It does not need to be updated on every release.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,6 +161,15 @@ uv run --package aegra-api pytest libs/aegra-api/tests/e2e/test_assistants/test_
 - Use descriptive test names: `test_should_return_error_when_invalid_input`
 - Aim for 80%+ code coverage
 
+## 🔌 API Compatibility
+
+Aegra is a drop-in replacement for LangSmith Deployments. Every request field the LangGraph SDK can send must either change behavior or return `422`. Never accept a field and ignore it.
+
+- Declare every SDK field on the request model, even ones Aegra does not implement yet; reject unsupported values with a clear error.
+- Extend the drift tests when you add a route or field, so a new SDK field fails CI instead of being dropped.
+- List accepted-but-inert fields in `docs/feature-support.mdx` with the reason.
+- Follow the public LangGraph Platform names and defaults for config keys, env vars and enum values.
+
 ## 🔒 Security
 
 - Never commit secrets, API keys, or credentials

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,7 +167,7 @@ Aegra is a drop-in replacement for LangSmith Deployments. Every request field th
 
 - Declare every SDK field on the request model, even ones Aegra does not implement yet; reject unsupported values with a clear error.
 - Extend the drift tests when you add a route or field, so a new SDK field fails CI instead of being dropped.
-- List accepted-but-inert fields in `docs/feature-support.mdx` with the reason.
+- The only fields allowed to be inert are ones that configure a system outside Aegra (LangSmith-side routing). List each in `docs/feature-support.mdx` with the reason.
 - Follow the public LangGraph Platform names and defaults for config keys, env vars and enum values.
 
 ## 🔒 Security


### PR DESCRIPTION
## Description

Two contributor-facing rules, both prompted by bugs and rework this week.

**API compatibility.** Every request field the LangGraph SDK can send either changes behavior or returns 422. A field that is accepted and quietly ignored is the most common compatibility bug: the client sees success and the behavior it asked for never happens. The section states the rule, the one exception (fields that only configure a LangSmith-side service), how to declare accepted keys, and where the drift tests live.

**Versioning.** `CLAUDE.md` said "always bump the version before creating a PR". That instruction made every PR in a release batch edit the same four files, so three PRs in a row had to be rebased to drop the bump. The section now says the release PR owns the bump and lists the four files it touches. The patch-versus-minor guidance stays, since it is how the release number is chosen.

Docs only. No version bump.

## Related Issues

Refs #503


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Documents the repository’s API compatibility contract and updates release-versioning guidance.
- Requires every LangGraph SDK request field to affect behavior or produce a clear `422`, except explicitly documented fields that only configure external LangSmith services.
- Defines accepted-key declarations, compatibility drift tests, and alignment with public LangGraph Platform names and defaults.
- Moves version bumps from individual feature or fix pull requests into batched release pull requests.

<h3>Confidence Score: 5/5</h3>

The documentation-only changes appear safe to merge, with both previous findings resolved and no new actionable issues identified.

The clarified compatibility exception limits inert fields to explicitly documented external-service settings, and the guidance now accurately identifies the dependent v2 safeguards while noting the outstanding v1 work. The newly added batched-release policy does not conflict with existing documentation or automation.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| CLAUDE.md | Adds strict SDK request-field compatibility rules and replaces per-PR version bumps with a consistent batched-release policy. |
| CONTRIBUTING.md | Adds concise contributor guidance covering SDK fields, drift tests, documented inert fields, and public naming conventions. |

</details>

<sub>Reviews (4): Last reviewed commit: ["docs: batch releases instead of bumping ..."](https://github.com/aegra/aegra/commit/b7885d4de1f8517855abc0620f03b58fb1bc1c0d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60725037)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded contribution guidance for maintaining API compatibility with LangSmith Deployments.
  * Documented requirements for explicitly handling SDK request fields and rejecting unsupported values.
  * Added guidance for contract-drift testing and documenting accepted but inactive fields.
  * Clarified that public configuration names, environment variables, and defaults must match LangGraph Platform conventions.
  * Updated versioning guidance to batch release-related updates into a dedicated release pull request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->