### PR TITLE
Patch/store

### DIFF
--- a/libs/aegra-api/src/aegra_api/config.py
+++ b/libs/aegra-api/src/aegra_api/config.py
@@ -2,7 +2,7 @@
 
 import json
 from pathlib import Path
-from typing import TypedDict
+from typing import Any, TypedDict
 
 import structlog
 
@@ -50,6 +50,7 @@ class StoreIndexConfig(TypedDict, total=False):
     - bedrock:amazon.titan-embed-text-v2:0 (1024 dims)
     - cohere:embed-english-v3.0 (1024 dims)
     """
+    embed_kwargs: dict[str, Any] | None
     fields: list[str] | None
     """JSON fields to embed. Defaults to ["$"] (entire document).
     Examples:

--- a/libs/aegra-api/src/aegra_api/core/database.py
+++ b/libs/aegra-api/src/aegra_api/core/database.py
@@ -1,6 +1,11 @@
 """Database manager with LangGraph integration"""
 
+import importlib
+import importlib.util
+from pathlib import Path
+
 import structlog
+from langchain.embeddings import init_embeddings
 from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
 from langgraph.store.postgres.aio import AsyncPostgresStore
 from psycopg.rows import dict_row
@@ -11,6 +16,27 @@ from aegra_api.config import load_store_config
 from aegra_api.settings import settings
 
 logger = structlog.get_logger(__name__)
+
+
+# 1. BÊ NGUYÊN LOGIC CỦA AEGRA SANG ĐỂ LOAD HÀM EMBED
+def _load_embed_object(import_path: str):
+    """Load object based on Aegra's native app_loader logic."""
+    path, name = import_path.rsplit(":", 1)
+    path_obj = Path(path)
+
+    # Logic nhận diện native từ Aegra
+    is_file_path = path_obj.suffix == ".py" or path.startswith("./") or path.startswith("../")
+
+    if is_file_path:
+        spec = importlib.util.spec_from_file_location("custom_embed_module", str(path_obj))
+        if spec is None or spec.loader is None:
+            raise ImportError(f"Cannot load spec from {path_obj}")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    else:
+        module = importlib.import_module(path)
+
+    return getattr(module, name)
 
 
 class DatabaseManager:
@@ -73,8 +99,35 @@ class DatabaseManager:
         await self._checkpointer.setup()  # Ensure tables exist
 
         # Load store configuration for semantic search (if configured)
+        # 2. LOGIC KHỞI TẠO STORE CỦA DATABASE MANAGER
         store_config = load_store_config()
         index_config = store_config.get("index") if store_config else None
+
+        if index_config and isinstance(index_config.get("embed"), str):
+            index_config = dict(index_config)
+            embed_spec = index_config.pop("embed")
+            embed_kwargs = index_config.pop("embed_kwargs", None) or {}
+
+            # Nếu chuỗi có chứa ":" và không thuộc danh sách Provider mặc định
+            if ":" in embed_spec and embed_spec.split(":")[0] not in [
+                "openai",
+                "google_genai",
+                "cohere",
+                "bedrock",
+                "azure_ai",
+                "azure_openai",
+                "google_vertexai",
+                "huggingface",
+                "mistralai",
+                "ollama",
+            ]:
+                # Dùng logic chuẩn của Aegra để load hàm
+                index_config["embed"] = _load_embed_object(embed_spec)
+
+            elif embed_kwargs:
+                index_config["embed"] = init_embeddings(embed_spec, **embed_kwargs)
+            else:
+                index_config["embed"] = embed_spec
 
         self._store = AsyncPostgresStore(conn=self.lg_pool, index=index_config)
         await self._store.setup()  # Ensure tables exist


### PR DESCRIPTION
## Description
<!-- Provide a clear description of your changes -->

## Type of Change
<!-- Check the relevant option -->
- [ ] `feat`: New feature
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation changes
- [ ] `style`: Code style/formatting
- [ ] `refactor`: Code refactoring
- [ ] `perf`: Performance improvement
- [ ] `test`: Tests added/updated
- [ ] `chore`: Maintenance (dependencies, build, etc.)
- [ ] `ci`: CI/CD changes

## Related Issues
<!-- Link related issues: Fixes #123, Closes #456 -->

## Changes Made
<!-- List the main changes -->
-
-
-

## Testing
<!-- Describe how you tested your changes -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing performed

## Checklist
<!-- Ensure all items are checked before requesting review -->
- [ ] Code follows project style (Ruff formatting)
- [ ] All linting checks pass (`make lint`)
- [ ] Type checking passes (`make type-check`)
- [ ] All tests pass (`make test`)
- [ ] Documentation updated (if needed)
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] PR title follows Conventional Commits format

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Additional Notes
<!-- Any additional information for reviewers -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Embedding configurations can now include additional model-specific options.
  - Custom embedding implementations can be loaded using supported module or file paths.
  - Embedding setup now supports passing configuration options directly to the selected embedding model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends semantic-store configuration with embedding keyword arguments and startup-time loading of custom embedding objects.

- Adds `embed_kwargs` to the store index configuration type.
- Initializes provider embeddings with configured keyword arguments.
- Loads custom embedding references from Python modules or files.
- Relative custom file references currently do not follow the repository’s configuration-directory-relative path contract.
- Required tests, documentation, annotations, and package version updates are missing.

<h3>Confidence Score: 4/5</h3>

The PR is not safe to merge until relative embed files resolve from the configuration directory and the explicit repository requirements are satisfied.

A supported configuration located outside the working directory can no longer reliably load a relative custom embedding file, causing startup failure or loading the wrong module; the implementation also lacks required tests, documentation, typing, and version updates.

**Files Needing Attention:** libs/aegra-api/src/aegra_api/core/database.py, libs/aegra-api/src/aegra_api/config.py

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/config.py | Adds the `embed_kwargs` store-index option, but the new public configuration format is undocumented. |
| libs/aegra-api/src/aegra_api/core/database.py | Adds provider and custom embedding initialization, but relative file references resolve from the wrong directory and repository requirements remain unmet. |

</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20aegra%2Faegra%20PR%20%23585%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=aegra%2Faegra&pr=585&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fcore%2Fdatabase.py%3A24%0A**Relative%20embed%20path%20misresolved**%0A%0AWhen%20%60AEGRA_CONFIG%60%20points%20outside%20the%20process%20working%20directory%2C%20a%20relative%20custom%20embed%20path%20such%20as%20%60.%2Fembeddings.py%3Aembed%60%20is%20resolved%20from%20the%20working%20directory%20instead%20of%20the%20configuration%20file%E2%80%99s%20directory.%20This%20can%20make%20database%20initialization%20fail%20or%20load%20an%20unintended%20file.%0A%0A%23%23%23%20Issue%202%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fcore%2Fdatabase.py%3A21%0A**Return%20annotation%20missing**%0A%0AThe%20new%20%60_load_embed_object%60%20function%20does%20not%20declare%20a%20return%20type.%20The%20repository%20requires%20explicit%20parameter%20and%20return%20annotations%20for%20every%20function%2C%20so%20this%20requirement%20must%20be%20satisfied%20before%20merging.%0A%0A%23%23%23%20Issue%203%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fcore%2Fdatabase.py%3A103-125%0A**Embedding%20paths%20lack%20tests**%0A%0AThe%20new%20custom%20embedding%20and%20%60embed_kwargs%60%20initialization%20branches%20have%20no%20regression%20coverage.%20The%20repository%20requires%20tests%20for%20new%20features%2C%20including%20edge%20cases%20and%20invalid%20inputs%2C%20so%20tests%20for%20provider%20kwargs%2C%20module%20and%20file%20references%2C%20invalid%20references%2C%20and%20configuration-relative%20files%20must%20be%20added%20before%20merging.%0A%0A%23%23%23%20Issue%204%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fcore%2Fdatabase.py%3A103-125%0A**Embedding%20configuration%20undocumented**%0A%0AThis%20change%20adds%20the%20user-facing%20%60embed_kwargs%60%20option%20and%20custom%20embedding-reference%20behavior%20without%20documenting%20either%20format.%20The%20repository%20requires%20documentation%20for%20every%20user-facing%20behavior%20change%2C%20so%20the%20relevant%20configuration%20documentation%20must%20be%20updated%20before%20merging.%0A%0A%23%23%23%20Issue%205%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fcore%2Fdatabase.py%3A103-125%0A**Package%20version%20not%20bumped**%0A%0AThis%20PR%20adds%20new%20store-configuration%20behavior%20without%20updating%20the%20package%20versions.%20The%20repository%20requires%20every%20PR%20to%20include%20the%20appropriate%20version%20bump%20and%20requires%20both%20package%20versions%20to%20remain%20aligned%2C%20so%20this%20must%20be%20addressed%20before%20merging.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=aegra%2Faegra&pr=585&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fcore%2Fdatabase.py%3A24%0A**Relative%20embed%20path%20misresolved**%0A%0AWhen%20%60AEGRA_CONFIG%60%20points%20outside%20the%20process%20working%20directory%2C%20a%20relative%20custom%20embed%20path%20such%20as%20%60.%2Fembeddings.py%3Aembed%60%20is%20resolved%20from%20the%20working%20directory%20instead%20of%20the%20configuration%20file%E2%80%99s%20directory.%20This%20can%20make%20database%20initialization%20fail%20or%20load%20an%20unintended%20file.%0A%0A%23%23%23%20Issue%202%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fcore%2Fdatabase.py%3A21%0A**Return%20annotation%20missing**%0A%0AThe%20new%20%60_load_embed_object%60%20function%20does%20not%20declare%20a%20return%20type.%20The%20repository%20requires%20explicit%20parameter%20and%20return%20annotations%20for%20every%20function%2C%20so%20this%20requirement%20must%20be%20satisfied%20before%20merging.%0A%0A%23%23%23%20Issue%203%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fcore%2Fdatabase.py%3A103-125%0A**Embedding%20paths%20lack%20tests**%0A%0AThe%20new%20custom%20embedding%20and%20%60embed_kwargs%60%20initialization%20branches%20have%20no%20regression%20coverage.%20The%20repository%20requires%20tests%20for%20new%20features%2C%20including%20edge%20cases%20and%20invalid%20inputs%2C%20so%20tests%20for%20provider%20kwargs%2C%20module%20and%20file%20references%2C%20invalid%20references%2C%20and%20configuration-relative%20files%20must%20be%20added%20before%20merging.%0A%0A%23%23%23%20Issue%204%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fcore%2Fdatabase.py%3A103-125%0A**Embedding%20configuration%20undocumented**%0A%0AThis%20change%20adds%20the%20user-facing%20%60embed_kwargs%60%20option%20and%20custom%20embedding-reference%20behavior%20without%20documenting%20either%20format.%20The%20repository%20requires%20documentation%20for%20every%20user-facing%20behavior%20change%2C%20so%20the%20relevant%20configuration%20documentation%20must%20be%20updated%20before%20merging.%0A%0A%23%23%23%20Issue%205%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fcore%2Fdatabase.py%3A103-125%0A**Package%20version%20not%20bumped**%0A%0AThis%20PR%20adds%20new%20store-configuration%20behavior%20without%20updating%20the%20package%20versions.%20The%20repository%20requires%20every%20PR%20to%20include%20the%20appropriate%20version%20bump%20and%20requires%20both%20package%20versions%20to%20remain%20aligned%2C%20so%20this%20must%20be%20addressed%20before%20merging.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=585&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22patch%2Fstore%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22patch%2Fstore%22.%0A%0A%23%23%23%20Issue%201%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fcore%2Fdatabase.py%3A24%0A**Relative%20embed%20path%20misresolved**%0A%0AWhen%20%60AEGRA_CONFIG%60%20points%20outside%20the%20process%20working%20directory%2C%20a%20relative%20custom%20embed%20path%20such%20as%20%60.%2Fembeddings.py%3Aembed%60%20is%20resolved%20from%20the%20working%20directory%20instead%20of%20the%20configuration%20file%E2%80%99s%20directory.%20This%20can%20make%20database%20initialization%20fail%20or%20load%20an%20unintended%20file.%0A%0A%23%23%23%20Issue%202%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fcore%2Fdatabase.py%3A21%0A**Return%20annotation%20missing**%0A%0AThe%20new%20%60_load_embed_object%60%20function%20does%20not%20declare%20a%20return%20type.%20The%20repository%20requires%20explicit%20parameter%20and%20return%20annotations%20for%20every%20function%2C%20so%20this%20requirement%20must%20be%20satisfied%20before%20merging.%0A%0A%23%23%23%20Issue%203%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fcore%2Fdatabase.py%3A103-125%0A**Embedding%20paths%20lack%20tests**%0A%0AThe%20new%20custom%20embedding%20and%20%60embed_kwargs%60%20initialization%20branches%20have%20no%20regression%20coverage.%20The%20repository%20requires%20tests%20for%20new%20features%2C%20including%20edge%20cases%20and%20invalid%20inputs%2C%20so%20tests%20for%20provider%20kwargs%2C%20module%20and%20file%20references%2C%20invalid%20references%2C%20and%20configuration-relative%20files%20must%20be%20added%20before%20merging.%0A%0A%23%23%23%20Issue%204%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fcore%2Fdatabase.py%3A103-125%0A**Embedding%20configuration%20undocumented**%0A%0AThis%20change%20adds%20the%20user-facing%20%60embed_kwargs%60%20option%20and%20custom%20embedding-reference%20behavior%20without%20documenting%20either%20format.%20The%20repository%20requires%20documentation%20for%20every%20user-facing%20behavior%20change%2C%20so%20the%20relevant%20configuration%20documentation%20must%20be%20updated%20before%20merging.%0A%0A%23%23%23%20Issue%205%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fcore%2Fdatabase.py%3A103-125%0A**Package%20version%20not%20bumped**%0A%0AThis%20PR%20adds%20new%20store-configuration%20behavior%20without%20updating%20the%20package%20versions.%20The%20repository%20requires%20every%20PR%20to%20include%20the%20appropriate%20version%20bump%20and%20requires%20both%20package%20versions%20to%20remain%20aligned%2C%20so%20this%20must%20be%20addressed%20before%20merging.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=aegra%2Faegra&pr=585&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Merge branch &#39;aegra:main&#39; into patch/sto..."](https://github.com/aegra/aegra/commit/ebfbab10e7336e218a43f0c965be50409525bab8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61107531)</sub>

> Greptile also left **5 inline comments** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/aegra/aegra/blob/main/CLAUDE.md))
- Knowledge Base — [Application composition and configuration](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/application-composition.md)

<!-- /greptile_comment -->