### PR TITLE
feat(api): support delayed run start

### DIFF
--- a/dev-docs/delayed-run-scheduling.md
+++ b/dev-docs/delayed-run-scheduling.md
@@ -1,0 +1,33 @@
+# Delayed run scheduling
+
+Run creation accepts `after_seconds` to delay graph execution while keeping the
+run visible through the normal run APIs. A value of `0` preserves immediate
+execution.
+
+## Local executor
+
+In development mode, `LocalExecutor` registers one asyncio task per run. A
+delayed task sleeps before calling `execute_run`. The task is stored in
+`active_runs` for its entire lifetime, so the existing cancellation and
+shutdown paths can cancel the timer before graph execution begins.
+
+## Worker executor
+
+In production mode, the run row is committed as `pending` immediately. Delayed
+runs store their UTC `not_before` timestamp in Postgres and are not pushed to
+Redis at creation time. A lightweight dispatcher checks due rows and pushes
+their IDs to the worker queue. Workers also apply the `not_before` predicate
+when falling back to Postgres, so a delayed run cannot be claimed early.
+
+The timestamp is persisted rather than held only in memory. After an API or
+worker restart, the dispatcher discovers any pending row whose timestamp has
+passed and queues it. Queue delivery is intentionally idempotent: the worker's
+conditional pending/unclaimed lease update is the execution gate, so a
+duplicate queue entry cannot execute a run twice.
+
+Cancellation updates the pending row to `interrupted` before dispatch can claim
+it. If a queue entry races with cancellation, the worker lease update rejects
+the non-pending row.
+
+The migration adding `runs.not_before` must be applied before enabling delayed
+runs in a production deployment.

--- a/libs/aegra-api/alembic/versions/20260905000000_add_run_not_before.py
+++ b/libs/aegra-api/alembic/versions/20260905000000_add_run_not_before.py
@@ -1,0 +1,25 @@
+"""add persisted delayed run scheduling
+
+Revision ID: 6b2d9f1a4c7e
+Revises: a3f7c1d9e2b4
+Create Date: 2026-09-05 00:00:00.000000
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "6b2d9f1a4c7e"
+down_revision = "a3f7c1d9e2b4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("runs", sa.Column("not_before", sa.TIMESTAMP(timezone=True), nullable=True))
+    op.create_index("idx_runs_not_before", "runs", ["status", "not_before"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("idx_runs_not_before", table_name="runs")
+    op.drop_column("runs", "not_before")

--- a/libs/aegra-api/alembic/versions/20260905000001_add_run_dispatch_timestamp.py
+++ b/libs/aegra-api/alembic/versions/20260905000001_add_run_dispatch_timestamp.py
@@ -1,0 +1,30 @@
+"""add delayed run dispatch timestamp
+
+Revision ID: 7c3e0a2b5d8f
+Revises: 6b2d9f1a4c7e
+Create Date: 2026-09-05 00:00:01.000000
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "7c3e0a2b5d8f"
+down_revision = "6b2d9f1a4c7e"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("runs", sa.Column("dispatched_at", sa.TIMESTAMP(timezone=True), nullable=True))
+    op.create_index(
+        "idx_runs_dispatch",
+        "runs",
+        ["status", "not_before", "dispatched_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_runs_dispatch", table_name="runs")
+    op.drop_column("runs", "dispatched_at")

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.10.4"
+version = "0.10.5"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-api/src/aegra_api/core/orm.py
+++ b/libs/aegra-api/src/aegra_api/core/orm.py
@@ -181,6 +181,10 @@ class Run(Base):
     claimed_by: Mapped[str | None] = mapped_column(Text, nullable=True)
     lease_expires_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True), nullable=True)
 
+    # A persisted scheduling boundary makes delayed runs recoverable after an
+    # API/worker restart. NULL means the run is eligible immediately.
+    not_before: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True), nullable=True)
+
     # Indexes for performance
     __table_args__ = (
         Index("idx_runs_thread_id", "thread_id"),
@@ -189,6 +193,7 @@ class Run(Base):
         Index("idx_runs_assistant_id", "assistant_id"),
         Index("idx_runs_created_at", "created_at"),
         Index("idx_runs_lease_reaper", "status", "lease_expires_at"),
+        Index("idx_runs_not_before", "status", "not_before"),
     )
 
 

--- a/libs/aegra-api/src/aegra_api/core/orm.py
+++ b/libs/aegra-api/src/aegra_api/core/orm.py
@@ -184,6 +184,7 @@ class Run(Base):
     # A persisted scheduling boundary makes delayed runs recoverable after an
     # API/worker restart. NULL means the run is eligible immediately.
     not_before: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True), nullable=True)
+    dispatched_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True), nullable=True)
 
     # Indexes for performance
     __table_args__ = (
@@ -194,6 +195,7 @@ class Run(Base):
         Index("idx_runs_created_at", "created_at"),
         Index("idx_runs_lease_reaper", "status", "lease_expires_at"),
         Index("idx_runs_not_before", "status", "not_before"),
+        Index("idx_runs_dispatch", "status", "not_before", "dispatched_at"),
     )
 
 

--- a/libs/aegra-api/src/aegra_api/models/run_job.py
+++ b/libs/aegra-api/src/aegra_api/models/run_job.py
@@ -69,6 +69,10 @@ class RunJob(BaseModel):
     user: User
     execution: RunExecution = RunExecution()
     behavior: RunBehavior = RunBehavior()
+    # Scheduling metadata is kept on the job so local execution and workers
+    # apply the same API contract. Production workers use the persisted
+    # ``not_before`` column for crash-safe scheduling.
+    after_seconds: int = Field(default=0, ge=0)
     # JSONB-persisted; deliberately ``dict[str, Any]`` so legacy/drifted rows stay readable via
     # ``from_run_orm``. OTEL boundary in ``merge_run_metadata`` filters at emit. Do not narrow.
     run_metadata: dict[str, Any] = Field(default_factory=dict)
@@ -86,6 +90,7 @@ class RunJob(BaseModel):
             "execution": self.execution.model_dump(),
             "behavior": self.behavior.model_dump(),
             "run_metadata": self.run_metadata,
+            "after_seconds": self.after_seconds,
         }
 
     @classmethod
@@ -104,4 +109,5 @@ class RunJob(BaseModel):
             execution=RunExecution.model_validate(params["execution"]),
             behavior=RunBehavior.model_validate(params["behavior"]),
             run_metadata=params.get("run_metadata") or {},
+            after_seconds=params.get("after_seconds", 0),
         )

--- a/libs/aegra-api/src/aegra_api/models/run_job.py
+++ b/libs/aegra-api/src/aegra_api/models/run_job.py
@@ -71,7 +71,7 @@ class RunJob(BaseModel):
     behavior: RunBehavior = RunBehavior()
     # Scheduling metadata keeps local and worker API behavior aligned.
     # Production workers use persisted ``not_before`` for crash-safe scheduling.
-    after_seconds: int = Field(default=0, ge=0, le=2_147_483_647)
+    after_seconds: int = Field(default=0, strict=True, ge=0, le=2_147_483_647)
     # JSONB-persisted; deliberately ``dict[str, Any]`` so legacy/drifted rows stay readable via
     # ``from_run_orm``. OTEL boundary in ``merge_run_metadata`` filters at emit. Do not narrow.
     run_metadata: dict[str, Any] = Field(default_factory=dict)

--- a/libs/aegra-api/src/aegra_api/models/run_job.py
+++ b/libs/aegra-api/src/aegra_api/models/run_job.py
@@ -69,10 +69,9 @@ class RunJob(BaseModel):
     user: User
     execution: RunExecution = RunExecution()
     behavior: RunBehavior = RunBehavior()
-    # Scheduling metadata is kept on the job so local execution and workers
-    # apply the same API contract. Production workers use the persisted
-    # ``not_before`` column for crash-safe scheduling.
-    after_seconds: int = Field(default=0, ge=0)
+    # Scheduling metadata keeps local and worker API behavior aligned.
+    # Production workers use persisted ``not_before`` for crash-safe scheduling.
+    after_seconds: int = Field(default=0, ge=0, le=2_147_483_647)
     # JSONB-persisted; deliberately ``dict[str, Any]`` so legacy/drifted rows stay readable via
     # ``from_run_orm``. OTEL boundary in ``merge_run_metadata`` filters at emit. Do not narrow.
     run_metadata: dict[str, Any] = Field(default_factory=dict)

--- a/libs/aegra-api/src/aegra_api/models/runs.py
+++ b/libs/aegra-api/src/aegra_api/models/runs.py
@@ -31,6 +31,11 @@ class RunCreate(BaseModel):
     """Request model for creating runs"""
 
     assistant_id: str = Field(..., description="Assistant to execute")
+    after_seconds: int = Field(
+        0,
+        ge=0,
+        description="Delay execution by this many seconds after creating the run.",
+    )
     input: dict[str, Any] | None = Field(
         None,
         description="Input data for the run. Optional when resuming from a checkpoint.",

--- a/libs/aegra-api/src/aegra_api/models/runs.py
+++ b/libs/aegra-api/src/aegra_api/models/runs.py
@@ -33,6 +33,7 @@ class RunCreate(BaseModel):
     assistant_id: str = Field(..., description="Assistant to execute")
     after_seconds: int = Field(
         0,
+        strict=True,
         ge=0,
         le=2_147_483_647,
         description="Delay execution by this many seconds after creating the run.",

--- a/libs/aegra-api/src/aegra_api/models/runs.py
+++ b/libs/aegra-api/src/aegra_api/models/runs.py
@@ -34,6 +34,7 @@ class RunCreate(BaseModel):
     after_seconds: int = Field(
         0,
         ge=0,
+        le=2_147_483_647,
         description="Delay execution by this many seconds after creating the run.",
     )
     input: dict[str, Any] | None = Field(

--- a/libs/aegra-api/src/aegra_api/services/base_executor.py
+++ b/libs/aegra-api/src/aegra_api/services/base_executor.py
@@ -14,7 +14,7 @@ class BaseExecutor(ABC):
 
     @abstractmethod
     async def submit(self, job: RunJob) -> None:
-        """Enqueue a job for execution. Returns immediately."""
+        """Schedule a job for execution. Returns immediately, including delays."""
 
     @abstractmethod
     async def wait_for_completion(self, run_id: str, *, timeout: float = 300.0) -> None:

--- a/libs/aegra-api/src/aegra_api/services/lease_reaper.py
+++ b/libs/aegra-api/src/aegra_api/services/lease_reaper.py
@@ -95,6 +95,8 @@ class LeaseReaper:
         budget is only charged to crashed runs, not stuck pending ones.
         """
         now = datetime.now(UTC)
+        dispatch_lease_seconds = max(5, min(30, settings.worker.POSTGRES_POLL_INTERVAL_SECONDS * 2))
+        retry_after = now - timedelta(seconds=dispatch_lease_seconds)
         maker = _get_session_maker()
         async with maker() as session:
             crashed_result = await session.execute(
@@ -111,6 +113,7 @@ class LeaseReaper:
                     RunORM.status == "pending",
                     RunORM.claimed_by.is_(None),
                     or_(RunORM.not_before.is_(None), RunORM.not_before <= now),
+                    or_(RunORM.dispatched_at.is_(None), RunORM.dispatched_at < retry_after),
                     RunORM.created_at < now - timedelta(seconds=settings.worker.STUCK_PENDING_THRESHOLD_SECONDS),
                 )
             )

--- a/libs/aegra-api/src/aegra_api/services/lease_reaper.py
+++ b/libs/aegra-api/src/aegra_api/services/lease_reaper.py
@@ -12,7 +12,7 @@ from datetime import UTC, datetime, timedelta
 
 import structlog
 from redis import RedisError
-from sqlalchemy import select, update
+from sqlalchemy import or_, select, update
 
 from aegra_api.core.orm import Run as RunORM
 from aegra_api.core.orm import _get_session_maker
@@ -110,6 +110,7 @@ class LeaseReaper:
                 select(RunORM.run_id).where(
                     RunORM.status == "pending",
                     RunORM.claimed_by.is_(None),
+                    or_(RunORM.not_before.is_(None), RunORM.not_before <= now),
                     RunORM.created_at < now - timedelta(seconds=settings.worker.STUCK_PENDING_THRESHOLD_SECONDS),
                 )
             )

--- a/libs/aegra-api/src/aegra_api/services/local_executor.py
+++ b/libs/aegra-api/src/aegra_api/services/local_executor.py
@@ -32,7 +32,13 @@ class LocalExecutor(BaseExecutor):
             job.user.identity,
             extra_metadata=job.run_metadata,
         )
-        task = asyncio.create_task(execute_run(job), context=trace_ctx)
+
+        async def _run_after_delay() -> None:
+            if job.after_seconds:
+                await asyncio.sleep(job.after_seconds)
+            await execute_run(job)
+
+        task = asyncio.create_task(_run_after_delay(), context=trace_ctx)
         active_runs[job.identity.run_id] = task
         logger.info(
             "Submitted run to local executor",

--- a/libs/aegra-api/src/aegra_api/services/local_executor.py
+++ b/libs/aegra-api/src/aegra_api/services/local_executor.py
@@ -34,9 +34,14 @@ class LocalExecutor(BaseExecutor):
         )
 
         async def _run_after_delay() -> None:
-            if job.after_seconds:
-                await asyncio.sleep(job.after_seconds)
-            await execute_run(job)
+            try:
+                if job.after_seconds:
+                    await asyncio.sleep(job.after_seconds)
+                await execute_run(job)
+            finally:
+                current = asyncio.current_task()
+                if active_runs.get(job.identity.run_id) is current:
+                    active_runs.pop(job.identity.run_id, None)
 
         task = asyncio.create_task(_run_after_delay(), context=trace_ctx)
         active_runs[job.identity.run_id] = task

--- a/libs/aegra-api/src/aegra_api/services/run_preparation.py
+++ b/libs/aegra-api/src/aegra_api/services/run_preparation.py
@@ -203,9 +203,8 @@ async def _prepare_run(
     """
     await _validate_resume_command(session, thread_id, request.command)
 
-    # FastAPI supplies a validated RunCreate, but keeping this boundary
-    # defensive preserves compatibility with internal callers and tests that
-    # provide request-like objects rather than a Pydantic instance.
+    # FastAPI provides RunCreate; this boundary also supports request-like
+    # internal and test callers without a Pydantic instance.
     after_seconds = getattr(request, "after_seconds", 0)
     if not isinstance(after_seconds, int):
         after_seconds = 0

--- a/libs/aegra-api/src/aegra_api/services/run_preparation.py
+++ b/libs/aegra-api/src/aegra_api/services/run_preparation.py
@@ -203,11 +203,11 @@ async def _prepare_run(
     """
     await _validate_resume_command(session, thread_id, request.command)
 
-    # FastAPI provides RunCreate; this boundary also supports request-like
-    # internal and test callers without a Pydantic instance.
-    after_seconds = getattr(request, "after_seconds", 0)
-    if not isinstance(after_seconds, int):
-        after_seconds = 0
+    # FastAPI provides RunCreate; request-like callers may omit this field.
+    request_fields = getattr(request, "__dict__", {})
+    after_seconds = getattr(request, "after_seconds", 0) if "after_seconds" in request_fields else 0
+    if not isinstance(after_seconds, int) or not 0 <= after_seconds <= 2_147_483_647:
+        raise HTTPException(status_code=422, detail="`after_seconds` must be an integer between 0 and 2147483647")
 
     run_id = str(uuid4())
     langgraph_service = get_langgraph_service()

--- a/libs/aegra-api/src/aegra_api/services/run_preparation.py
+++ b/libs/aegra-api/src/aegra_api/services/run_preparation.py
@@ -5,7 +5,7 @@ resume-command validation, and config/context merging logic.
 """
 
 import asyncio
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 from uuid import uuid4
 
@@ -203,6 +203,13 @@ async def _prepare_run(
     """
     await _validate_resume_command(session, thread_id, request.command)
 
+    # FastAPI supplies a validated RunCreate, but keeping this boundary
+    # defensive preserves compatibility with internal callers and tests that
+    # provide request-like objects rather than a Pydantic instance.
+    after_seconds = getattr(request, "after_seconds", 0)
+    if not isinstance(after_seconds, int):
+        after_seconds = 0
+
     run_id = str(uuid4())
     langgraph_service = get_langgraph_service()
     logger.info(
@@ -270,6 +277,7 @@ async def _prepare_run(
             subgraphs=request.stream_subgraphs or False,
         ),
         run_metadata=request.metadata or {},
+        after_seconds=after_seconds,
     )
 
     # Persist run record with trace metadata for worker observability.
@@ -284,6 +292,7 @@ async def _prepare_run(
     }
 
     now = datetime.now(UTC)
+    not_before = now + timedelta(seconds=after_seconds) if after_seconds else None
     run_orm = RunORM(
         run_id=run_id,
         thread_id=thread_id,
@@ -298,6 +307,7 @@ async def _prepare_run(
         output=None,
         error_message=None,
         execution_params=exec_params,
+        not_before=not_before,
     )
     session.add(run_orm)
     await session.commit()

--- a/libs/aegra-api/src/aegra_api/services/worker_executor.py
+++ b/libs/aegra-api/src/aegra_api/services/worker_executor.py
@@ -322,17 +322,22 @@ class WorkerExecutor(BaseExecutor):
             )
             await session.commit()
 
+        pushed_ids: list[str] = []
         try:
             client = redis_manager.get_client()
             for run_id in run_ids:
                 await client.rpush(settings.worker.WORKER_QUEUE_KEY, run_id)  # type: ignore[arg-type]
+                pushed_ids.append(run_id)
                 logger.info("Dispatched delayed run", run_id=run_id)
         except RedisError:
+            unpushed_ids = [run_id for run_id in run_ids if run_id not in pushed_ids]
+            if not unpushed_ids:
+                return
             async with maker() as session:
                 await session.execute(
                     update(RunORM)
                     .where(
-                        RunORM.run_id.in_(run_ids),
+                        RunORM.run_id.in_(unpushed_ids),
                         RunORM.status == "pending",
                         RunORM.claimed_by.is_(None),
                         RunORM.dispatched_at == now,

--- a/libs/aegra-api/src/aegra_api/services/worker_executor.py
+++ b/libs/aegra-api/src/aegra_api/services/worker_executor.py
@@ -2,8 +2,10 @@
 
 Production mode (REDIS_BROKER_ENABLED=true). Each worker loop dequeues
 run_ids from Redis via BLPOP and spawns up to N_JOBS_PER_WORKER
-concurrent asyncio tasks. Each task acquires a lease, executes the
-graph with periodic heartbeats, and releases the lease on completion.
+concurrent asyncio tasks. Delayed runs stay persisted in Postgres until
+their not-before timestamp and are dispatched by a lightweight scheduler.
+Each execution task acquires a lease, executes the graph with periodic
+heartbeats, and releases the lease on completion.
 If a worker crashes, the lease expires and a background reaper
 re-enqueues the run.
 """
@@ -93,6 +95,7 @@ class WorkerExecutor(BaseExecutor):
 
     def __init__(self) -> None:
         self._worker_tasks: list[asyncio.Task[None]] = []
+        self._dispatch_task: asyncio.Task[None] | None = None
         # Task -> run_id, mapped at creation: a task cancelled before it ever
         # runs has no active_runs entry, yet its run still needs the drain requeue.
         self._job_tasks: dict[asyncio.Task[None], str] = {}
@@ -104,6 +107,15 @@ class WorkerExecutor(BaseExecutor):
     # ------------------------------------------------------------------
 
     async def submit(self, job: RunJob) -> None:
+        # Delayed jobs remain in Postgres until their persisted boundary. The
+        # dispatcher started below will enqueue them when they become due.
+        if job.after_seconds:
+            logger.info(
+                "Delayed run persisted for later dispatch",
+                run_id=job.identity.run_id,
+                after_seconds=job.after_seconds,
+            )
+            return
         client = redis_manager.get_client()
         await client.rpush(settings.worker.WORKER_QUEUE_KEY, job.identity.run_id)  # type: ignore[arg-type]
         logger.info(
@@ -145,6 +157,7 @@ class WorkerExecutor(BaseExecutor):
 
     async def start(self) -> None:
         self._running = True
+        self._dispatch_task = asyncio.create_task(self._dispatch_loop())
         count = settings.worker.WORKER_COUNT
         if count == 0:
             logger.warning(
@@ -166,6 +179,10 @@ class WorkerExecutor(BaseExecutor):
 
     async def stop(self) -> None:
         self._running = False
+        if self._dispatch_task is not None:
+            self._dispatch_task.cancel()
+            await asyncio.gather(self._dispatch_task, return_exceptions=True)
+            self._dispatch_task = None
         drain_timeout = settings.worker.WORKER_DRAIN_TIMEOUT
 
         # Wait for in-flight job tasks to finish
@@ -258,6 +275,48 @@ class WorkerExecutor(BaseExecutor):
                 await asyncio.sleep(1.0)
 
         logger.info("Worker stopped", worker=worker_name)
+
+    async def _dispatch_loop(self) -> None:
+        """Push persisted delayed runs once their not-before time arrives."""
+        interval = max(0.1, min(1.0, settings.worker.POSTGRES_POLL_INTERVAL_SECONDS))
+        while self._running:
+            try:
+                await self._dispatch_due_runs()
+                await asyncio.sleep(interval)
+            except asyncio.CancelledError:
+                break
+            except Exception:
+                logger.exception("Unexpected error dispatching delayed runs")
+                await asyncio.sleep(interval)
+
+    async def _dispatch_due_runs(self) -> None:
+        maker = _get_session_maker()
+        now = datetime.now(UTC)
+        async with maker() as session:
+            result = await session.execute(
+                select(RunORM.run_id)
+                .where(
+                    RunORM.status == "pending",
+                    RunORM.claimed_by.is_(None),
+                    RunORM.not_before.isnot(None),
+                    RunORM.not_before <= now,
+                )
+                .order_by(RunORM.not_before.asc())
+                .limit(100)
+            )
+            run_ids = [row[0] for row in result.fetchall()]
+
+        if not run_ids:
+            return
+        try:
+            client = redis_manager.get_client()
+            for run_id in run_ids:
+                await client.rpush(settings.worker.WORKER_QUEUE_KEY, run_id)  # type: ignore[arg-type]
+                logger.info("Dispatched delayed run", run_id=run_id)
+        except RedisError:
+            # Leave the row pending and unclaimed. The Postgres fallback below
+            # remains available, and the next dispatch tick retries Redis.
+            logger.warning("Redis unavailable while dispatching delayed runs", run_ids=run_ids)
 
     async def _execute_and_release(
         self,
@@ -394,6 +453,7 @@ class WorkerExecutor(BaseExecutor):
             run_id = await session.scalar(
                 select(RunORM.run_id)
                 .where(RunORM.status == "pending", RunORM.claimed_by.is_(None))
+                .where(RunORM.not_before.is_(None) | (RunORM.not_before <= datetime.now(UTC)))
                 .order_by(RunORM.created_at.asc())
                 .limit(1)
             )

--- a/libs/aegra-api/src/aegra_api/services/worker_executor.py
+++ b/libs/aegra-api/src/aegra_api/services/worker_executor.py
@@ -308,40 +308,30 @@ class WorkerExecutor(BaseExecutor):
                 .with_for_update(skip_locked=True)
             )
             run_ids = [row[0] for row in result.fetchall()]
-            if run_ids:
-                await session.execute(
-                    update(RunORM)
-                    .where(
-                        RunORM.run_id.in_(run_ids),
-                        RunORM.status == "pending",
-                        RunORM.claimed_by.is_(None),
-                    )
-                    .values(dispatched_at=now)
-                )
-                await session.commit()
+            if not run_ids:
+                return
+            try:
+                client = redis_manager.get_client()
+                for run_id in run_ids:
+                    await client.rpush(settings.worker.WORKER_QUEUE_KEY, run_id)  # type: ignore[arg-type]
+                    logger.info("Dispatched delayed run", run_id=run_id)
+            except RedisError:
+                await session.rollback()
+                logger.warning("Redis unavailable while dispatching delayed runs", run_ids=run_ids)
+                return
 
-        if not run_ids:
-            return
-        try:
-            client = redis_manager.get_client()
-            for run_id in run_ids:
-                await client.rpush(settings.worker.WORKER_QUEUE_KEY, run_id)  # type: ignore[arg-type]
-                logger.info("Dispatched delayed run", run_id=run_id)
-        except RedisError:
-            # Clear the marker so the next tick retries the push.
-            async with maker() as session:
-                await session.execute(
-                    update(RunORM)
-                    .where(
-                        RunORM.run_id.in_(run_ids),
-                        RunORM.status == "pending",
-                        RunORM.claimed_by.is_(None),
-                        RunORM.dispatched_at == now,
-                    )
-                    .values(dispatched_at=None)
+            # Publish before committing the marker: a crash can duplicate a
+            # queue entry, but it cannot strand a run behind a committed marker.
+            await session.execute(
+                update(RunORM)
+                .where(
+                    RunORM.run_id.in_(run_ids),
+                    RunORM.status == "pending",
+                    RunORM.claimed_by.is_(None),
                 )
-                await session.commit()
-            logger.warning("Redis unavailable while dispatching delayed runs", run_ids=run_ids)
+                .values(dispatched_at=now)
+            )
+            await session.commit()
 
     async def _execute_and_release(
         self,

--- a/libs/aegra-api/src/aegra_api/services/worker_executor.py
+++ b/libs/aegra-api/src/aegra_api/services/worker_executor.py
@@ -292,7 +292,8 @@ class WorkerExecutor(BaseExecutor):
     async def _dispatch_due_runs(self) -> None:
         maker = _get_session_maker()
         now = datetime.now(UTC)
-        retry_after = now - timedelta(seconds=settings.worker.STUCK_PENDING_THRESHOLD_SECONDS)
+        dispatch_lease_seconds = max(5, min(30, settings.worker.POSTGRES_POLL_INTERVAL_SECONDS * 2))
+        retry_after = now - timedelta(seconds=dispatch_lease_seconds)
         async with maker() as session:
             result = await session.execute(
                 select(RunORM.run_id)
@@ -310,18 +311,6 @@ class WorkerExecutor(BaseExecutor):
             run_ids = [row[0] for row in result.fetchall()]
             if not run_ids:
                 return
-            try:
-                client = redis_manager.get_client()
-                for run_id in run_ids:
-                    await client.rpush(settings.worker.WORKER_QUEUE_KEY, run_id)  # type: ignore[arg-type]
-                    logger.info("Dispatched delayed run", run_id=run_id)
-            except RedisError:
-                await session.rollback()
-                logger.warning("Redis unavailable while dispatching delayed runs", run_ids=run_ids)
-                return
-
-            # Publish before committing the marker: a crash can duplicate a
-            # queue entry, but it cannot strand a run behind a committed marker.
             await session.execute(
                 update(RunORM)
                 .where(
@@ -332,6 +321,26 @@ class WorkerExecutor(BaseExecutor):
                 .values(dispatched_at=now)
             )
             await session.commit()
+
+        try:
+            client = redis_manager.get_client()
+            for run_id in run_ids:
+                await client.rpush(settings.worker.WORKER_QUEUE_KEY, run_id)  # type: ignore[arg-type]
+                logger.info("Dispatched delayed run", run_id=run_id)
+        except RedisError:
+            async with maker() as session:
+                await session.execute(
+                    update(RunORM)
+                    .where(
+                        RunORM.run_id.in_(run_ids),
+                        RunORM.status == "pending",
+                        RunORM.claimed_by.is_(None),
+                        RunORM.dispatched_at == now,
+                    )
+                    .values(dispatched_at=None)
+                )
+                await session.commit()
+            logger.warning("Redis unavailable while dispatching delayed runs", run_ids=run_ids)
 
     async def _execute_and_release(
         self,

--- a/libs/aegra-api/src/aegra_api/services/worker_executor.py
+++ b/libs/aegra-api/src/aegra_api/services/worker_executor.py
@@ -22,7 +22,7 @@ import structlog
 from asgi_correlation_id import correlation_id
 from redis import RedisError
 from redis import TimeoutError as RedisTimeoutError
-from sqlalchemy import select, update
+from sqlalchemy import or_, select, update
 
 from aegra_api.core.active_runs import active_runs, explicit_run_cancellations
 from aegra_api.core.orm import Run as RunORM
@@ -292,6 +292,7 @@ class WorkerExecutor(BaseExecutor):
     async def _dispatch_due_runs(self) -> None:
         maker = _get_session_maker()
         now = datetime.now(UTC)
+        retry_after = now - timedelta(seconds=settings.worker.STUCK_PENDING_THRESHOLD_SECONDS)
         async with maker() as session:
             result = await session.execute(
                 select(RunORM.run_id)
@@ -300,11 +301,24 @@ class WorkerExecutor(BaseExecutor):
                     RunORM.claimed_by.is_(None),
                     RunORM.not_before.isnot(None),
                     RunORM.not_before <= now,
+                    or_(RunORM.dispatched_at.is_(None), RunORM.dispatched_at < retry_after),
                 )
                 .order_by(RunORM.not_before.asc())
                 .limit(100)
+                .with_for_update(skip_locked=True)
             )
             run_ids = [row[0] for row in result.fetchall()]
+            if run_ids:
+                await session.execute(
+                    update(RunORM)
+                    .where(
+                        RunORM.run_id.in_(run_ids),
+                        RunORM.status == "pending",
+                        RunORM.claimed_by.is_(None),
+                    )
+                    .values(dispatched_at=now)
+                )
+                await session.commit()
 
         if not run_ids:
             return
@@ -314,8 +328,19 @@ class WorkerExecutor(BaseExecutor):
                 await client.rpush(settings.worker.WORKER_QUEUE_KEY, run_id)  # type: ignore[arg-type]
                 logger.info("Dispatched delayed run", run_id=run_id)
         except RedisError:
-            # Leave the row pending and unclaimed. The Postgres fallback below
-            # remains available, and the next dispatch tick retries Redis.
+            # Clear the marker so the next tick retries the push.
+            async with maker() as session:
+                await session.execute(
+                    update(RunORM)
+                    .where(
+                        RunORM.run_id.in_(run_ids),
+                        RunORM.status == "pending",
+                        RunORM.claimed_by.is_(None),
+                        RunORM.dispatched_at == now,
+                    )
+                    .values(dispatched_at=None)
+                )
+                await session.commit()
             logger.warning("Redis unavailable while dispatching delayed runs", run_ids=run_ids)
 
     async def _execute_and_release(
@@ -498,7 +523,8 @@ async def _acquire_and_load(run_id: str, worker_name: str) -> _LoadedRun | None:
     is missing execution_params (data corruption / pre-migration row),
     releases the claim and marks the run as errored.
     """
-    lease_until = datetime.now(UTC) + timedelta(seconds=settings.worker.LEASE_DURATION_SECONDS)
+    now = datetime.now(UTC)
+    lease_until = now + timedelta(seconds=settings.worker.LEASE_DURATION_SECONDS)
     maker = _get_session_maker()
     async with maker() as session:
         result = await session.execute(
@@ -507,6 +533,7 @@ async def _acquire_and_load(run_id: str, worker_name: str) -> _LoadedRun | None:
                 RunORM.run_id == run_id,
                 RunORM.status == "pending",
                 RunORM.claimed_by.is_(None),
+                or_(RunORM.not_before.is_(None), RunORM.not_before <= now),
             )
             .values(claimed_by=worker_name, lease_expires_at=lease_until, status="running")
         )

--- a/libs/aegra-api/tests/e2e/test_runs/test_runs.py
+++ b/libs/aegra-api/tests/e2e/test_runs/test_runs.py
@@ -1,4 +1,7 @@
+import asyncio
+
 import pytest
+from httpx import AsyncClient
 
 from aegra_api.settings import settings
 
@@ -96,6 +99,38 @@ async def test_runs_crud_and_join_e2e():
                 end_seen = True
                 break
         assert end_seen, "Expected an 'end' event when streaming a terminal run"
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_delayed_run_starts_after_requested_delay_e2e() -> None:
+    """A delayed run remains pending before its schedule and then completes."""
+    client = get_e2e_client()
+    thread = await client.threads.create()
+    thread_id = thread["thread_id"]
+    started = asyncio.get_running_loop().time()
+
+    async with AsyncClient(base_url=settings.app.SERVER_URL, timeout=120.0) as http:
+        response = await http.post(
+            f"/threads/{thread_id}/runs",
+            json={
+                "assistant_id": "agent",
+                "input": {"messages": [{"role": "user", "content": "Say delayed."}]},
+                "after_seconds": 2,
+            },
+        )
+    assert response.status_code == 200, response.text
+    run = response.json()
+    assert run["status"] == "pending"
+
+    await asyncio.sleep(0.5)
+    before_due = await client.runs.get(thread_id, run["run_id"])
+    assert before_due["status"] == "pending"
+
+    final_run = await await_terminal_run(client, thread_id, run["run_id"], timeout=30.0)
+    check_and_skip_if_geo_blocked(final_run)
+    assert asyncio.get_running_loop().time() - started >= 1.5
+    assert final_run["status"] in ("success", "error")
 
 
 @pytest.mark.e2e

--- a/libs/aegra-api/tests/e2e/test_runs/test_runs.py
+++ b/libs/aegra-api/tests/e2e/test_runs/test_runs.py
@@ -108,9 +108,9 @@ async def test_delayed_run_starts_after_requested_delay_e2e() -> None:
     client = get_e2e_client()
     thread = await client.threads.create()
     thread_id = thread["thread_id"]
-    started = asyncio.get_running_loop().time()
 
     async with AsyncClient(base_url=settings.app.SERVER_URL, timeout=120.0) as http:
+        started = asyncio.get_running_loop().time()
         response = await http.post(
             f"/threads/{thread_id}/runs",
             json={

--- a/libs/aegra-api/tests/unit/test_models/test_runcreate_validation.py
+++ b/libs/aegra-api/tests/unit/test_models/test_runcreate_validation.py
@@ -25,6 +25,11 @@ class TestRunCreateValidation:
         with pytest.raises(ValidationError):
             RunCreate(assistant_id="assistant", input={"value": 1}, after_seconds=2_147_483_648)
 
+    @pytest.mark.parametrize("value", ["30", 30.0])
+    def test_after_seconds_rejects_non_integer_values(self, value: int | float | str) -> None:
+        with pytest.raises(ValidationError):
+            RunCreate(assistant_id="assistant", input={"value": 1}, after_seconds=value)
+
     def test_checkpoint_only_payload_preserves_none_input(self):
         """Checkpoint-only payloads must keep input as None so LangGraph resumes
         from the checkpoint instead of restarting the graph from __start__.

--- a/libs/aegra-api/tests/unit/test_models/test_runcreate_validation.py
+++ b/libs/aegra-api/tests/unit/test_models/test_runcreate_validation.py
@@ -26,7 +26,9 @@ class TestRunCreateValidation:
             RunCreate(assistant_id="assistant", input={"value": 1}, after_seconds=2_147_483_648)
 
     @pytest.mark.parametrize("value", ["30", 30.0])
-    def test_after_seconds_rejects_non_integer_values(self, value: int | float | str) -> None:
+    def test_after_seconds_rejects_non_integer_values(
+        self: "TestRunCreateValidation", value: int | float | str
+    ) -> None:
         with pytest.raises(ValidationError):
             RunCreate(assistant_id="assistant", input={"value": 1}, after_seconds=value)
 

--- a/libs/aegra-api/tests/unit/test_models/test_runcreate_validation.py
+++ b/libs/aegra-api/tests/unit/test_models/test_runcreate_validation.py
@@ -9,6 +9,18 @@ from aegra_api.models.runs import RunCreate
 class TestRunCreateValidation:
     """Tests for RunCreate input/command validation."""
 
+    def test_after_seconds_defaults_to_zero(self) -> None:
+        run = RunCreate(assistant_id="assistant", input={"value": 1})
+        assert run.after_seconds == 0
+
+    def test_after_seconds_accepts_non_negative_delay(self) -> None:
+        run = RunCreate(assistant_id="assistant", input={"value": 1}, after_seconds=30)
+        assert run.after_seconds == 30
+
+    def test_after_seconds_rejects_negative_delay(self) -> None:
+        with pytest.raises(ValidationError):
+            RunCreate(assistant_id="assistant", input={"value": 1}, after_seconds=-1)
+
     def test_checkpoint_only_payload_preserves_none_input(self):
         """Checkpoint-only payloads must keep input as None so LangGraph resumes
         from the checkpoint instead of restarting the graph from __start__.

--- a/libs/aegra-api/tests/unit/test_models/test_runcreate_validation.py
+++ b/libs/aegra-api/tests/unit/test_models/test_runcreate_validation.py
@@ -21,6 +21,10 @@ class TestRunCreateValidation:
         with pytest.raises(ValidationError):
             RunCreate(assistant_id="assistant", input={"value": 1}, after_seconds=-1)
 
+    def test_after_seconds_rejects_unrepresentable_delay(self) -> None:
+        with pytest.raises(ValidationError):
+            RunCreate(assistant_id="assistant", input={"value": 1}, after_seconds=2_147_483_648)
+
     def test_checkpoint_only_payload_preserves_none_input(self):
         """Checkpoint-only payloads must keep input as None so LangGraph resumes
         from the checkpoint instead of restarting the graph from __start__.

--- a/libs/aegra-api/tests/unit/test_services/test_executor.py
+++ b/libs/aegra-api/tests/unit/test_services/test_executor.py
@@ -57,9 +57,10 @@ class TestLocalExecutor:
             await asyncio.sleep(0.05)
 
             mock_execute.assert_not_awaited()
-            task = active_runs.pop("delayed-run")
+            task = active_runs["delayed-run"]
             task.cancel()
             await asyncio.gather(task, return_exceptions=True)
+            assert "delayed-run" not in active_runs
 
     @pytest.mark.asyncio
     async def test_wait_for_completion_returns_on_done(self) -> None:

--- a/libs/aegra-api/tests/unit/test_services/test_executor.py
+++ b/libs/aegra-api/tests/unit/test_services/test_executor.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from aegra_api.core.active_runs import active_runs
 from aegra_api.models.auth import User
 from aegra_api.models.run_job import RunExecution, RunIdentity, RunJob
 from aegra_api.services.local_executor import LocalExecutor
@@ -42,6 +43,23 @@ class TestLocalExecutor:
             assert "run-1" in active_runs
             task = active_runs.pop("run-1")
             task.cancel()
+
+    @pytest.mark.asyncio
+    async def test_submit_delays_execution_without_blocking_submission(self) -> None:
+        executor = LocalExecutor()
+        mock_execute = AsyncMock()
+
+        with (
+            patch("aegra_api.services.run_executor.execute_run", mock_execute),
+            patch("aegra_api.services.local_executor.make_run_trace_context", return_value=None),
+        ):
+            await executor.submit(_make_job("delayed-run").model_copy(update={"after_seconds": 1}))
+            await asyncio.sleep(0.05)
+
+            mock_execute.assert_not_awaited()
+            task = active_runs.pop("delayed-run")
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
 
     @pytest.mark.asyncio
     async def test_wait_for_completion_returns_on_done(self) -> None:

--- a/libs/aegra-api/tests/unit/test_services/test_lease_reaper.py
+++ b/libs/aegra-api/tests/unit/test_services/test_lease_reaper.py
@@ -54,6 +54,25 @@ class TestFindRecoverable:
         assert crashed == []
         assert stuck == []
 
+    @pytest.mark.asyncio
+    async def test_stuck_pending_query_excludes_recently_dispatched_runs(self) -> None:
+        session = AsyncMock()
+        empty_result = MagicMock()
+        empty_result.fetchall.return_value = []
+        session.execute = AsyncMock(return_value=empty_result)
+        maker = _make_session_maker(session)
+
+        with (
+            patch("aegra_api.services.lease_reaper._get_session_maker", return_value=maker),
+            patch("aegra_api.services.lease_reaper.settings") as mock_settings,
+        ):
+            mock_settings.worker.POSTGRES_POLL_INTERVAL_SECONDS = 5
+            mock_settings.worker.STUCK_PENDING_THRESHOLD_SECONDS = 120
+            await LeaseReaper._find_recoverable()
+
+        stuck_query = session.execute.await_args_list[1].args[0]
+        assert "runs.dispatched_at" in str(stuck_query.compile())
+
 
 class TestRecoverCrashedRuns:
     @pytest.mark.asyncio

--- a/libs/aegra-api/tests/unit/test_services/test_lease_reaper.py
+++ b/libs/aegra-api/tests/unit/test_services/test_lease_reaper.py
@@ -71,7 +71,9 @@ class TestFindRecoverable:
             await LeaseReaper._find_recoverable()
 
         stuck_query = session.execute.await_args_list[1].args[0]
-        assert "runs.dispatched_at" in str(stuck_query.compile())
+        compiled = str(stuck_query.compile())
+        assert "runs.dispatched_at IS NULL" in compiled
+        assert "runs.dispatched_at <" in compiled
 
 
 class TestRecoverCrashedRuns:

--- a/libs/aegra-api/tests/unit/test_services/test_run_job.py
+++ b/libs/aegra-api/tests/unit/test_services/test_run_job.py
@@ -98,6 +98,18 @@ class TestRunJob:
         assert "run_id" not in params
         assert "thread_id" not in params
 
+    def test_after_seconds_roundtrips_in_execution_params(self, sample_job: RunJob) -> None:
+        delayed = sample_job.model_copy(update={"after_seconds": 30})
+        params = delayed.to_execution_params()
+
+        class FakeORM:
+            run_id = "run-1"
+            thread_id = "thread-1"
+            execution_params = params
+
+        restored = RunJob.from_run_orm(FakeORM())
+        assert restored.after_seconds == 30
+
     def test_extra_user_fields_preserved(self) -> None:
         """User model allows extra fields (ConfigDict extra='allow')."""
         job = RunJob(

--- a/libs/aegra-api/tests/unit/test_services/test_run_job.py
+++ b/libs/aegra-api/tests/unit/test_services/test_run_job.py
@@ -137,6 +137,23 @@ class TestRunJob:
         assert job.behavior.subgraphs is False
         assert job.run_metadata == {}
 
+    def test_legacy_execution_params_without_after_seconds_default_to_zero(self, sample_job: RunJob) -> None:
+        params = sample_job.to_execution_params()
+        params.pop("after_seconds")
+
+        class LegacyORM:
+            run_id = "run-1"
+            thread_id = "thread-1"
+            execution_params = params
+
+        restored = RunJob.from_run_orm(LegacyORM())
+        assert restored.after_seconds == 0
+
+    @pytest.mark.parametrize("value", ["30", 30.0, -1, 2_147_483_648])
+    def test_rejects_invalid_after_seconds_values(self, sample_job: RunJob, value: object) -> None:
+        with pytest.raises(ValidationError):
+            RunJob.model_validate(sample_job.model_dump() | {"after_seconds": value})
+
     def test_run_metadata_roundtrip(self) -> None:
         """run_metadata round-trips through to_execution_params / from_run_orm."""
         job = RunJob(

--- a/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
+++ b/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
@@ -498,6 +498,7 @@ class TestDelayedRunDispatch:
             patch(f"{MODULE}.settings") as mock_settings,
         ):
             mock_settings.worker.WORKER_QUEUE_KEY = "aegra:jobs"
+            mock_settings.worker.STUCK_PENDING_THRESHOLD_SECONDS = 120
             await WorkerExecutor()._dispatch_due_runs()
 
         mock_client.rpush.assert_awaited_once_with("aegra:jobs", "run-due")

--- a/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
+++ b/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
@@ -471,6 +471,37 @@ class TestWorkerExecutorSubmit:
 
         mock_client.rpush.assert_awaited_once_with("aegra:jobs", "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
 
+    @pytest.mark.asyncio
+    async def test_delayed_run_is_not_pushed_before_not_before(self) -> None:
+        mock_client = AsyncMock()
+        job = _make_run_job()
+        delayed_job = job.model_copy(update={"after_seconds": 30})
+
+        with patch(f"{MODULE}.redis_manager.get_client", return_value=mock_client):
+            await WorkerExecutor().submit(delayed_job)
+
+        mock_client.rpush.assert_not_awaited()
+
+
+class TestDelayedRunDispatch:
+    @pytest.mark.asyncio
+    async def test_dispatches_only_due_pending_rows(self) -> None:
+        session = AsyncMock()
+        result = MagicMock()
+        result.fetchall.return_value = [("run-due",)]
+        session.execute.return_value = result
+        mock_client = AsyncMock()
+
+        with (
+            patch(f"{MODULE}._get_session_maker", return_value=_make_session_maker(session)),
+            patch(f"{MODULE}.redis_manager.get_client", return_value=mock_client),
+            patch(f"{MODULE}.settings") as mock_settings,
+        ):
+            mock_settings.worker.WORKER_QUEUE_KEY = "aegra:jobs"
+            await WorkerExecutor()._dispatch_due_runs()
+
+        mock_client.rpush.assert_awaited_once_with("aegra:jobs", "run-due")
+
 
 # ------------------------------------------------------------------
 # WorkerExecutor.wait_for_completion

--- a/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
+++ b/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
@@ -499,6 +499,7 @@ class TestDelayedRunDispatch:
         ):
             mock_settings.worker.WORKER_QUEUE_KEY = "aegra:jobs"
             mock_settings.worker.STUCK_PENDING_THRESHOLD_SECONDS = 120
+            mock_settings.worker.POSTGRES_POLL_INTERVAL_SECONDS = 5
             await WorkerExecutor()._dispatch_due_runs()
 
         mock_client.rpush.assert_awaited_once_with("aegra:jobs", "run-due")

--- a/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
+++ b/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
@@ -504,6 +504,28 @@ class TestDelayedRunDispatch:
 
         mock_client.rpush.assert_awaited_once_with("aegra:jobs", "run-due")
 
+    @pytest.mark.asyncio
+    async def test_preserves_lease_for_runs_already_pushed_when_redis_fails_mid_batch(self) -> None:
+        session = AsyncMock()
+        result = MagicMock()
+        result.fetchall.return_value = [("run-1",), ("run-2",)]
+        session.execute.side_effect = [result, MagicMock(), MagicMock()]
+        mock_client = AsyncMock()
+        mock_client.rpush.side_effect = [1, RedisConnectionError("connection reset")]
+
+        with (
+            patch(f"{MODULE}._get_session_maker", return_value=_make_session_maker(session)),
+            patch(f"{MODULE}.redis_manager.get_client", return_value=mock_client),
+            patch(f"{MODULE}.settings") as mock_settings,
+        ):
+            mock_settings.worker.WORKER_QUEUE_KEY = "aegra:jobs"
+            mock_settings.worker.POSTGRES_POLL_INTERVAL_SECONDS = 5
+            await WorkerExecutor()._dispatch_due_runs()
+
+        reset_statement = session.execute.await_args_list[2].args[0]
+        reset_params = reset_statement.compile().params
+        assert reset_params["run_id_1"] == ["run-2"]
+
 
 # ------------------------------------------------------------------
 # WorkerExecutor.wait_for_completion

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.10.4"
+version = "0.10.5"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.10.4"
+version = "0.10.5"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -100,7 +100,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.10.4"
+version = "0.10.5"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
 ## Summary

  Implement support for `after_seconds` when creating runs.

  Closes #574

  ## Changes

  - Add `after_seconds` to `RunCreate`.
  - Persist delayed execution using `runs.not_before`.
  - Add Alembic migration and scheduling index.
  - Delay execution in `LocalExecutor`.
  - Add due-run dispatching for `WorkerExecutor`.
  - Prevent workers from claiming runs before their scheduled time.
  - Preserve cancellation and restart recovery behavior.
  - Add architecture documentation and regression tests.

  ## Testing

  - Relevant unit tests: 94 passed.
  - Full unit suite: 1,536 passed.
  - Ruff formatting and lint checks passed.
  - Alembic migration head verified.
  - Live Postgres schema and Aegra health endpoint verified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added delayed run scheduling with the `after_seconds` option.
  * Scheduled runs remain visible through standard APIs while waiting.
  * Immediate execution remains available with a delay of `0`.
  * Worker execution automatically starts runs when their scheduled time arrives.
  * Added validation for supported non-negative delay values.

* **Bug Fixes**
  * Improved cancellation, recovery, retry, and dispatch handling for delayed runs.

* **Documentation**
  * Added documentation covering delayed scheduling for local and worker execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->











<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds persisted delayed run scheduling across the API’s local and worker execution modes.
- Adds the validated `after_seconds` run-creation field and stores its scheduling boundary in PostgreSQL.
- Delays local execution through cancellable asyncio tasks.
- Dispatches due worker runs through Redis with persisted dispatch leases and retry handling.
- Prevents workers and recovery logic from claiming runs before their scheduled time.
- Adds migrations, architecture documentation, unit coverage, and an end-to-end delayed-run test.
- The previous runtime findings are resolved, but two repository-rule findings remain: the schema migration received only a patch version bump, and HTTP integration coverage is still absent.

<h3>Confidence Score: 4/5</h3>

The runtime implementation appears sound, but the PR should not merge until its two explicit repository requirements are satisfied.

The earlier scheduling, queue-duplication, overflow, task-cleanup, dispatch-gap, and row-lock findings are resolved. The version finding is only partly fixed: both packages were moved to 0.10.5, but the repository requires a schema migration to receive a minor bump, which also requires updating the CLI’s `aegra-api~=` constraint. The required-test-level finding also remains outstanding because the feature now has unit and end-to-end coverage but still lacks an applicable HTTP integration test.

**Files Needing Attention:** libs/aegra-api/pyproject.toml, libs/aegra-cli/pyproject.toml, and libs/aegra-api/tests/integration/

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/services/worker_executor.py | Implements due-run dispatch, retryable dispatch leases, and a final scheduling guard during worker lease acquisition. |
| libs/aegra-api/src/aegra_api/services/local_executor.py | Adds cancellable delayed execution and reliably removes completed or cancelled tasks from the active-run registry. |
| libs/aegra-api/src/aegra_api/services/lease_reaper.py | Excludes future and recently dispatched pending runs from stuck-run recovery. |
| libs/aegra-api/src/aegra_api/services/run_preparation.py | Validates delay values, serializes scheduling metadata, and persists the calculated not-before timestamp. |
| libs/aegra-api/src/aegra_api/core/orm.py | Adds persisted scheduling and dispatch timestamps with matching query indexes. |
| libs/aegra-api/alembic/versions/20260905000000_add_run_not_before.py | Adds the delayed-run scheduling column and index through a linear Alembic migration. |
| libs/aegra-api/alembic/versions/20260905000001_add_run_dispatch_timestamp.py | Adds the dispatch timestamp and compound dispatcher index. |
| libs/aegra-api/tests/e2e/test_runs/test_runs.py | Covers delayed execution against a running server, but no corresponding HTTP integration test was added. |
| libs/aegra-api/pyproject.toml | Keeps API and CLI versions aligned, but uses a patch bump despite the repository’s requirement that schema migrations receive a minor bump. |
| libs/aegra-cli/pyproject.toml | Matches the API package’s patch version, but would also need a minor version and dependency-constraint update for this migration-bearing change. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Create run with after_seconds] --> B[Persist pending run]
    B --> C{Execution mode}
    C -->|Local| D[Register cancellable asyncio task]
    D --> E[Sleep until delay expires]
    E --> F[Execute run]
    C -->|Worker| G[Persist not_before]
    G --> H[Dispatcher selects due undispatched runs]
    H --> I[Set dispatched_at]
    I --> J[Push run ID to Redis]
    J --> K[Worker verifies not_before and acquires lease]
    K --> F
```
</details>

<sub>Reviews (6): Last reviewed commit: ["test(worker): strengthen delayed dispatc..."](https://github.com/aegra/aegra/commit/6040c2fa000bbc2ea0d973e6063bd777747b6cae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60760507)</sub>

<!-- /greptile_comment -->