### PR TITLE
feat(api): add GET /assistants/{assistant_id}/subgraphs/{namespace}

### DIFF
--- a/docs/feature-support.mdx
+++ b/docs/feature-support.mdx
@@ -21,6 +21,7 @@ description: "What Aegra supports today, what's coming soon, and what's not yet 
 | Assistant versioning | Supported | Each update creates a new version. Pin or roll back. |
 | Graph schemas | Supported | Input, output, state, and config schemas exposed via API. |
 | Graph visualization | Supported | Mermaid graph structure returned by the API. |
+| Subgraph schemas | Supported | Subgraph schemas listing and single namespace lookup. |
 
 ### Threads and state
 

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -772,6 +772,78 @@
         }
       }
     },
+    "/assistants/{assistant_id}/subgraphs/{namespace}": {
+      "get": {
+        "tags": [
+          "Assistants"
+        ],
+        "summary": "Get Assistant Subgraph By Namespace",
+        "description": "Get a specific subgraph of an assistant by namespace.\n\nReturns the subgraph definitions for the requested namespace. Set\n`recurse=true` to include deeply nested subgraphs.",
+        "operationId": "get_assistant_subgraph_by_namespace_assistants__assistant_id__subgraphs__namespace__get",
+        "parameters": [
+          {
+            "name": "assistant_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Assistant Id"
+            }
+          },
+          {
+            "name": "namespace",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Namespace"
+            }
+          },
+          {
+            "name": "recurse",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "description": "Recursively include nested subgraphs.",
+              "default": false,
+              "title": "Recurse"
+            },
+            "description": "Recursively include nested subgraphs."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentProtocolError"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/threads": {
       "get": {
         "tags": [

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Aegra",
     "description": "Production-ready Agent Protocol server",
-    "version": "0.10.4"
+    "version": "0.10.5"
   },
   "paths": {
     "/info": {
@@ -817,7 +817,11 @@
             "description": "Successful Response",
             "content": {
               "application/json": {
-                "schema": {}
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "title": "Response Get Assistant Subgraph By Namespace Assistants  Assistant Id  Subgraphs  Namespace  Get"
+                }
               }
             }
           },

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.10.4"
+version = "0.10.5"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-api/src/aegra_api/api/assistants.py
+++ b/libs/aegra-api/src/aegra_api/api/assistants.py
@@ -237,3 +237,18 @@ async def get_assistant_subgraphs(
     namespace.
     """
     return await service.get_assistant_subgraphs(assistant_id, namespace, recurse)
+
+
+@router.get("/assistants/{assistant_id}/subgraphs/{namespace}", responses={**NOT_FOUND})
+async def get_assistant_subgraph_by_namespace(
+    assistant_id: str,
+    namespace: str,
+    recurse: bool = Query(False, description="Recursively include nested subgraphs."),
+    service: AssistantService = Depends(get_assistant_service),
+):
+    """Get a specific subgraph of an assistant by namespace.
+
+    Returns the subgraph definitions for the requested namespace. Set
+    `recurse=true` to include deeply nested subgraphs.
+    """
+    return await service.get_assistant_subgraph(assistant_id, namespace, recurse)

--- a/libs/aegra-api/src/aegra_api/api/assistants.py
+++ b/libs/aegra-api/src/aegra_api/api/assistants.py
@@ -11,6 +11,8 @@ Architecture:
 - Service Layer (assistant_service.py): Business logic, validation, orchestration
 """
 
+from typing import Any
+
 from fastapi import APIRouter, Body, Depends, Query
 
 from aegra_api.core.auth_deps import auth_dependency
@@ -245,7 +247,7 @@ async def get_assistant_subgraph_by_namespace(
     namespace: str,
     recurse: bool = Query(False, description="Recursively include nested subgraphs."),
     service: AssistantService = Depends(get_assistant_service),
-):
+) -> dict[str, Any]:
     """Get a specific subgraph of an assistant by namespace.
 
     Returns the subgraph definitions for the requested namespace. Set

--- a/libs/aegra-api/src/aegra_api/core/auth_registry.py
+++ b/libs/aegra-api/src/aegra_api/core/auth_registry.py
@@ -32,6 +32,7 @@ ROUTE_AUTH_MAP: Final[dict[tuple[str, str], tuple[str, str]]] = {
     ("GET", "/assistants/{assistant_id}/schemas"): ("assistants", "read"),
     ("GET", "/assistants/{assistant_id}/graph"): ("assistants", "read"),
     ("GET", "/assistants/{assistant_id}/subgraphs"): ("assistants", "read"),
+    ("GET", "/assistants/{assistant_id}/subgraphs/{namespace}"): ("assistants", "read"),
     # --- threads ------------------------------------------------------------
     ("POST", "/threads"): ("threads", "create"),
     ("GET", "/threads"): ("threads", "search"),
@@ -114,6 +115,7 @@ SELF_DISPATCHING: Final[frozenset[tuple[str, str]]] = frozenset(
         ("GET", "/assistants/{assistant_id}/schemas"),
         ("GET", "/assistants/{assistant_id}/graph"),
         ("GET", "/assistants/{assistant_id}/subgraphs"),
+        ("GET", "/assistants/{assistant_id}/subgraphs/{namespace}"),
         ("POST", "/threads"),
         ("GET", "/threads"),
         ("POST", "/threads/search"),

--- a/libs/aegra-api/src/aegra_api/services/assistant_service.py
+++ b/libs/aegra-api/src/aegra_api/services/assistant_service.py
@@ -663,6 +663,18 @@ class AssistantService(Authenticated):
         except Exception as e:
             raise HTTPException(400, f"Failed to get subgraphs: {str(e)}") from e
 
+    async def get_assistant_subgraph(
+        self,
+        assistant_id: str,
+        namespace: str,
+        recurse: bool = False,
+    ) -> dict[str, Any]:
+        """Get a specific subgraph of an assistant by namespace"""
+        subgraphs = await self.get_assistant_subgraphs(assistant_id, namespace=namespace, recurse=recurse)
+        if not subgraphs or namespace not in subgraphs:
+            raise HTTPException(404, detail=f"Subgraph namespace '{namespace}' not found")
+        return subgraphs
+
 
 def get_assistant_service(
     session: AsyncSession = Depends(get_session),

--- a/libs/aegra-api/tests/e2e/test_assistants/test_assistant_graph.py
+++ b/libs/aegra-api/tests/e2e/test_assistants/test_assistant_graph.py
@@ -242,6 +242,74 @@ async def test_get_assistant_subgraphs_not_found():
 
 @pytest.mark.e2e
 @pytest.mark.asyncio
+async def test_get_assistant_subgraph_by_namespace():
+    """Test that we can retrieve a specific subgraph by namespace.
+
+    Uses subgraph_agent which has actual subgraphs.
+    """
+    client = get_e2e_client()
+
+    # 1. Create an assistant with a graph that has subgraphs
+    assistant = await client.assistants.create(
+        name="Test Subgraph Namespace Assistant",
+        description="Assistant for testing single subgraph namespace endpoint",
+        graph_id="subgraph_agent",
+        if_exists="do_nothing",
+    )
+
+    try:
+        # 2. First get all subgraphs to know a valid namespace
+        all_subgraphs = await client.assistants.get_subgraphs(assistant_id=assistant["assistant_id"])
+        assert len(all_subgraphs) > 0, "subgraph_agent should have subgraphs"
+        target_namespace = next(iter(all_subgraphs.keys()))
+
+        # 3. Query the specific namespace
+        subgraph = await client.assistants.get_subgraphs(
+            assistant_id=assistant["assistant_id"],
+            namespace=target_namespace,
+        )
+
+        assert isinstance(subgraph, dict)
+        assert target_namespace in subgraph
+
+        elog(
+            "Single subgraph retrieved successfully by namespace",
+            {
+                "assistant_id": assistant["assistant_id"],
+                "namespace": target_namespace,
+            },
+        )
+    finally:
+        await client.assistants.delete(assistant_id=assistant["assistant_id"])
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_get_assistant_subgraph_by_namespace_not_found():
+    """Test that querying a non-existent subgraph namespace returns 404."""
+    client = get_e2e_client()
+
+    assistant = await client.assistants.create(
+        name="Test Subgraph 404 Assistant",
+        description="Assistant for testing 404 on missing subgraph namespace",
+        graph_id="subgraph_agent",
+        if_exists="do_nothing",
+    )
+
+    try:
+        with pytest.raises(Exception) as exc_info:
+            await client.assistants.get_subgraphs(
+                assistant_id=assistant["assistant_id"],
+                namespace="non_existent_namespace_xyz",
+            )
+        assert "404" in str(exc_info.value) or "not found" in str(exc_info.value).lower()
+        elog("Subgraphs endpoint correctly returns 404 for non-existent namespace", {})
+    finally:
+        await client.assistants.delete(assistant_id=assistant["assistant_id"])
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
 async def test_system_assistant_graph_access():
     """
     Test that we can access graph for system-created assistants.

--- a/libs/aegra-api/tests/e2e/test_assistants/test_assistant_graph.py
+++ b/libs/aegra-api/tests/e2e/test_assistants/test_assistant_graph.py
@@ -1,4 +1,5 @@
 import pytest
+from langgraph_sdk.errors import NotFoundError
 
 from tests.e2e._utils import elog, get_e2e_client
 
@@ -270,7 +271,8 @@ async def test_get_assistant_subgraph_by_namespace() -> None:
         )
 
         assert isinstance(subgraph, dict)
-        assert target_namespace in subgraph
+        assert set(subgraph.keys()) == {target_namespace}
+        assert subgraph[target_namespace] == all_subgraphs[target_namespace]
 
         elog(
             "Single subgraph retrieved successfully by namespace",
@@ -297,12 +299,12 @@ async def test_get_assistant_subgraph_by_namespace_not_found() -> None:
     )
 
     try:
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(NotFoundError) as exc_info:
             await client.assistants.get_subgraphs(
                 assistant_id=assistant["assistant_id"],
                 namespace="non_existent_namespace_xyz",
             )
-        assert "404" in str(exc_info.value) or "not found" in str(exc_info.value).lower()
+        assert exc_info.value.status_code == 404
         elog("Subgraphs endpoint correctly returns 404 for non-existent namespace", {})
     finally:
         await client.assistants.delete(assistant_id=assistant["assistant_id"])

--- a/libs/aegra-api/tests/e2e/test_assistants/test_assistant_graph.py
+++ b/libs/aegra-api/tests/e2e/test_assistants/test_assistant_graph.py
@@ -242,7 +242,7 @@ async def test_get_assistant_subgraphs_not_found():
 
 @pytest.mark.e2e
 @pytest.mark.asyncio
-async def test_get_assistant_subgraph_by_namespace():
+async def test_get_assistant_subgraph_by_namespace() -> None:
     """Test that we can retrieve a specific subgraph by namespace.
 
     Uses subgraph_agent which has actual subgraphs.
@@ -285,7 +285,7 @@ async def test_get_assistant_subgraph_by_namespace():
 
 @pytest.mark.e2e
 @pytest.mark.asyncio
-async def test_get_assistant_subgraph_by_namespace_not_found():
+async def test_get_assistant_subgraph_by_namespace_not_found() -> None:
     """Test that querying a non-existent subgraph namespace returns 404."""
     client = get_e2e_client()
 

--- a/libs/aegra-api/tests/integration/test_api/test_assistants_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_assistants_crud.py
@@ -1,6 +1,7 @@
 """Integration tests for assistants CRUD operations"""
 
 import pytest
+from fastapi import HTTPException
 
 from aegra_api.services.assistant_service import get_assistant_service
 from tests.fixtures.clients import create_test_app, make_client
@@ -778,7 +779,7 @@ class TestGetAssistantSubgraphs:
 class TestGetAssistantSubgraphByNamespace:
     """Test GET /assistants/{assistant_id}/subgraphs/{namespace}"""
 
-    def test_get_assistant_subgraph_by_namespace(self, client, mock_assistant_service):
+    def test_get_assistant_subgraph_by_namespace(self, client, mock_assistant_service) -> None:
         """Test getting specific subgraph by namespace"""
         subgraphs = {
             "subgraph_1": {
@@ -795,7 +796,7 @@ class TestGetAssistantSubgraphByNamespace:
         assert "subgraph_1" in data
         mock_assistant_service.get_assistant_subgraph.assert_called_once_with("test-assistant-123", "subgraph_1", False)
 
-    def test_get_assistant_subgraph_by_namespace_with_recurse(self, client, mock_assistant_service):
+    def test_get_assistant_subgraph_by_namespace_with_recurse(self, client, mock_assistant_service) -> None:
         """Test getting specific subgraph by namespace with recurse=true"""
         subgraphs = {
             "subgraph_1": {"nodes": []},
@@ -810,10 +811,8 @@ class TestGetAssistantSubgraphByNamespace:
         assert "subgraph_1" in data
         mock_assistant_service.get_assistant_subgraph.assert_called_once_with("test-assistant-123", "subgraph_1", True)
 
-    def test_get_assistant_subgraph_by_namespace_not_found(self, client, mock_assistant_service):
+    def test_get_assistant_subgraph_by_namespace_not_found(self, client, mock_assistant_service) -> None:
         """Test 404 when namespace is not found"""
-        from fastapi import HTTPException
-
         mock_assistant_service.get_assistant_subgraph.side_effect = HTTPException(
             status_code=404, detail="Subgraph namespace 'missing' not found"
         )

--- a/libs/aegra-api/tests/integration/test_api/test_assistants_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_assistants_crud.py
@@ -773,3 +773,52 @@ class TestGetAssistantSubgraphs:
         assert resp.status_code == 200
         data = resp.json()
         assert isinstance(data, dict)
+
+
+class TestGetAssistantSubgraphByNamespace:
+    """Test GET /assistants/{assistant_id}/subgraphs/{namespace}"""
+
+    def test_get_assistant_subgraph_by_namespace(self, client, mock_assistant_service):
+        """Test getting specific subgraph by namespace"""
+        subgraphs = {
+            "subgraph_1": {
+                "nodes": ["node_a", "node_b"],
+                "edges": [{"from": "node_a", "to": "node_b"}],
+            }
+        }
+        mock_assistant_service.get_assistant_subgraph.return_value = subgraphs
+
+        resp = client.get("/assistants/test-assistant-123/subgraphs/subgraph_1")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "subgraph_1" in data
+        mock_assistant_service.get_assistant_subgraph.assert_called_once_with("test-assistant-123", "subgraph_1", False)
+
+    def test_get_assistant_subgraph_by_namespace_with_recurse(self, client, mock_assistant_service):
+        """Test getting specific subgraph by namespace with recurse=true"""
+        subgraphs = {
+            "subgraph_1": {"nodes": []},
+            "subgraph_1:nested": {"nodes": []},
+        }
+        mock_assistant_service.get_assistant_subgraph.return_value = subgraphs
+
+        resp = client.get("/assistants/test-assistant-123/subgraphs/subgraph_1?recurse=true")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "subgraph_1" in data
+        mock_assistant_service.get_assistant_subgraph.assert_called_once_with("test-assistant-123", "subgraph_1", True)
+
+    def test_get_assistant_subgraph_by_namespace_not_found(self, client, mock_assistant_service):
+        """Test 404 when namespace is not found"""
+        from fastapi import HTTPException
+
+        mock_assistant_service.get_assistant_subgraph.side_effect = HTTPException(
+            status_code=404, detail="Subgraph namespace 'missing' not found"
+        )
+
+        resp = client.get("/assistants/test-assistant-123/subgraphs/missing")
+
+        assert resp.status_code == 404
+        assert resp.json()["detail"] == "Subgraph namespace 'missing' not found"

--- a/libs/aegra-api/tests/unit/test_core/test_auth_registry.py
+++ b/libs/aegra-api/tests/unit/test_core/test_auth_registry.py
@@ -181,6 +181,7 @@ _SPEC_TUPLES: dict[tuple[str, str], tuple[str, str]] = {
     ("GET", "/assistants/{assistant_id}/schemas"): ("assistants", "read"),
     ("GET", "/assistants/{assistant_id}/graph"): ("assistants", "read"),
     ("GET", "/assistants/{assistant_id}/subgraphs"): ("assistants", "read"),
+    ("GET", "/assistants/{assistant_id}/subgraphs/{namespace}"): ("assistants", "read"),
     # threads
     ("POST", "/threads"): ("threads", "create"),
     ("GET", "/threads"): ("threads", "search"),

--- a/libs/aegra-api/tests/unit/test_services/test_assistant_service.py
+++ b/libs/aegra-api/tests/unit/test_services/test_assistant_service.py
@@ -1157,6 +1157,7 @@ class TestAuthDispatch:
             ("get_assistant_schemas", ("asst-1",)),
             ("get_assistant_graph", ("asst-1", False)),
             ("get_assistant_subgraphs", ("asst-1", None, False)),
+            ("get_assistant_subgraph", ("asst-1", "ns-1", False)),
             ("delete_assistant", ("asst-1",)),
             ("set_assistant_latest", ("asst-1", 1)),
             ("update_assistant", ("asst-1", AssistantUpdate(name="x"))),
@@ -1203,3 +1204,33 @@ class TestAuthDispatch:
         stmt = assistant_service.session.scalars.call_args.args[0]
         compiled = stmt.compile(dialect=postgresql.dialect())
         assert {"owner": "user-123"} in compiled.params.values()
+
+
+class TestGetAssistantSubgraph:
+    """Test AssistantService.get_assistant_subgraph"""
+
+    @pytest.mark.asyncio
+    async def test_get_assistant_subgraph_success(self, assistant_service: AssistantService):
+        expected = {"agent:sub": {"input_schema": {}, "output_schema": {}}}
+        with patch.object(
+            assistant_service, "get_assistant_subgraphs", new=AsyncMock(return_value=expected)
+        ) as mock_get:
+            result = await assistant_service.get_assistant_subgraph("asst-1", "agent:sub", recurse=True)
+            mock_get.assert_awaited_once_with("asst-1", namespace="agent:sub", recurse=True)
+            assert result == expected
+
+    @pytest.mark.asyncio
+    async def test_get_assistant_subgraph_not_found_empty(self, assistant_service: AssistantService):
+        with patch.object(assistant_service, "get_assistant_subgraphs", new=AsyncMock(return_value={})):
+            with pytest.raises(HTTPException) as exc_info:
+                await assistant_service.get_assistant_subgraph("asst-1", "missing_ns")
+            assert exc_info.value.status_code == 404
+            assert "missing_ns" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_get_assistant_subgraph_not_found_different_ns(self, assistant_service: AssistantService):
+        with patch.object(assistant_service, "get_assistant_subgraphs", new=AsyncMock(return_value={"other_ns": {}})):
+            with pytest.raises(HTTPException) as exc_info:
+                await assistant_service.get_assistant_subgraph("asst-1", "target_ns")
+            assert exc_info.value.status_code == 404
+            assert "target_ns" in exc_info.value.detail

--- a/libs/aegra-api/tests/unit/test_services/test_assistant_service.py
+++ b/libs/aegra-api/tests/unit/test_services/test_assistant_service.py
@@ -1210,7 +1210,7 @@ class TestGetAssistantSubgraph:
     """Test AssistantService.get_assistant_subgraph"""
 
     @pytest.mark.asyncio
-    async def test_get_assistant_subgraph_success(self, assistant_service: AssistantService):
+    async def test_get_assistant_subgraph_success(self, assistant_service: AssistantService) -> None:
         expected = {"agent:sub": {"input_schema": {}, "output_schema": {}}}
         with patch.object(
             assistant_service, "get_assistant_subgraphs", new=AsyncMock(return_value=expected)
@@ -1220,7 +1220,7 @@ class TestGetAssistantSubgraph:
             assert result == expected
 
     @pytest.mark.asyncio
-    async def test_get_assistant_subgraph_not_found_empty(self, assistant_service: AssistantService):
+    async def test_get_assistant_subgraph_not_found_empty(self, assistant_service: AssistantService) -> None:
         with patch.object(assistant_service, "get_assistant_subgraphs", new=AsyncMock(return_value={})):
             with pytest.raises(HTTPException) as exc_info:
                 await assistant_service.get_assistant_subgraph("asst-1", "missing_ns")
@@ -1228,7 +1228,7 @@ class TestGetAssistantSubgraph:
             assert "missing_ns" in exc_info.value.detail
 
     @pytest.mark.asyncio
-    async def test_get_assistant_subgraph_not_found_different_ns(self, assistant_service: AssistantService):
+    async def test_get_assistant_subgraph_not_found_different_ns(self, assistant_service: AssistantService) -> None:
         with patch.object(assistant_service, "get_assistant_subgraphs", new=AsyncMock(return_value={"other_ns": {}})):
             with pytest.raises(HTTPException) as exc_info:
                 await assistant_service.get_assistant_subgraph("asst-1", "target_ns")

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.10.4"
+version = "0.10.5"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
## Summary

Adds the `GET /assistants/{assistant_id}/subgraphs/{namespace}` endpoint for Agent Protocol and LangGraph SDK compatibility, resolving #572.

LangGraph Platform exposes `GET /assistants/{assistant_id}/subgraphs/{namespace}` to return the schemas of one named subgraph. Previously, Aegra only served `GET /assistants/{assistant_id}/subgraphs` (listing all subgraphs), causing calls from `client.assistants.get_subgraphs(assistant_id, namespace=...)` to return 404.

## Changes

- **Route**: Added `GET /assistants/{assistant_id}/subgraphs/{namespace}` in `libs/aegra-api/src/aegra_api/api/assistants.py` supporting `recurse: bool = False`.
- **Service**: Added `get_assistant_subgraph()` in `libs/aegra-api/src/aegra_api/services/assistant_service.py` to query the subgraph and raise an `HTTPException(404)` when the requested namespace does not exist.
- **Auth**: Registered `("GET", "/assistants/{assistant_id}/subgraphs/{namespace}"): ("assistants", "read")` in `ROUTE_AUTH_MAP` and `SELF_DISPATCHING` in `core/auth_registry.py`.
- **Docs & OpenAPI**: Updated `docs/feature-support.mdx` and regenerated `docs/openapi.json`.
- **Tests**:
  - Unit tests for `AssistantService.get_assistant_subgraph` (valid namespace, missing namespace 404, wrong namespace 404).
  - Integration tests for `GET /assistants/{assistant_id}/subgraphs/{namespace}` via FastAPI `TestClient`.
  - Auth registry coverage in `test_auth_registry.py`.
  - E2E tests in `test_assistant_graph.py` covering SDK namespace lookup and 404 behavior.

Closes #572


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving a specific assistant subgraph by namespace.
  * Added optional recursive lookup for nested subgraphs.
  * Documented subgraph schema support in the feature matrix and API reference.

* **Bug Fixes**
  * Requests for unavailable namespaces now return a not-found response.

* **Tests**
  * Added coverage for successful, recursive, and missing-namespace subgraph lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds Agent Protocol and LangGraph SDK compatibility for retrieving one assistant subgraph by namespace.
- Adds the namespace-specific route, service lookup, and assistants-read authorization registration.
- Returns 404 when the requested namespace is unavailable.
- Adds unit, integration, and E2E coverage, including recursive and missing-namespace behavior.
- Updates OpenAPI documentation, feature support documentation, and synchronizes both package versions at 0.10.5.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no outstanding findings.

The earlier annotation and import-placement findings were resolved, and the synchronized 0.10.5 package bumps fully address the remaining versioning finding. The subsequent changes only strengthen E2E assertions using SDK APIs supported by the pinned dependency.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/api/assistants.py | Adds the typed namespace-specific subgraph route and delegates lookup to the assistant service. |
| libs/aegra-api/src/aegra_api/services/assistant_service.py | Filters subgraphs through the existing retrieval path and returns 404 when the requested namespace is absent. |
| libs/aegra-api/src/aegra_api/core/auth_registry.py | Registers the endpoint for assistants-read authorization and self-dispatch. |
| libs/aegra-api/tests/e2e/test_assistants/test_assistant_graph.py | Verifies exact namespace lookup results and typed SDK 404 behavior. |
| libs/aegra-api/tests/integration/test_api/test_assistants_crud.py | Covers route delegation, recursive lookup, and missing-namespace responses. |
| libs/aegra-api/tests/unit/test_services/test_assistant_service.py | Covers successful service lookup and both empty and mismatched namespace results. |
| libs/aegra-api/pyproject.toml | Applies the required synchronized patch release bump to aegra-api. |
| libs/aegra-cli/pyproject.toml | Keeps the aegra-cli version synchronized with aegra-api. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant SDK as LangGraph SDK
    participant API as Assistants API
    participant Service as AssistantService
    participant Graph as Assistant Graph

    SDK->>API: "GET /assistants/{id}/subgraphs/{namespace}?recurse=..."
    API->>Service: get_assistant_subgraph(id, namespace, recurse)
    Service->>Graph: get subgraphs filtered by namespace
    Graph-->>Service: Namespace-to-schema mapping
    alt Namespace exists
        Service-->>API: Matching subgraph mapping
        API-->>SDK: 200 OK
    else Namespace unavailable
        Service-->>API: HTTPException(404)
        API-->>SDK: 404 Not Found
    end
```
</details>

<sub>Reviews (3): Last reviewed commit: ["test(e2e): strengthen subgraph namespace..."](https://github.com/aegra/aegra/commit/98cd3258f72ba818c4af7d3216466c49d8a1d4b9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60744873)</sub>

<!-- /greptile_comment -->