### PR TITLE
Fix/cron metadata filters

### DIFF
--- a/docs/feature-support.mdx
+++ b/docs/feature-support.mdx
@@ -41,7 +41,7 @@ description: "What Aegra supports today, what's coming soon, and what's not yet 
 | Sync wait | Supported | Block until run completes and return final output. |
 | Subgraph streaming | Supported | Stream events from nested subgraphs. |
 | Stateless runs | Supported | Execute without persisting thread state. |
-| Cron / scheduled jobs | Supported | Trigger runs on a schedule. Standard and seconds-level cron expressions. IANA timezone support. |
+| Cron / scheduled jobs | Supported | Create, read, update, delete, search, and count scheduled jobs, including metadata filtering. Standard and seconds-level cron expressions. IANA timezone support. |
 
 ### Scaling and reliability
 

--- a/docs/guides/authentication.mdx
+++ b/docs/guides/authentication.mdx
@@ -345,6 +345,7 @@ Convenience shortcuts are also available directly on `config["configurable"]`:
 
 - `config["configurable"]["user_id"]` -- the user's identity
 - `config["configurable"]["user_display_name"]` -- the user's display name
+- `config["configurable"]["graph_id"]` -- the graph key from `aegra.json` for the running assistant
 
 ## Provider examples
 

--- a/docs/guides/cron.mdx
+++ b/docs/guides/cron.mdx
@@ -159,6 +159,10 @@ crons = await client.crons.search(thread_id="<thread_id>")
 
 # Count matching crons
 total = await client.crons.count(assistant_id="agent")
+
+# Filter by metadata
+crons = await client.crons.search(metadata={"team": "research"})
+total = await client.crons.count(metadata={"team": "research"})
 ```
 
 ## Updating a cron

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Aegra",
     "description": "Production-ready Agent Protocol server",
-    "version": "0.10.3"
+    "version": "0.10.4"
   },
   "paths": {
     "/info": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Aegra",
     "description": "Production-ready Agent Protocol server",
-    "version": "0.10.6"
+    "version": "0.10.7"
   },
   "paths": {
     "/info": {
@@ -3794,6 +3794,18 @@
               }
             ],
             "title": "Thread Id"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata"
           }
         },
         "type": "object",
@@ -4136,6 +4148,18 @@
               }
             ],
             "title": "Thread Id"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata"
           },
           "enabled": {
             "anyOf": [

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.10.3"
+version = "0.10.4"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.10.6"
+version = "0.10.7"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-api/src/aegra_api/models/crons.py
+++ b/libs/aegra-api/src/aegra_api/models/crons.py
@@ -141,6 +141,7 @@ class CronSearchRequest(BaseModel):
 
     assistant_id: str | None = None
     thread_id: str | None = None
+    metadata: dict[str, Any] | None = None
     enabled: bool | None = None
     limit: int = Field(10, ge=1, le=1000)
     offset: int = Field(0, ge=0)
@@ -153,3 +154,4 @@ class CronCountRequest(BaseModel):
 
     assistant_id: str | None = None
     thread_id: str | None = None
+    metadata: dict[str, Any] | None = None

--- a/libs/aegra-api/src/aegra_api/services/cron_service.py
+++ b/libs/aegra-api/src/aegra_api/services/cron_service.py
@@ -395,6 +395,8 @@ class CronService:
             stmt = stmt.where(CronORM.assistant_id == resolved_assistant_id)
         if request.thread_id is not None:
             stmt = stmt.where(CronORM.thread_id == request.thread_id)
+        if request.metadata:
+            stmt = stmt.where(CronORM.metadata_dict.op("@>")(request.metadata))
         if request.enabled is not None:
             stmt = stmt.where(CronORM.enabled == request.enabled)
 
@@ -428,6 +430,8 @@ class CronService:
             stmt = stmt.where(CronORM.assistant_id == resolved_assistant_id)
         if request.thread_id is not None:
             stmt = stmt.where(CronORM.thread_id == request.thread_id)
+        if request.metadata:
+            stmt = stmt.where(CronORM.metadata_dict.op("@>")(request.metadata))
 
         total = await self.session.scalar(stmt)
         return total or 0

--- a/libs/aegra-api/src/aegra_api/services/langgraph_service.py
+++ b/libs/aegra-api/src/aegra_api/services/langgraph_service.py
@@ -703,6 +703,7 @@ def create_run_config(
     thread_id: str,
     user: User | BaseUser | None,
     *,
+    graph_id: str | None = None,
     additional_config: dict[str, Any] | None = None,
     checkpoint: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
@@ -746,6 +747,9 @@ def create_run_config(
     if checkpoint and isinstance(checkpoint, dict):
         safe = strip_pinned_config_keys(checkpoint)
         cfg["configurable"].update({k: v for k, v in safe.items() if v is not None})
+
+    if graph_id is not None:
+        cfg["configurable"].setdefault("graph_id", graph_id)
 
     # Finally inject user context via existing helper
     return inject_user_context(user, cfg)

--- a/libs/aegra-api/src/aegra_api/services/run_executor.py
+++ b/libs/aegra-api/src/aegra_api/services/run_executor.py
@@ -256,6 +256,7 @@ def _build_run_config(job: RunJob) -> dict[str, Any]:
         job.identity.run_id,
         job.identity.thread_id,
         job.user,
+        graph_id=job.identity.graph_id,
         additional_config=job.execution.config,
         checkpoint=job.execution.checkpoint,
     )

--- a/libs/aegra-api/tests/e2e/test_crons/test_crons.py
+++ b/libs/aegra-api/tests/e2e/test_crons/test_crons.py
@@ -309,6 +309,40 @@ async def test_cron_search_and_count() -> None:
 
 @pytest.mark.e2e
 @pytest.mark.asyncio
+async def test_cron_search_and_count_filter_by_metadata() -> None:
+    """Metadata filters select only matching crons for the current user."""
+    client = get_e2e_client()
+    assistant = await client.assistants.create(
+        graph_id="agent",
+        config={"tags": ["e2e-cron-metadata-filter"]},
+        if_exists="do_nothing",
+    )
+    assistant_id = assistant["assistant_id"]
+    cron_ids: list[str] = []
+
+    try:
+        for schedule, team in (("0 11 * * *", "research"), ("0 12 * * *", "support")):
+            created = await _create_cron_via_http(
+                {
+                    "assistant_id": assistant_id,
+                    "schedule": schedule,
+                    "enabled": False,
+                    "metadata": {"team": team},
+                    "input": {},
+                }
+            )
+            cron_ids.append(created["cron_id"])
+
+        filtered = await client.crons.search(metadata={"team": "research"})
+        assert {cron["cron_id"] for cron in filtered} == {cron_ids[0]}
+        assert await client.crons.count(metadata={"team": "research"}) == 1
+    finally:
+        for cron_id in cron_ids:
+            await client.crons.delete(cron_id)
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
 async def test_cron_update() -> None:
     """Create a cron, update its schedule and enabled flag, verify the response."""
     client = get_e2e_client()

--- a/libs/aegra-api/tests/integration/test_api/test_crons_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_crons_crud.py
@@ -247,6 +247,15 @@ class TestSearchCrons:
         assert resp.status_code == 200
         mock_cron_service.search_crons.assert_called_once()
 
+    def test_passes_metadata_filter(self, client, mock_cron_service: AsyncMock) -> None:
+        mock_cron_service.search_crons.return_value = []
+
+        resp = client.post("/runs/crons/search", json={"metadata": {"team": "research"}})
+
+        assert resp.status_code == 200
+        request = mock_cron_service.search_crons.call_args.args[0]
+        assert request.metadata == {"team": "research"}
+
 
 # ---------------------------------------------------------------------------
 # POST /runs/crons/count  →  int
@@ -278,6 +287,15 @@ class TestCountCrons:
         resp = client.post("/runs/crons/count", json={"assistant_id": "asst-001"})
         assert resp.status_code == 200
         assert resp.json() == 3
+
+    def test_passes_metadata_filter(self, client, mock_cron_service: AsyncMock) -> None:
+        mock_cron_service.count_crons.return_value = 1
+
+        resp = client.post("/runs/crons/count", json={"metadata": {"team": "research"}})
+
+        assert resp.status_code == 200
+        request = mock_cron_service.count_crons.call_args.args[0]
+        assert request.metadata == {"team": "research"}
 
     def test_filters_by_thread_id(self, client, mock_cron_service: AsyncMock) -> None:
         mock_cron_service.count_crons.return_value = 1

--- a/libs/aegra-api/tests/unit/test_services/test_cron_service.py
+++ b/libs/aegra-api/tests/unit/test_services/test_cron_service.py
@@ -461,6 +461,21 @@ class TestSearchCrons:
         assert result[0].cron_id == "c1"
         assert result[1].cron_id == "c2"
 
+    @pytest.mark.asyncio
+    async def test_filters_by_metadata(
+        self,
+        cron_service: CronService,
+        mock_session: AsyncMock,
+    ) -> None:
+        scalars = Mock()
+        scalars.all.return_value = []
+        mock_session.scalars.return_value = scalars
+
+        await cron_service.search_crons(CronSearchRequest(metadata={"team": "research"}), "test-user")
+
+        statement = mock_session.scalars.call_args.args[0]
+        assert "@>" in str(statement)
+
 
 class TestCountCrons:
     """Test CronService.count_crons."""
@@ -505,6 +520,20 @@ class TestCountCrons:
         mock_session.scalar.return_value = 1
         result = await cron_service.count_crons(CronCountRequest(thread_id="t-1"), "test-user")
         assert result == 1
+
+    @pytest.mark.asyncio
+    async def test_filters_by_metadata(
+        self,
+        cron_service: CronService,
+        mock_session: AsyncMock,
+    ) -> None:
+        mock_session.scalar.return_value = 1
+
+        result = await cron_service.count_crons(CronCountRequest(metadata={"team": "research"}), "test-user")
+
+        assert result == 1
+        statement = mock_session.scalar.call_args.args[0]
+        assert "@>" in str(statement)
 
 
 # ---------------------------------------------------------------------------

--- a/libs/aegra-api/tests/unit/test_services/test_langgraph_service.py
+++ b/libs/aegra-api/tests/unit/test_services/test_langgraph_service.py
@@ -663,6 +663,39 @@ class TestLangGraphServiceConfigs:
 
         assert result["configurable"]["checkpoint_key"] == "checkpoint_value"
 
+    def test_create_run_config_sets_graph_id_when_absent(self) -> None:
+        mock_user = Mock()
+        mock_user.identity = "user-123"
+        mock_user.display_name = "Test User"
+
+        with patch(
+            "aegra_api.services.langgraph_service.get_tracing_callbacks",
+            return_value=[],
+        ):
+            result = create_run_config("run-789", "thread-456", mock_user, graph_id="agent")
+
+        assert result["configurable"]["graph_id"] == "agent"
+
+    def test_create_run_config_preserves_client_graph_id(self) -> None:
+        mock_user = Mock()
+        mock_user.identity = "user-123"
+        mock_user.display_name = "Test User"
+        additional_config = {"configurable": {"graph_id": "client-agent"}}
+
+        with patch(
+            "aegra_api.services.langgraph_service.get_tracing_callbacks",
+            return_value=[],
+        ):
+            result = create_run_config(
+                "run-789",
+                "thread-456",
+                mock_user,
+                graph_id="server-agent",
+                additional_config=additional_config,
+            )
+
+        assert result["configurable"]["graph_id"] == "client-agent"
+
     def test_create_run_config_ignores_client_thread_id_override(self):
         """A client-supplied configurable.thread_id must not redirect execution.
 

--- a/libs/aegra-api/tests/unit/test_services/test_run_executor.py
+++ b/libs/aegra-api/tests/unit/test_services/test_run_executor.py
@@ -9,6 +9,7 @@ from aegra_api.models.auth import User
 from aegra_api.models.run_job import RunExecution, RunIdentity, RunJob
 from aegra_api.services import run_executor as run_executor_module
 from aegra_api.services.run_executor import (
+    _build_run_config,
     _GraphResult,
     _lease_loss_cancellations,
     _signal_end_event,
@@ -76,6 +77,16 @@ class TestExecuteRunSuccess:
         assert mock_finalize.await_args.kwargs["status"] == "success"
 
         mock_signal_end.assert_awaited_once_with("run-1", "success")
+
+
+class TestBuildRunConfig:
+    def test_injects_job_graph_id_into_configurable(self) -> None:
+        job = _make_job()
+
+        with patch("aegra_api.services.langgraph_service.get_tracing_callbacks", return_value=[]):
+            config = _build_run_config(job)
+
+        assert config["configurable"]["graph_id"] == "graph-1"
 
 
 class TestExecuteRunCancelledError:

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.10.3"
+version = "0.10.4"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.10.6"
+version = "0.10.7"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.10.3"
+version = "0.10.4"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -100,7 +100,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.10.3"
+version = "0.10.4"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.10.6"
+version = "0.10.7"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -100,7 +100,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.10.6"
+version = "0.10.7"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
 ## Related Issue

  Fixes #582

  ## Summary

  Cron search and count silently ignored the `metadata` filter supported by
  the LangGraph SDK.

  ## Changes

  - Added `metadata` to `CronSearchRequest`.
  - Added `metadata` to `CronCountRequest`.
  - Applied PostgreSQL JSONB containment filtering to cron search and count.
  - Preserved tenant scoping with `user_id`.
  - Added unit, integration, and E2E coverage.
  - Updated cron documentation and OpenAPI.
  - Synchronized package versions to `0.10.7`.

  ## Testing

  - 2,057 API unit/integration tests passed.
  - 12 real-Postgres cron E2E tests passed.
  - Ruff format and lint passed.
  - One existing E2E test was skipped because it requires seconds-level cron
  scheduling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added metadata-based filtering for scheduled job search and count operations.
  - Run configurations now expose the assistant’s graph identifier through the configurable settings.

- **Documentation**
  - Expanded scheduled job feature documentation, including supported CRUD, search, count, metadata filtering, and usage examples.
  - Documented the graph identifier configuration shortcut.

- **Tests**
  - Added coverage for metadata filtering and graph identifier propagation across scheduled jobs and run configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds LangGraph-compatible metadata filtering to cron search and count, updates the API schema and documentation, and propagates a graph identifier into run configuration.

- Adds metadata fields to cron search/count request models and JSONB containment predicates to their queries.
- Adds unit, integration, and PostgreSQL-backed end-to-end coverage.
- Exposes `configurable.graph_id` to user graph code.
- Synchronizes API and CLI package versions at `0.10.7`.

<h3>Confidence Score: 4/5</h3>

The PR is not safe to merge until runtime graph configuration consistently exposes the authoritative graph ID rather than a client-supplied override.

Cron metadata filtering is functionally tenant-scoped, although it lacks an index for scalable queries; the blocking failure is that client configuration can make the graph observe an identity different from the graph actually selected for execution.

**Files Needing Attention:** libs/aegra-api/src/aegra_api/services/langgraph_service.py, libs/aegra-api/src/aegra_api/services/cron_service.py

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/models/crons.py | Adds optional metadata filters to cron search and count request schemas. |
| libs/aegra-api/src/aegra_api/services/cron_service.py | Applies tenant-scoped JSONB containment filters, but without an index supporting the new metadata queries. |
| libs/aegra-api/src/aegra_api/services/langgraph_service.py | Adds graph ID propagation while incorrectly allowing client configuration to override the authoritative value. |
| libs/aegra-api/src/aegra_api/services/run_executor.py | Passes the server-resolved job graph ID through the shared local and worker run-configuration path. |
| libs/aegra-api/tests/e2e/test_crons/test_crons.py | Adds real-PostgreSQL coverage for metadata-filtered cron search and count. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Cron search/count request] --> B[Validate metadata]
  B --> C[Apply tenant user_id predicate]
  C --> D[Apply JSONB metadata containment]
  D --> E[Return rows or count]

  F[Assistant's authoritative graph_id] --> G[Build run configuration]
  H[Client configurable.graph_id] --> G
  G --> I[Runtime configurable.graph_id]
  F --> J[Select graph to execute]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20aegra%2Faegra%20PR%20%23583%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=aegra%2Faegra&pr=583&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fservices%2Flanggraph_service.py%3A751-752%0A**Client%20Can%20Spoof%20Graph%20ID**%0A%0AWhen%20a%20run%20request%20supplies%20%60config.configurable.graph_id%60%2C%20%60setdefault%60%20preserves%20that%20client-controlled%20value%20instead%20of%20the%20authoritative%20%60job.identity.graph_id%60.%20The%20graph%20is%20still%20selected%20using%20the%20assistant%E2%80%99s%20server-resolved%20graph%20ID%2C%20but%20user%20graph%20code%20sees%20a%20different%20value.%20This%20breaks%20the%20documented%20contract%20and%20can%20make%20graph-specific%20behavior%20run%20under%20the%20wrong%20identity.%20Assign%20the%20authoritative%20graph%20ID%20unconditionally%2C%20as%20is%20already%20done%20for%20%60thread_id%60%20and%20%60run_id%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20graph_id%20is%20not%20None%3A%0A%20%20%20%20%20%20%20%20cfg%5B%22configurable%22%5D%5B%22graph_id%22%5D%20%3D%20graph_id%0A%60%60%60%0A%0A%23%23%23%20Issue%202%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fservices%2Fcron_service.py%3A398-399%0A**Metadata%20Queries%20Lack%20Index**%0A%0AThe%20new%20JSONB%20containment%20filters%20have%20no%20supporting%20GIN%20index%20on%20%60crons.metadata%60.%20PostgreSQL%20must%20therefore%20inspect%20every%20cron%20belonging%20to%20a%20tenant%20when%20metadata%20filtering%20is%20used%2C%20making%20both%20search%20and%20count%20increasingly%20expensive%20for%20tenants%20with%20many%20scheduled%20jobs.%20Add%20an%20appropriate%20metadata%20index%20through%20an%20Alembic%20migration.%20The%20same%20concern%20applies%20to%20the%20count%20predicate%20at%20lines%20433%E2%80%93434.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=aegra%2Faegra&pr=583&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fservices%2Flanggraph_service.py%3A751-752%0A**Client%20Can%20Spoof%20Graph%20ID**%0A%0AWhen%20a%20run%20request%20supplies%20%60config.configurable.graph_id%60%2C%20%60setdefault%60%20preserves%20that%20client-controlled%20value%20instead%20of%20the%20authoritative%20%60job.identity.graph_id%60.%20The%20graph%20is%20still%20selected%20using%20the%20assistant%E2%80%99s%20server-resolved%20graph%20ID%2C%20but%20user%20graph%20code%20sees%20a%20different%20value.%20This%20breaks%20the%20documented%20contract%20and%20can%20make%20graph-specific%20behavior%20run%20under%20the%20wrong%20identity.%20Assign%20the%20authoritative%20graph%20ID%20unconditionally%2C%20as%20is%20already%20done%20for%20%60thread_id%60%20and%20%60run_id%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20graph_id%20is%20not%20None%3A%0A%20%20%20%20%20%20%20%20cfg%5B%22configurable%22%5D%5B%22graph_id%22%5D%20%3D%20graph_id%0A%60%60%60%0A%0A%23%23%23%20Issue%202%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fservices%2Fcron_service.py%3A398-399%0A**Metadata%20Queries%20Lack%20Index**%0A%0AThe%20new%20JSONB%20containment%20filters%20have%20no%20supporting%20GIN%20index%20on%20%60crons.metadata%60.%20PostgreSQL%20must%20therefore%20inspect%20every%20cron%20belonging%20to%20a%20tenant%20when%20metadata%20filtering%20is%20used%2C%20making%20both%20search%20and%20count%20increasingly%20expensive%20for%20tenants%20with%20many%20scheduled%20jobs.%20Add%20an%20appropriate%20metadata%20index%20through%20an%20Alembic%20migration.%20The%20same%20concern%20applies%20to%20the%20count%20predicate%20at%20lines%20433%E2%80%93434.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=583&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22fix%2Fcron-metadata-filters%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fcron-metadata-filters%22.%0A%0A%23%23%23%20Issue%201%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fservices%2Flanggraph_service.py%3A751-752%0A**Client%20Can%20Spoof%20Graph%20ID**%0A%0AWhen%20a%20run%20request%20supplies%20%60config.configurable.graph_id%60%2C%20%60setdefault%60%20preserves%20that%20client-controlled%20value%20instead%20of%20the%20authoritative%20%60job.identity.graph_id%60.%20The%20graph%20is%20still%20selected%20using%20the%20assistant%E2%80%99s%20server-resolved%20graph%20ID%2C%20but%20user%20graph%20code%20sees%20a%20different%20value.%20This%20breaks%20the%20documented%20contract%20and%20can%20make%20graph-specific%20behavior%20run%20under%20the%20wrong%20identity.%20Assign%20the%20authoritative%20graph%20ID%20unconditionally%2C%20as%20is%20already%20done%20for%20%60thread_id%60%20and%20%60run_id%60.%0A%0A%60%60%60suggestion%0A%20%20%20%20if%20graph_id%20is%20not%20None%3A%0A%20%20%20%20%20%20%20%20cfg%5B%22configurable%22%5D%5B%22graph_id%22%5D%20%3D%20graph_id%0A%60%60%60%0A%0A%23%23%23%20Issue%202%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fservices%2Fcron_service.py%3A398-399%0A**Metadata%20Queries%20Lack%20Index**%0A%0AThe%20new%20JSONB%20containment%20filters%20have%20no%20supporting%20GIN%20index%20on%20%60crons.metadata%60.%20PostgreSQL%20must%20therefore%20inspect%20every%20cron%20belonging%20to%20a%20tenant%20when%20metadata%20filtering%20is%20used%2C%20making%20both%20search%20and%20count%20increasingly%20expensive%20for%20tenants%20with%20many%20scheduled%20jobs.%20Add%20an%20appropriate%20metadata%20index%20through%20an%20Alembic%20migration.%20The%20same%20concern%20applies%20to%20the%20count%20predicate%20at%20lines%20433%E2%80%93434.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=aegra%2Faegra&pr=583&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(api): filter crons by metadata"](https://github.com/aegra/aegra/commit/992cc78507bece5c4cd698309f151bd88c74fb64) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60904460)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->