### PR TITLE
fix(api): reject oversized or blank client thread_id with 422

### DIFF
--- a/docs/guides/threads-and-state.mdx
+++ b/docs/guides/threads-and-state.mdx
@@ -33,6 +33,10 @@ async def main():
 asyncio.run(main())
 ```
 
+<Note>
+  A client-provided `thread_id` must be 1–255 non-blank characters. Omit the field (or send `null`) to let the server generate a UUID. Longer or blank values are rejected with 422 before they hit PostgreSQL's btree key limit (~2704 bytes).
+</Note>
+
 ## Thread status
 
 Threads have a status that reflects their current state:

--- a/libs/aegra-api/src/aegra_api/models/threads.py
+++ b/libs/aegra-api/src/aegra_api/models/threads.py
@@ -11,6 +11,10 @@ from aegra_api.utils.status_compat import validate_thread_status
 # (timedelta.max is ~1.44e9 minutes); rejects inf/1e308 at validation time.
 MAX_TTL_MINUTES = 1_000_000_000
 
+# Stay well under PostgreSQL btree's ~2704-byte index tuple cap even uncompressed.
+# LangGraph SDK has no cap; PostgresSaver docs recommend 255 characters.
+MAX_THREAD_ID_LENGTH = 255
+
 
 class ThreadTTLSpec(BaseModel):
     """Per-thread TTL override supplied on thread creation.
@@ -45,7 +49,14 @@ class ThreadCreate(BaseModel):
     thread_id: str | None = Field(
         None,
         alias="threadId",
-        description="Optional client-provided thread ID for idempotent creation",
+        min_length=1,
+        max_length=MAX_THREAD_ID_LENGTH,
+        description=(
+            "Optional client-provided thread ID for idempotent creation. "
+            "Omit or null to let the server generate a UUID. "
+            f"When set, 1–{MAX_THREAD_ID_LENGTH} characters and not blank "
+            "(must fit PostgreSQL btree keys uncompressed)."
+        ),
     )
     if_exists: str | None = Field(
         "raise",
@@ -56,6 +67,13 @@ class ThreadCreate(BaseModel):
         None,
         description="Per-thread TTL override; requires TTL to be configured server-side or default_ttl set",
     )
+
+    @field_validator("thread_id")
+    @classmethod
+    def _thread_id_not_blank(cls, v: str | None) -> str | None:
+        if v is not None and not v.strip():
+            raise ValueError("thread_id must not be blank")
+        return v
 
 
 class ThreadUpdate(BaseModel):

--- a/libs/aegra-api/tests/e2e/test_threads/test_thread_create_id_validation.py
+++ b/libs/aegra-api/tests/e2e/test_threads/test_thread_create_id_validation.py
@@ -1,0 +1,20 @@
+"""E2E: oversized client thread_id is 422, not a Postgres 500."""
+
+import secrets
+
+import pytest
+from httpx import AsyncClient
+
+from aegra_api.settings import settings
+from tests.e2e._utils import elog
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_create_thread_rejects_oversized_id_with_422() -> None:
+    thread_id = secrets.token_hex(2500)
+    async with AsyncClient(base_url=settings.app.SERVER_URL, timeout=30.0) as http_client:
+        resp = await http_client.post("/threads", json={"thread_id": thread_id})
+    elog("oversized thread_id", {"status": resp.status_code, "body": resp.text[:500]})
+    assert resp.status_code == 422
+    assert "thread_id" in resp.text

--- a/libs/aegra-api/tests/integration/test_api/test_threads_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_threads_crud.py
@@ -1,8 +1,10 @@
 """Integration tests for threads CRUD operations"""
 
+import secrets
 from contextlib import asynccontextmanager
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from uuid import uuid4
 
 import pytest
 from fastapi import FastAPI
@@ -199,6 +201,33 @@ class TestCreateThread:
         assert resp.status_code == 200
         data = resp.json()
         assert data["thread_id"] == custom_id
+
+    def test_create_thread_rejects_oversized_random_id(self, client: TestClient) -> None:
+        """Oversized ids 422 at validation; they must not reach Postgres btree."""
+        resp = client.post("/threads", json={"thread_id": secrets.token_hex(2500)})
+        assert resp.status_code == 422
+        assert "thread_id" in resp.text
+
+    def test_create_thread_rejects_empty_id(self, client: TestClient) -> None:
+        resp = client.post("/threads", json={"thread_id": ""})
+        assert resp.status_code == 422
+        assert "thread_id" in resp.text
+
+    def test_create_thread_rejects_blank_id(self, client: TestClient) -> None:
+        resp = client.post("/threads", json={"thread_id": "   "})
+        assert resp.status_code == 422
+        assert "thread_id" in resp.text
+
+    def test_create_thread_accepts_uuid(self, client: TestClient) -> None:
+        thread_id = str(uuid4())
+        resp = client.post("/threads", json={"thread_id": thread_id})
+        assert resp.status_code == 200
+        assert resp.json()["thread_id"] == thread_id
+
+    def test_create_thread_omitted_id_still_200(self, client: TestClient) -> None:
+        resp = client.post("/threads", json={})
+        assert resp.status_code == 200
+        assert resp.json()["thread_id"]
 
     def test_create_thread_if_exists_do_nothing(self):
         """Test ifExists='do_nothing' returns existing thread"""

--- a/libs/aegra-api/tests/unit/test_models/test_thread_create_id_validation.py
+++ b/libs/aegra-api/tests/unit/test_models/test_thread_create_id_validation.py
@@ -1,0 +1,51 @@
+"""Validation tests for client-provided ThreadCreate.thread_id."""
+
+import secrets
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from aegra_api.models.threads import MAX_THREAD_ID_LENGTH, ThreadCreate
+
+
+class TestThreadCreateThreadId:
+    """Provided thread_id must be non-blank and fit PostgreSQL btree keys."""
+
+    def test_omitted_thread_id_is_none(self) -> None:
+        request = ThreadCreate.model_validate({})
+
+        assert request.thread_id is None
+
+    def test_explicit_null_is_none(self) -> None:
+        request = ThreadCreate.model_validate({"thread_id": None})
+
+        assert request.thread_id is None
+
+    def test_accepts_uuid(self) -> None:
+        thread_id = str(uuid4())
+        request = ThreadCreate.model_validate({"thread_id": thread_id})
+
+        assert request.thread_id == thread_id
+
+    def test_accepts_max_length(self) -> None:
+        thread_id = "a" * MAX_THREAD_ID_LENGTH
+        request = ThreadCreate.model_validate({"thread_id": thread_id})
+
+        assert request.thread_id == thread_id
+
+    def test_rejects_empty_string(self) -> None:
+        with pytest.raises(ValidationError):
+            ThreadCreate.model_validate({"thread_id": ""})
+
+    def test_rejects_blank(self) -> None:
+        with pytest.raises(ValidationError):
+            ThreadCreate.model_validate({"thread_id": "   "})
+
+    def test_rejects_oversized_random_id(self) -> None:
+        with pytest.raises(ValidationError):
+            ThreadCreate.model_validate({"thread_id": secrets.token_hex(2500)})
+
+    def test_rejects_one_over_max_length(self) -> None:
+        with pytest.raises(ValidationError):
+            ThreadCreate.model_validate({"thread_id": "a" * (MAX_THREAD_ID_LENGTH + 1)})


### PR DESCRIPTION
## Summary
- Fixes #567
- `POST /threads` now 422s a client-provided `thread_id` that is blank or longer than 255 characters (LangGraph SDK has no length cap; Platform requires a UUID, which we do not adopt so `my-thread-123` keeps working; 255 matches PostgresSaver docs and stays well under PostgreSQL btree's ~2704-byte index tuple cap even uncompressed). Omit or `null` still mints a server UUID.
- No PK type change, no RunCreate / durability changes, no version bump. Patch is batched with #503; this PR stays on 0.10.4.

## Test plan
- [x] `uv run ruff check` / `ruff format` on changed files
- [x] unit: `test_thread_create_id_validation.py` (omit, null, UUID, max length, empty, blank, oversized random, max+1)
- [x] integration: `test_threads_crud.py` create path (oversized random 422, empty/blank 422, UUID 200, omitted 200)
- [ ] e2e: `test_thread_create_id_validation.py` oversized 422 against a live server (docker daemon was down locally)


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Thread creation now rejects empty, whitespace-only, and overly long client-provided thread IDs with a clear validation error instead of a server error.
  - Valid IDs up to 255 characters, including UUIDs, continue to be accepted.
  - Omitting the thread ID or providing `null` continues to generate an ID automatically.

- **Documentation**
  - Added guidance on accepted thread ID formats, length limits, automatic generation, and validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds request-model validation so `POST /threads` rejects blank or client-provided thread IDs longer than 255 characters with a 422 response instead of allowing persistence to fail later.

- Adds length and nonblank validation to `ThreadCreate.thread_id`.
- Documents the client-visible constraint.
- Adds unit, integration, and E2E regression coverage.
- Still needs the synchronized package version bump required by repository policy.
- Still needs the generated OpenAPI contract refreshed.

<h3>Confidence Score: 4/5</h3>

The validation itself appears sound, but the PR should not merge until the required synchronized version bump is made and the checked-in OpenAPI contract is regenerated.

No runtime correctness or security defect was found in the new validation; the remaining findings are an explicit repository-versioning violation and a stale generated API contract.

**Files Needing Attention:** libs/aegra-api/src/aegra_api/models/threads.py, docs/openapi.json, libs/aegra-api/pyproject.toml, libs/aegra-cli/pyproject.toml

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/models/threads.py | Adds correct early validation for blank and oversized client thread IDs, but the associated version and generated API contract updates are missing. |
| docs/guides/threads-and-state.mdx | Documents the new thread-ID limits and server-generated-ID behavior. |
| libs/aegra-api/tests/unit/test_models/test_thread_create_id_validation.py | Covers model validation boundaries, invalid values, null handling, and generated-style UUID values. |
| libs/aegra-api/tests/integration/test_api/test_threads_crud.py | Exercises the new validation through the HTTP create-thread route alongside accepted creation paths. |
| libs/aegra-api/tests/e2e/test_threads/test_thread_create_id_validation.py | Adds live-server coverage that verifies oversized identifiers receive 422 responses. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20aegra%2Faegra%20PR%20%23579%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=aegra%2Faegra&pr=579&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fmodels%2Fthreads.py%3A49-60%0A**Required%20version%20bump%20missing**%0A%0AThis%20changes%20user-facing%20API%20validation%20without%20updating%20either%20package%20version.%20The%20repository%20requires%20every%20PR%20to%20bump%20the%20version%2C%20classifies%20bug%20fixes%20as%20patch%20bumps%2C%20and%20requires%20%60aegra-api%60%20and%20%60aegra-cli%60%20to%20stay%20at%20the%20same%20version.%20Both%20package%20manifests%20must%20be%20updated%20before%20merging.%0A%0A%23%23%23%20Issue%202%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fmodels%2Fthreads.py%3A49-60%0A**OpenAPI%20contract%20remains%20stale**%0A%0AThe%20request%20model%20now%20enforces%20a%201%E2%80%93255-character%20limit%2C%20but%20the%20checked-in%20OpenAPI%20schema%20still%20describes%20%60threadId%60%20as%20an%20unconstrained%20string.%20Code-generated%20clients%20and%20other%20contract%20consumers%20will%20not%20know%20about%20the%20new%20validation%2C%20so%20they%20may%20send%20values%20that%20unexpectedly%20receive%20422%20responses.%20Regenerate%20%60docs%2Fopenapi.json%60%20with%20this%20change.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=aegra%2Faegra&pr=579&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fmodels%2Fthreads.py%3A49-60%0A**Required%20version%20bump%20missing**%0A%0AThis%20changes%20user-facing%20API%20validation%20without%20updating%20either%20package%20version.%20The%20repository%20requires%20every%20PR%20to%20bump%20the%20version%2C%20classifies%20bug%20fixes%20as%20patch%20bumps%2C%20and%20requires%20%60aegra-api%60%20and%20%60aegra-cli%60%20to%20stay%20at%20the%20same%20version.%20Both%20package%20manifests%20must%20be%20updated%20before%20merging.%0A%0A%23%23%23%20Issue%202%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fmodels%2Fthreads.py%3A49-60%0A**OpenAPI%20contract%20remains%20stale**%0A%0AThe%20request%20model%20now%20enforces%20a%201%E2%80%93255-character%20limit%2C%20but%20the%20checked-in%20OpenAPI%20schema%20still%20describes%20%60threadId%60%20as%20an%20unconstrained%20string.%20Code-generated%20clients%20and%20other%20contract%20consumers%20will%20not%20know%20about%20the%20new%20validation%2C%20so%20they%20may%20send%20values%20that%20unexpectedly%20receive%20422%20responses.%20Regenerate%20%60docs%2Fopenapi.json%60%20with%20this%20change.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=579&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22fix%2F567-thread-id-max-length%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2F567-thread-id-max-length%22.%0A%0A%23%23%23%20Issue%201%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fmodels%2Fthreads.py%3A49-60%0A**Required%20version%20bump%20missing**%0A%0AThis%20changes%20user-facing%20API%20validation%20without%20updating%20either%20package%20version.%20The%20repository%20requires%20every%20PR%20to%20bump%20the%20version%2C%20classifies%20bug%20fixes%20as%20patch%20bumps%2C%20and%20requires%20%60aegra-api%60%20and%20%60aegra-cli%60%20to%20stay%20at%20the%20same%20version.%20Both%20package%20manifests%20must%20be%20updated%20before%20merging.%0A%0A%23%23%23%20Issue%202%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fmodels%2Fthreads.py%3A49-60%0A**OpenAPI%20contract%20remains%20stale**%0A%0AThe%20request%20model%20now%20enforces%20a%201%E2%80%93255-character%20limit%2C%20but%20the%20checked-in%20OpenAPI%20schema%20still%20describes%20%60threadId%60%20as%20an%20unconstrained%20string.%20Code-generated%20clients%20and%20other%20contract%20consumers%20will%20not%20know%20about%20the%20new%20validation%2C%20so%20they%20may%20send%20values%20that%20unexpectedly%20receive%20422%20responses.%20Regenerate%20%60docs%2Fopenapi.json%60%20with%20this%20change.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=aegra%2Faegra&pr=579&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(api): reject oversized or blank clie..."](https://github.com/aegra/aegra/commit/0d24361a3a2565a933a1c3dbf97cbf19451f93b4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60755697)</sub>

> Greptile also left **2 inline comments** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://github.com/aegra/aegra/blob/main/CLAUDE.md))
- Knowledge Base — [HTTP API contracts](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/api-contracts.md)
- Knowledge Base — [Assistants, threads, and state](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/assistant-thread-state.md)
</details>


<!-- /greptile_comment -->