### PR TITLE
fix(api): reject unsupported thread search select

### DIFF
--- a/docs/guides/threads-and-state.mdx
+++ b/docs/guides/threads-and-state.mdx
@@ -138,6 +138,9 @@ threads = await client.threads.search(
 
 `limit` accepts 1 through `MAX_SEARCH_LIMIT` (default 1000, matching LangGraph Platform). Omitted or null `limit` uses `min(20, MAX_SEARCH_LIMIT)`. Values above the cap return 422.
 
+Response projection with `select` is not implemented yet. Sending a non-null
+`select` value returns 422 instead of silently returning the default thread shape.
+
 ## Listing threads
 
 ```python

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Aegra",
     "description": "Production-ready Agent Protocol server",
-    "version": "0.10.5"
+    "version": "0.10.6"
   },
   "paths": {
     "/info": {
@@ -5567,6 +5567,21 @@
             ],
             "title": "Status",
             "description": "Thread status filter (idle, busy, interrupted, error)"
+          },
+          "select": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Select",
+            "description": "Response projection fields. Currently unsupported; non-null values return 422."
           },
           "limit": {
             "anyOf": [

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.10.5"
+version = "0.10.6"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-api/src/aegra_api/models/threads.py
+++ b/libs/aegra-api/src/aegra_api/models/threads.py
@@ -111,6 +111,11 @@ class ThreadSearchRequest(BaseModel):
 
     metadata: dict[str, Any] | None = Field(None, description="Metadata filters")
     status: str | None = Field(None, description="Thread status filter (idle, busy, interrupted, error)")
+    select: list[str] | None = Field(
+        None,
+        exclude=True,
+        description="Response projection fields. Currently unsupported; non-null values return 422.",
+    )
     # None default + validate_default so omitted and JSON null share one resolver.
     limit: int | None = Field(
         default=None,
@@ -146,6 +151,13 @@ class ThreadSearchRequest(BaseModel):
         if v is not None:
             return validate_thread_status(v)
         return v
+
+    @field_validator("select")
+    @classmethod
+    def reject_unsupported_select(cls: type["ThreadSearchRequest"], v: list[str] | None) -> None:
+        if v is not None:
+            raise ValueError("select projection is not supported")
+        return None
 
 
 class ThreadSearchResponse(BaseModel):

--- a/libs/aegra-api/tests/e2e/test_threads/test_search.py
+++ b/libs/aegra-api/tests/e2e/test_threads/test_search.py
@@ -232,3 +232,20 @@ async def test_search_returns_422_when_limit_exceeds_cap_e2e() -> None:
         )
     assert resp.status_code == 422, resp.text
     assert "limit" in resp.text
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_search_returns_422_for_unsupported_select_e2e() -> None:
+    """select must fail explicitly until thread projection is implemented."""
+    async with AsyncClient(base_url=settings.app.SERVER_URL, timeout=30.0) as http_client:
+        resp = await http_client.post(
+            "/threads/search",
+            json={
+                "status": "interrupted",
+                "limit": 10,
+                "select": ["thread_id", "status", "interrupts"],
+            },
+        )
+    assert resp.status_code == 422, resp.text
+    assert "select projection is not supported" in resp.text

--- a/libs/aegra-api/tests/integration/test_api/test_threads_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_threads_crud.py
@@ -540,6 +540,22 @@ class TestSearchThreads:
         assert isinstance(data, list)
         assert len(data) == 3
 
+    def test_search_threads_rejects_unsupported_select(self: "TestSearchThreads", client: TestClient) -> None:
+        resp = client.post(
+            "/threads/search",
+            json={
+                "status": "interrupted",
+                "limit": 10,
+                "select": ["thread_id", "status", "interrupts"],
+            },
+        )
+        assert resp.status_code == 422
+        detail = resp.json()["detail"]
+        assert any(
+            error.get("loc") == ["body", "select"] and "select projection is not supported" in error.get("msg", "")
+            for error in detail
+        )
+
     def test_search_threads_with_status(self, client):
         """Test searching with status filter"""
         resp = client.post("/threads/search", json={"status": "idle"})

--- a/libs/aegra-api/tests/unit/test_models/test_thread_status_validation.py
+++ b/libs/aegra-api/tests/unit/test_models/test_thread_status_validation.py
@@ -83,3 +83,28 @@ class TestThreadSearchRequestStatusValidation:
         """Test that ThreadSearchRequest rejects invalid status values."""
         with pytest.raises(ValueError, match="Invalid thread status"):
             ThreadSearchRequest(status="invalid_status")
+
+
+class TestThreadSearchRequestSelectValidation:
+    """Tests for unsupported thread search response projection."""
+
+    def test_thread_search_request_allows_omitted_select(self: "TestThreadSearchRequestSelectValidation") -> None:
+        request = ThreadSearchRequest()
+        assert request.select is None
+
+    def test_thread_search_request_allows_null_select(self: "TestThreadSearchRequestSelectValidation") -> None:
+        request = ThreadSearchRequest(select=None)
+        assert request.select is None
+
+    def test_thread_search_request_omits_select_from_auth_payload(
+        self: "TestThreadSearchRequestSelectValidation",
+    ) -> None:
+        request = ThreadSearchRequest()
+        assert "select" not in request.model_dump()
+
+    @pytest.mark.parametrize("select", [[], ["thread_id"], ["interrupts"]])
+    def test_thread_search_request_rejects_non_null_select(
+        self: "TestThreadSearchRequestSelectValidation", select: list[str]
+    ) -> None:
+        with pytest.raises(ValueError, match="select projection is not supported"):
+            ThreadSearchRequest(select=select)

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.10.5"
+version = "0.10.6"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.10.5"
+version = "0.10.6"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -100,7 +100,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.10.5"
+version = "0.10.6"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
## Description

Rejects non-null Agent Protocol `select` values on `POST /threads/search` with a clear 422 validation response while response projection remains unsupported. Requests that omit `select` or send `null` keep the existing response shape. This intentionally does not implement the broader projection work tracked in #330.

## Type of Change

- [ ] `feat`: New feature
- [x] `fix`: Bug fix
- [ ] `docs`: Documentation changes
- [ ] `style`: Code style/formatting
- [ ] `refactor`: Code refactoring
- [ ] `perf`: Performance improvement
- [ ] `test`: Tests added/updated
- [ ] `chore`: Maintenance (dependencies, build, etc.)
- [ ] `ci`: CI/CD changes

## Related Issues

Closes #564

## Changes Made

- Add request-model validation that rejects non-null `select` values before search execution.
- Add unit, integration, and E2E coverage using the issue reproduction payload.
- Document the unsupported projection behavior, regenerate OpenAPI, and keep package versions in sync.

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] E2E tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Code follows project style (Ruff formatting)
- [x] All linting checks pass (`make lint`)
- [ ] Type checking passes (`make type-check`)
- [ ] All tests pass (`make test`)
- [x] Documentation updated (if needed)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] PR title follows Conventional Commits format

## Screenshots (if applicable)

Not applicable.

## Additional Notes

- API unit and integration suite: `2057 passed, 1 skipped`.
- Focused model and integration regression suite: `81 passed`.
- Exact #564 reproduction E2E passed in both dev (LocalExecutor) and prod (WorkerExecutor + Redis) modes.
- All applicable pre-commit hooks pass on the changed files.
- The workspace-wide `ty` run reports 57 existing diagnostics; CI currently treats this check as non-blocking. The changed request model passes a focused `ty` check.
- The local Windows CLI suite reports `190 passed, 2 failed`; both failures are unrelated `.env` host/port loading cases, and this PR does not change CLI behavior beyond the required synchronized package version bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented that response projection for thread searches is currently unsupported.
  * Clarified that providing a non-null `select` value returns a 422 validation error.
  * Updated the API specification to reflect the `select` request field and version 0.10.6.

* **Bug Fixes**
  * Thread searches now consistently reject unsupported `select` values with a clear validation error.

* **Tests**
  * Added coverage for validation behavior across end-to-end, integration, and unit tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR explicitly rejects unsupported non-null thread-search projections while preserving existing behavior for omitted and null `select` values.

- Adds request-model validation before thread search execution.
- Documents the unsupported projection contract and regenerates OpenAPI.
- Adds unit, integration, and E2E regression coverage.
- Synchronizes the API and CLI patch versions and lockfile metadata.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; the validation behavior, published contract, documentation, and regression tests are aligned.

No actionable failures remain: omitted and null `select` values preserve existing searches, while all non-null values fail before search execution with the intended validation response.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/models/threads.py | Adds a nullable request field whose validator rejects every non-null projection value before search or authorization processing. |
| libs/aegra-api/tests/unit/test_models/test_thread_status_validation.py | Covers omitted, null, excluded-from-dump, empty-list, and populated-list behavior for `select`. |
| libs/aegra-api/tests/integration/test_api/test_threads_crud.py | Verifies the HTTP validation response includes the expected field location and message. |
| libs/aegra-api/tests/e2e/test_threads/test_search.py | Exercises the issue payload against a running server and expects an explicit 422 response. |
| docs/openapi.json | Regenerates the public schema with the nullable `select` field and unsupported-behavior description. |
| docs/guides/threads-and-state.mdx | Documents that non-null projections are unsupported and return 422. |
| uv.lock | Synchronizes only the editable API and CLI workspace package versions. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[POST /threads/search] --> B{select value}
    B -->|omitted or null| C[Validate remaining filters]
    C --> D[Execute thread search]
    B -->|non-null| E[Return 422 validation response]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api): reject unsupported thread sear..."](https://github.com/aegra/aegra/commit/7c73b4e31eae7eab2380a8406a0c3e8ec98648b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61577960)</sub>

**Context used:**

- Knowledge Base — [HTTP API contracts](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/api-contracts.md)
- Knowledge Base — [Assistants, threads, and state](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/assistant-thread-state.md)

<!-- /greptile_comment -->