### PR TITLE
fix(api): filter crons by metadata

### DIFF
--- a/docs/feature-support.mdx
+++ b/docs/feature-support.mdx
@@ -41,7 +41,7 @@ description: "What Aegra supports today, what's coming soon, and what's not yet 
 | Sync wait | Supported | Block until run completes and return final output. |
 | Subgraph streaming | Supported | Stream events from nested subgraphs. |
 | Stateless runs | Supported | Execute without persisting thread state. |
-| Cron / scheduled jobs | Supported | Trigger runs on a schedule. Standard and seconds-level cron expressions. IANA timezone support. |
+| Cron / scheduled jobs | Supported | Create, read, update, delete, search, and count scheduled jobs, including metadata filtering. Standard and seconds-level cron expressions. IANA timezone support. |
 
 ### Scaling and reliability
 

--- a/docs/guides/cron.mdx
+++ b/docs/guides/cron.mdx
@@ -159,6 +159,10 @@ crons = await client.crons.search(thread_id="<thread_id>")
 
 # Count matching crons
 total = await client.crons.count(assistant_id="agent")
+
+# Filter by metadata
+crons = await client.crons.search(metadata={"team": "research"})
+total = await client.crons.count(metadata={"team": "research"})
 ```
 
 ## Updating a cron

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Aegra",
     "description": "Production-ready Agent Protocol server",
-    "version": "0.10.7"
+    "version": "0.10.6"
   },
   "paths": {
     "/info": {

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Aegra",
     "description": "Production-ready Agent Protocol server",
-    "version": "0.10.5"
+    "version": "0.10.7"
   },
   "paths": {
     "/info": {
@@ -3794,6 +3794,18 @@
               }
             ],
             "title": "Thread Id"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata"
           }
         },
         "type": "object",
@@ -4136,6 +4148,18 @@
               }
             ],
             "title": "Thread Id"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata"
           },
           "enabled": {
             "anyOf": [

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.10.7"
+version = "0.10.6"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.10.5"
+version = "0.10.7"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-api/src/aegra_api/models/crons.py
+++ b/libs/aegra-api/src/aegra_api/models/crons.py
@@ -141,6 +141,7 @@ class CronSearchRequest(BaseModel):
 
     assistant_id: str | None = None
     thread_id: str | None = None
+    metadata: dict[str, Any] | None = None
     enabled: bool | None = None
     limit: int = Field(10, ge=1, le=1000)
     offset: int = Field(0, ge=0)
@@ -153,3 +154,4 @@ class CronCountRequest(BaseModel):
 
     assistant_id: str | None = None
     thread_id: str | None = None
+    metadata: dict[str, Any] | None = None

--- a/libs/aegra-api/src/aegra_api/services/cron_service.py
+++ b/libs/aegra-api/src/aegra_api/services/cron_service.py
@@ -395,6 +395,8 @@ class CronService:
             stmt = stmt.where(CronORM.assistant_id == resolved_assistant_id)
         if request.thread_id is not None:
             stmt = stmt.where(CronORM.thread_id == request.thread_id)
+        if request.metadata:
+            stmt = stmt.where(CronORM.metadata_dict.op("@>")(request.metadata))
         if request.enabled is not None:
             stmt = stmt.where(CronORM.enabled == request.enabled)
 
@@ -428,6 +430,8 @@ class CronService:
             stmt = stmt.where(CronORM.assistant_id == resolved_assistant_id)
         if request.thread_id is not None:
             stmt = stmt.where(CronORM.thread_id == request.thread_id)
+        if request.metadata:
+            stmt = stmt.where(CronORM.metadata_dict.op("@>")(request.metadata))
 
         total = await self.session.scalar(stmt)
         return total or 0

--- a/libs/aegra-api/tests/e2e/test_crons/test_crons.py
+++ b/libs/aegra-api/tests/e2e/test_crons/test_crons.py
@@ -310,7 +310,6 @@ async def test_cron_search_and_count() -> None:
 @pytest.mark.e2e
 @pytest.mark.asyncio
 async def test_cron_search_and_count_filter_by_metadata() -> None:
-    """Metadata filters select only matching crons for the current user."""
     client = get_e2e_client()
     assistant = await client.assistants.create(
         graph_id="agent",

--- a/libs/aegra-api/tests/e2e/test_crons/test_crons.py
+++ b/libs/aegra-api/tests/e2e/test_crons/test_crons.py
@@ -333,9 +333,18 @@ async def test_cron_search_and_count_filter_by_metadata() -> None:
             )
             cron_ids.append(created["cron_id"])
 
-        filtered = await client.crons.search(metadata={"team": "research"})
+        filtered = await client.crons.search(
+            assistant_id=assistant_id,
+            metadata={"team": "research"},
+        )
         assert {cron["cron_id"] for cron in filtered} == {cron_ids[0]}
-        assert await client.crons.count(metadata={"team": "research"}) == 1
+        assert (
+            await client.crons.count(
+                assistant_id=assistant_id,
+                metadata={"team": "research"},
+            )
+            == 1
+        )
     finally:
         for cron_id in cron_ids:
             await client.crons.delete(cron_id)

--- a/libs/aegra-api/tests/e2e/test_crons/test_crons.py
+++ b/libs/aegra-api/tests/e2e/test_crons/test_crons.py
@@ -309,6 +309,40 @@ async def test_cron_search_and_count() -> None:
 
 @pytest.mark.e2e
 @pytest.mark.asyncio
+async def test_cron_search_and_count_filter_by_metadata() -> None:
+    """Metadata filters select only matching crons for the current user."""
+    client = get_e2e_client()
+    assistant = await client.assistants.create(
+        graph_id="agent",
+        config={"tags": ["e2e-cron-metadata-filter"]},
+        if_exists="do_nothing",
+    )
+    assistant_id = assistant["assistant_id"]
+    cron_ids: list[str] = []
+
+    try:
+        for schedule, team in (("0 11 * * *", "research"), ("0 12 * * *", "support")):
+            created = await _create_cron_via_http(
+                {
+                    "assistant_id": assistant_id,
+                    "schedule": schedule,
+                    "enabled": False,
+                    "metadata": {"team": team},
+                    "input": {},
+                }
+            )
+            cron_ids.append(created["cron_id"])
+
+        filtered = await client.crons.search(metadata={"team": "research"})
+        assert {cron["cron_id"] for cron in filtered} == {cron_ids[0]}
+        assert await client.crons.count(metadata={"team": "research"}) == 1
+    finally:
+        for cron_id in cron_ids:
+            await client.crons.delete(cron_id)
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
 async def test_cron_update() -> None:
     """Create a cron, update its schedule and enabled flag, verify the response."""
     client = get_e2e_client()

--- a/libs/aegra-api/tests/integration/test_api/test_crons_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_crons_crud.py
@@ -247,6 +247,15 @@ class TestSearchCrons:
         assert resp.status_code == 200
         mock_cron_service.search_crons.assert_called_once()
 
+    def test_passes_metadata_filter(self, client, mock_cron_service: AsyncMock) -> None:
+        mock_cron_service.search_crons.return_value = []
+
+        resp = client.post("/runs/crons/search", json={"metadata": {"team": "research"}})
+
+        assert resp.status_code == 200
+        request = mock_cron_service.search_crons.call_args.args[0]
+        assert request.metadata == {"team": "research"}
+
 
 # ---------------------------------------------------------------------------
 # POST /runs/crons/count  →  int
@@ -278,6 +287,15 @@ class TestCountCrons:
         resp = client.post("/runs/crons/count", json={"assistant_id": "asst-001"})
         assert resp.status_code == 200
         assert resp.json() == 3
+
+    def test_passes_metadata_filter(self, client, mock_cron_service: AsyncMock) -> None:
+        mock_cron_service.count_crons.return_value = 1
+
+        resp = client.post("/runs/crons/count", json={"metadata": {"team": "research"}})
+
+        assert resp.status_code == 200
+        request = mock_cron_service.count_crons.call_args.args[0]
+        assert request.metadata == {"team": "research"}
 
     def test_filters_by_thread_id(self, client, mock_cron_service: AsyncMock) -> None:
         mock_cron_service.count_crons.return_value = 1

--- a/libs/aegra-api/tests/integration/test_api/test_crons_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_crons_crud.py
@@ -247,7 +247,7 @@ class TestSearchCrons:
         assert resp.status_code == 200
         mock_cron_service.search_crons.assert_called_once()
 
-    def test_passes_metadata_filter(self, client, mock_cron_service: AsyncMock) -> None:
+    def test_passes_metadata_filter(self, client: TestClient, mock_cron_service: AsyncMock) -> None:
         mock_cron_service.search_crons.return_value = []
 
         resp = client.post("/runs/crons/search", json={"metadata": {"team": "research"}})
@@ -288,7 +288,7 @@ class TestCountCrons:
         assert resp.status_code == 200
         assert resp.json() == 3
 
-    def test_passes_metadata_filter(self, client, mock_cron_service: AsyncMock) -> None:
+    def test_passes_metadata_filter(self, client: TestClient, mock_cron_service: AsyncMock) -> None:
         mock_cron_service.count_crons.return_value = 1
 
         resp = client.post("/runs/crons/count", json={"metadata": {"team": "research"}})

--- a/libs/aegra-api/tests/unit/test_services/test_cron_service.py
+++ b/libs/aegra-api/tests/unit/test_services/test_cron_service.py
@@ -461,6 +461,21 @@ class TestSearchCrons:
         assert result[0].cron_id == "c1"
         assert result[1].cron_id == "c2"
 
+    @pytest.mark.asyncio
+    async def test_filters_by_metadata(
+        self,
+        cron_service: CronService,
+        mock_session: AsyncMock,
+    ) -> None:
+        scalars = Mock()
+        scalars.all.return_value = []
+        mock_session.scalars.return_value = scalars
+
+        await cron_service.search_crons(CronSearchRequest(metadata={"team": "research"}), "test-user")
+
+        statement = mock_session.scalars.call_args.args[0]
+        assert "@>" in str(statement)
+
 
 class TestCountCrons:
     """Test CronService.count_crons."""
@@ -505,6 +520,20 @@ class TestCountCrons:
         mock_session.scalar.return_value = 1
         result = await cron_service.count_crons(CronCountRequest(thread_id="t-1"), "test-user")
         assert result == 1
+
+    @pytest.mark.asyncio
+    async def test_filters_by_metadata(
+        self,
+        cron_service: CronService,
+        mock_session: AsyncMock,
+    ) -> None:
+        mock_session.scalar.return_value = 1
+
+        result = await cron_service.count_crons(CronCountRequest(metadata={"team": "research"}), "test-user")
+
+        assert result == 1
+        statement = mock_session.scalar.call_args.args[0]
+        assert "@>" in str(statement)
 
 
 # ---------------------------------------------------------------------------

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.10.5"
+version = "0.10.7"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.10.7"
+version = "0.10.6"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.10.7"
+version = "0.10.6"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -100,7 +100,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.10.7"
+version = "0.10.6"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.10.5"
+version = "0.10.7"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -100,7 +100,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.10.5"
+version = "0.10.7"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
 ## Summary

  Fixes #582.

  Cron search and count requests now correctly support filtering by
  metadata. The metadata filter is applied using PostgreSQL JSONB
  containment for consistent results.

  ## Changes

  - Added `metadata` filters to cron search and count request models.
  - Applied metadata filtering to both search and count queries.
  - Added unit, integration, and E2E test coverage.
  - Updated API documentation, OpenAPI schema, CLI/API versions, and
  lockfile.

  ## Validation

  - Full API unit and integration tests passed.
  - Cron E2E tests passed.
  - Ruff formatting and lint checks passed.

  Closes #582.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added metadata filtering for cron job searches and count requests.
  * Cron operations now support locating and counting jobs by key-value metadata, including assistant-scoped queries.

* **Documentation**
  * Updated the cron feature matrix and guide with metadata filtering details and examples.
  * Updated the API specification to document optional metadata filters for cron searches and counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->







<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds metadata containment filtering to cron search and count operations.
- Extends both cron request models with an optional metadata filter.
- Applies PostgreSQL JSONB containment while retaining existing owner, assistant, and thread scoping.
- Adds unit, integration, and isolated end-to-end regression coverage.
- Updates user documentation, the generated OpenAPI contract, and aligned API/CLI package versions.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no outstanding correctness, security, or repository-rule issues.

Both previous findings were manually resolved, and the current code contains their requested fixes: the end-to-end metadata test is assistant-scoped and the filler docstring is absent. The metadata predicates preserve tenant scoping and use bound JSONB operands consistently in search and count.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/services/cron_service.py | Adds parameter-bound JSONB metadata containment predicates to owner-scoped cron search and count queries. |
| libs/aegra-api/src/aegra_api/models/crons.py | Adds optional metadata objects to cron search and count request contracts. |
| libs/aegra-api/tests/e2e/test_crons/test_crons.py | Verifies metadata search and count behavior using assistant-scoped test data and deterministic cleanup. |
| docs/openapi.json | Exposes the new metadata fields and aligns the documented API version with the package patch release. |

</details>

<sub>Reviews (4): Last reviewed commit: ["chore: align cron metadata release versi..."](https://github.com/aegra/aegra/commit/13e0ddc7fc01d6a0fd6b863d768f2bd03ce03666) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60904962)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Cron scheduling and review fixes](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/cron-scheduling.md)
- Knowledge Base — [HTTP API contracts](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/api-contracts.md)
- Knowledge Base — [Developer tooling and API export](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/developer-tooling.md)
</details>


<!-- /greptile_comment -->