### PR TITLE
fix(api): sweep orphaned stateless threads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -112,6 +112,14 @@ CRON_ENABLED=true
 # AEGRA_THREAD_TTL=43200
 # AEGRA_THREAD_TTL={"strategy": "keep_latest", "default_ttl": 1440, "sweep_interval_minutes": 5, "sweep_limit": 10000}
 
+# --- Stateless orphan thread cleanup ---
+# Reclaims stateless-run threads left behind by client disconnects after they
+# have no pending/running runs. Persistent threads and on_completion=keep are
+# never marked for this cleanup.
+# EPHEMERAL_THREAD_RETENTION_SECONDS=86400
+# EPHEMERAL_THREAD_SWEEP_INTERVAL_SECONDS=300
+# EPHEMERAL_THREAD_SWEEP_LIMIT=100
+
 # --- Event Streaming (Agent Protocol v2) ---
 # The v2 thread streaming endpoints (/threads/{id}/stream/events and
 # /threads/{id}/commands) used by the latest LangGraph JS/Python SDKs.

--- a/docs/reference/environment-variables.mdx
+++ b/docs/reference/environment-variables.mdx
@@ -189,6 +189,20 @@ AEGRA_THREAD_TTL='{"strategy": "keep_latest", "default_ttl": 1440, "sweep_interv
 `AEGRA_THREAD_TTL` takes precedence. When set, the `checkpointer.ttl` block in `aegra.json` is ignored entirely and unset fields fall back to their defaults. See the [configuration reference](/reference/configuration#checkpointer) for field semantics.
 </Note>
 
+## Stateless orphan thread cleanup
+
+Stateless runs normally delete their generated thread after completion. If a
+client disconnects while terminal events are being delivered, the background
+sweeper reclaims the explicitly marked thread after its retention period. It
+never reclaims persistent threads or stateless runs using
+`on_completion="keep"`, and it skips threads with pending or running runs.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `EPHEMERAL_THREAD_RETENTION_SECONDS` | `86400` | Minimum age before an orphaned stateless thread can be reclaimed |
+| `EPHEMERAL_THREAD_SWEEP_INTERVAL_SECONDS` | `300` | Delay between cleanup passes |
+| `EPHEMERAL_THREAD_SWEEP_LIMIT` | `100` | Maximum number of threads considered per pass |
+
 ## Prometheus metrics
 
 | Variable | Default | Description |

--- a/libs/aegra-api/alembic/versions/20260908000000_add_ephemeral_thread_marker.py
+++ b/libs/aegra-api/alembic/versions/20260908000000_add_ephemeral_thread_marker.py
@@ -1,0 +1,26 @@
+"""add explicit marker for stateless-run threads
+
+Revision ID: c4e8d2f1a6b7
+Revises: a3f7c1d9e2b4
+Create Date: 2026-09-08 00:00:00.000000
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+
+revision = "c4e8d2f1a6b7"
+down_revision = "a3f7c1d9e2b4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("thread", sa.Column("is_ephemeral", sa.Boolean(), server_default=sa.text("false"), nullable=False))
+    op.create_index("idx_thread_ephemeral_updated", "thread", ["is_ephemeral", "updated_at"], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index("idx_thread_ephemeral_updated", table_name="thread")
+    op.drop_column("thread", "is_ephemeral")

--- a/libs/aegra-api/alembic/versions/20260908000000_add_ephemeral_thread_marker.py
+++ b/libs/aegra-api/alembic/versions/20260908000000_add_ephemeral_thread_marker.py
@@ -9,7 +9,6 @@ import sqlalchemy as sa
 
 from alembic import op
 
-
 revision = "c4e8d2f1a6b7"
 down_revision = "a3f7c1d9e2b4"
 branch_labels = None

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.10.5"
+version = "0.11.0"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-api/src/aegra_api/api/stateless_runs.py
+++ b/libs/aegra-api/src/aegra_api/api/stateless_runs.py
@@ -7,6 +7,7 @@ explicitly sets ``on_completion="keep"``).
 """
 
 import asyncio
+import contextlib
 from collections.abc import AsyncIterator, Mapping
 from uuid import uuid4
 
@@ -33,6 +34,7 @@ from aegra_api.services.run_cleanup import (
     delete_thread_by_id,
     schedule_background_cleanup,
 )
+from aegra_api.services.run_preparation import ephemeral_run_context
 
 router = APIRouter(tags=["Stateless Runs"], dependencies=auth_dependency)
 logger = structlog.getLogger(__name__)
@@ -138,7 +140,8 @@ async def stateless_wait_for_run(
     should_delete = request.on_completion != "keep"
 
     try:
-        response = await wait_for_run(thread_id, request, user)
+        with ephemeral_run_context() if should_delete else contextlib.nullcontext():
+            response = await wait_for_run(thread_id, request, user)
     except Exception:
         if should_delete:
             try:
@@ -206,7 +209,8 @@ async def stateless_stream_run(
     should_delete = request.on_completion != "keep"
 
     try:
-        response = await create_and_stream_run(thread_id, request, user)
+        with ephemeral_run_context() if should_delete else contextlib.nullcontext():
+            response = await create_and_stream_run(thread_id, request, user)
     except Exception:
         # create_and_stream_run may have auto-created the thread via
         # update_thread_metadata before raising; clean up to avoid orphans.
@@ -288,7 +292,8 @@ async def stateless_create_run(
     should_delete = request.on_completion != "keep"
 
     try:
-        result = await create_run(thread_id, request, user, session)
+        with ephemeral_run_context() if should_delete else contextlib.nullcontext():
+            result = await create_run(thread_id, request, user, session)
     except Exception:
         # create_run may have auto-created the thread via
         # update_thread_metadata before raising; clean up to avoid orphans.

--- a/libs/aegra-api/src/aegra_api/core/orm.py
+++ b/libs/aegra-api/src/aegra_api/core/orm.py
@@ -145,11 +145,15 @@ class Thread(Base):
     # Database column is 'metadata_json' (per database.py). ORM attribute 'metadata_json' must map to that column.
     metadata_json: Mapped[dict] = mapped_column("metadata_json", JsonbSafe, server_default=text("'{}'::jsonb"))
     user_id: Mapped[str] = mapped_column(Text, nullable=False)
+    is_ephemeral: Mapped[bool] = mapped_column(Boolean, server_default=text("false"), nullable=False)
     created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), server_default=text("now()"))
     updated_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), server_default=text("now()"))
 
     # Indexes for performance
-    __table_args__ = (Index("idx_thread_user", "user_id"),)
+    __table_args__ = (
+        Index("idx_thread_user", "user_id"),
+        Index("idx_thread_ephemeral_updated", "is_ephemeral", "updated_at"),
+    )
 
 
 class Run(Base):

--- a/libs/aegra-api/src/aegra_api/main.py
+++ b/libs/aegra-api/src/aegra_api/main.py
@@ -37,6 +37,7 @@ from aegra_api.observability.metrics import setup_prometheus_metrics
 from aegra_api.observability.setup import setup_observability
 from aegra_api.services.broker import broker_manager
 from aegra_api.services.cron_scheduler import cron_scheduler
+from aegra_api.services.ephemeral_thread_sweeper import ephemeral_thread_sweeper
 from aegra_api.services.executor import executor
 from aegra_api.services.langgraph_service import get_langgraph_service
 from aegra_api.services.lease_reaper import lease_reaper
@@ -144,12 +145,14 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     # the config here also fails fast on an invalid retention policy.
     if get_thread_ttl_config() is not None:
         await thread_ttl_sweeper.start()
+    await ephemeral_thread_sweeper.start()
 
     yield
 
     # Shutdown order: ttl sweeper → cron → reaper → executor (drains jobs) → broker → Redis → DB
     if get_thread_ttl_config() is not None:
         await thread_ttl_sweeper.stop()
+    await ephemeral_thread_sweeper.stop()
     if settings.cron.CRON_ENABLED:
         await cron_scheduler.stop()
     if settings.redis.REDIS_BROKER_ENABLED:

--- a/libs/aegra-api/src/aegra_api/observability/metrics.py
+++ b/libs/aegra-api/src/aegra_api/observability/metrics.py
@@ -37,6 +37,15 @@ THREAD_TTL_SWEPT = prometheus_client.Counter(
     labelnames=["outcome"],
 )
 
+EPHEMERAL_THREAD_SWEPT = prometheus_client.Counter(
+    "aegra_ephemeral_thread_swept_total",
+    "Stateless-run threads processed by the orphan sweeper, by outcome.",
+    labelnames=["outcome"],
+)
+
+for _outcome in ("deleted", "error"):
+    EPHEMERAL_THREAD_SWEPT.labels(outcome=_outcome)
+
 for _outcome in ("deleted", "pruned", "error"):
     THREAD_TTL_SWEPT.labels(outcome=_outcome)
 

--- a/libs/aegra-api/src/aegra_api/services/ephemeral_thread_sweeper.py
+++ b/libs/aegra-api/src/aegra_api/services/ephemeral_thread_sweeper.py
@@ -7,6 +7,7 @@ explicitly marked as ephemeral and old enough to be safely reclaimed.
 """
 
 import asyncio
+from collections.abc import Collection
 from datetime import UTC, datetime, timedelta
 
 import structlog
@@ -26,19 +27,24 @@ logger = structlog.getLogger(__name__)
 _SWEEP_ERRORS: tuple[type[BaseException], ...] = (PsycopgError, SQLAlchemyError, OSError)
 
 
-def _orphaned_threads_stmt(*, cutoff: datetime, limit: int) -> Select[tuple[ThreadORM]]:
+def _orphaned_threads_stmt(
+    *, cutoff: datetime, limit: int, exclude_ids: Collection[str] = ()
+) -> Select[tuple[ThreadORM]]:
     """Claim old ephemeral threads that have no active run.
 
     Locking the thread row prevents a concurrent run insert from racing the
     checkpoint/thread deletion. The run foreign key takes a key-share lock and
     therefore waits for this claim transaction to finish.
     """
+    conditions = [
+        ThreadORM.is_ephemeral.is_(True),
+        ThreadORM.updated_at <= cutoff,
+    ]
+    if exclude_ids:
+        conditions.append(ThreadORM.thread_id.not_in(exclude_ids))
     return (
         select(ThreadORM)
-        .where(
-            ThreadORM.is_ephemeral.is_(True),
-            ThreadORM.updated_at <= cutoff,
-        )
+        .where(*conditions)
         .order_by(ThreadORM.updated_at.asc())
         .limit(limit)
         .with_for_update(skip_locked=True, of=ThreadORM)
@@ -50,38 +56,49 @@ async def sweep_orphaned_threads() -> tuple[int, int, int]:
     cutoff = datetime.now(UTC) - timedelta(seconds=settings.ephemeral_thread.EPHEMERAL_THREAD_RETENTION_SECONDS)
     maker = _get_session_maker()
     async with maker() as session:
-        rows = (
-            await session.scalars(
-                _orphaned_threads_stmt(
-                    cutoff=cutoff,
-                    limit=settings.ephemeral_thread.EPHEMERAL_THREAD_SWEEP_LIMIT,
-                )
-            )
-        ).all()
         deleted = 0
         errors = 0
         deleted_threads: list[ThreadORM] = []
-        for thread in rows:
-            active_run = await session.scalar(
-                select(RunORM.run_id)
-                .where(
-                    RunORM.thread_id == thread.thread_id,
-                    RunORM.status.in_(("pending", "running")),
+        excluded_ids: set[str] = set()
+        claimed = 0
+        while len(deleted_threads) < settings.ephemeral_thread.EPHEMERAL_THREAD_SWEEP_LIMIT:
+            rows = (
+                await session.scalars(
+                    _orphaned_threads_stmt(
+                        cutoff=cutoff,
+                        limit=settings.ephemeral_thread.EPHEMERAL_THREAD_SWEEP_LIMIT,
+                        exclude_ids=excluded_ids,
+                    )
                 )
-                .limit(1)
-            )
-            if active_run is not None:
-                continue
-            try:
-                # Checkpoints are in the LangGraph pool, so delete them first.
-                # A failure leaves the thread row available for a later retry.
-                await db_manager.get_checkpointer().adelete_thread(thread.thread_id)
-                await session.delete(thread)
-                deleted_threads.append(thread)
-            except _SWEEP_ERRORS:
-                errors += 1
-                EPHEMERAL_THREAD_SWEPT.labels(outcome="error").inc()
-                logger.exception("Failed to reclaim orphaned ephemeral thread", thread_id=thread.thread_id)
+            ).all()
+            if not rows:
+                break
+            claimed += len(rows)
+            for thread in rows:
+                active_run = await session.scalar(
+                    select(RunORM.run_id)
+                    .where(
+                        RunORM.thread_id == thread.thread_id,
+                        RunORM.status.in_(("pending", "running")),
+                    )
+                    .limit(1)
+                )
+                if active_run is not None:
+                    excluded_ids.add(thread.thread_id)
+                    continue
+                try:
+                    # Checkpoints are in the LangGraph pool, so delete them first.
+                    # A failure leaves the thread row available for a later retry.
+                    await db_manager.get_checkpointer().adelete_thread(thread.thread_id)
+                    await session.delete(thread)
+                    deleted_threads.append(thread)
+                except _SWEEP_ERRORS:
+                    excluded_ids.add(thread.thread_id)
+                    errors += 1
+                    EPHEMERAL_THREAD_SWEPT.labels(outcome="error").inc()
+                    logger.exception("Failed to reclaim orphaned ephemeral thread", thread_id=thread.thread_id)
+                if len(deleted_threads) >= settings.ephemeral_thread.EPHEMERAL_THREAD_SWEEP_LIMIT:
+                    break
         try:
             await session.commit()
         except _SWEEP_ERRORS:
@@ -94,7 +111,7 @@ async def sweep_orphaned_threads() -> tuple[int, int, int]:
             deleted = len(deleted_threads)
             for _ in deleted_threads:
                 EPHEMERAL_THREAD_SWEPT.labels(outcome="deleted").inc()
-    return len(rows), deleted, errors
+    return claimed, deleted, errors
 
 
 class EphemeralThreadSweeper:

--- a/libs/aegra-api/src/aegra_api/services/ephemeral_thread_sweeper.py
+++ b/libs/aegra-api/src/aegra_api/services/ephemeral_thread_sweeper.py
@@ -7,7 +7,6 @@ explicitly marked as ephemeral and old enough to be safely reclaimed.
 """
 
 import asyncio
-import contextlib
 from datetime import UTC, datetime, timedelta
 
 import structlog
@@ -70,19 +69,30 @@ async def sweep_orphaned_threads() -> tuple[int, int, int]:
         ).all()
         deleted = 0
         errors = 0
+        deleted_threads: list[ThreadORM] = []
         for thread in rows:
             try:
                 # Checkpoints are in the LangGraph pool, so delete them first.
                 # A failure leaves the thread row available for a later retry.
                 await db_manager.get_checkpointer().adelete_thread(thread.thread_id)
                 await session.delete(thread)
-                deleted += 1
-                EPHEMERAL_THREAD_SWEPT.labels(outcome="deleted").inc()
+                deleted_threads.append(thread)
             except _SWEEP_ERRORS:
                 errors += 1
                 EPHEMERAL_THREAD_SWEPT.labels(outcome="error").inc()
                 logger.exception("Failed to reclaim orphaned ephemeral thread", thread_id=thread.thread_id)
-        await session.commit()
+        try:
+            await session.commit()
+        except _SWEEP_ERRORS:
+            await session.rollback()
+            errors += len(deleted_threads)
+            for _ in deleted_threads:
+                EPHEMERAL_THREAD_SWEPT.labels(outcome="error").inc()
+            logger.exception("Failed to commit orphaned ephemeral thread sweep")
+        else:
+            deleted = len(deleted_threads)
+            for _ in deleted_threads:
+                EPHEMERAL_THREAD_SWEPT.labels(outcome="deleted").inc()
     return len(rows), deleted, errors
 
 
@@ -109,10 +119,10 @@ class EphemeralThreadSweeper:
         """Stop the background task."""
         self._running = False
         if self._task is not None:
-            self._task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await self._task
+            task = self._task
             self._task = None
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
         logger.info("Ephemeral thread sweeper stopped")
 
     async def _loop(self) -> None:

--- a/libs/aegra-api/src/aegra_api/services/ephemeral_thread_sweeper.py
+++ b/libs/aegra-api/src/aegra_api/services/ephemeral_thread_sweeper.py
@@ -1,0 +1,141 @@
+"""Reclaim stateless-run threads left behind by disconnected clients.
+
+Stateless endpoints normally delete their generated thread when the response
+finishes. A disconnect can race with terminal-event delivery, especially when
+Redis workers and API instances are separate. This sweeper handles only rows
+explicitly marked as ephemeral and old enough to be safely reclaimed.
+"""
+
+import asyncio
+import contextlib
+from datetime import UTC, datetime, timedelta
+
+import structlog
+from psycopg import Error as PsycopgError
+from sqlalchemy import Select, select
+from sqlalchemy.exc import SQLAlchemyError
+
+from aegra_api.core.database import db_manager
+from aegra_api.core.orm import Run as RunORM
+from aegra_api.core.orm import Thread as ThreadORM
+from aegra_api.core.orm import _get_session_maker
+from aegra_api.observability.metrics import EPHEMERAL_THREAD_SWEPT
+from aegra_api.settings import settings
+
+logger = structlog.getLogger(__name__)
+
+_SWEEP_ERRORS: tuple[type[BaseException], ...] = (PsycopgError, SQLAlchemyError, OSError)
+
+
+def _orphaned_threads_stmt(*, cutoff: datetime, limit: int) -> Select[tuple[ThreadORM]]:
+    """Claim old ephemeral threads that have no active run.
+
+    Locking the thread row prevents a concurrent run insert from racing the
+    checkpoint/thread deletion. The run foreign key takes a key-share lock and
+    therefore waits for this claim transaction to finish.
+    """
+    active_runs_exist = (
+        select(RunORM.run_id)
+        .where(
+            RunORM.thread_id == ThreadORM.thread_id,
+            RunORM.status.in_(("pending", "running")),
+        )
+        .exists()
+    )
+    return (
+        select(ThreadORM)
+        .where(
+            ThreadORM.is_ephemeral.is_(True),
+            ThreadORM.updated_at <= cutoff,
+            ~active_runs_exist,
+        )
+        .order_by(ThreadORM.updated_at.asc())
+        .limit(limit)
+        .with_for_update(skip_locked=True, of=ThreadORM)
+    )
+
+
+async def sweep_orphaned_threads() -> tuple[int, int, int]:
+    """Delete one bounded batch and return ``(claimed, deleted, errors)``."""
+    cutoff = datetime.now(UTC) - timedelta(seconds=settings.ephemeral_thread.EPHEMERAL_THREAD_RETENTION_SECONDS)
+    maker = _get_session_maker()
+    async with maker() as session:
+        rows = (
+            await session.scalars(
+                _orphaned_threads_stmt(
+                    cutoff=cutoff,
+                    limit=settings.ephemeral_thread.EPHEMERAL_THREAD_SWEEP_LIMIT,
+                )
+            )
+        ).all()
+        deleted = 0
+        errors = 0
+        for thread in rows:
+            try:
+                # Checkpoints are in the LangGraph pool, so delete them first.
+                # A failure leaves the thread row available for a later retry.
+                await db_manager.get_checkpointer().adelete_thread(thread.thread_id)
+                await session.delete(thread)
+                deleted += 1
+                EPHEMERAL_THREAD_SWEPT.labels(outcome="deleted").inc()
+            except _SWEEP_ERRORS:
+                errors += 1
+                EPHEMERAL_THREAD_SWEPT.labels(outcome="error").inc()
+                logger.exception("Failed to reclaim orphaned ephemeral thread", thread_id=thread.thread_id)
+        await session.commit()
+    return len(rows), deleted, errors
+
+
+class EphemeralThreadSweeper:
+    """Periodically reclaims stale ephemeral threads."""
+
+    def __init__(self) -> None:
+        """Initialize the background task state."""
+        self._task: asyncio.Task[None] | None = None
+        self._running = False
+
+    async def start(self) -> None:
+        """Start periodic orphan cleanup."""
+        self._running = True
+        self._task = asyncio.create_task(self._loop())
+        logger.info(
+            "Ephemeral thread sweeper started",
+            retention_seconds=settings.ephemeral_thread.EPHEMERAL_THREAD_RETENTION_SECONDS,
+            interval_seconds=settings.ephemeral_thread.EPHEMERAL_THREAD_SWEEP_INTERVAL_SECONDS,
+            sweep_limit=settings.ephemeral_thread.EPHEMERAL_THREAD_SWEEP_LIMIT,
+        )
+
+    async def stop(self) -> None:
+        """Stop the background task."""
+        self._running = False
+        if self._task is not None:
+            self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._task
+            self._task = None
+        logger.info("Ephemeral thread sweeper stopped")
+
+    async def _loop(self) -> None:
+        """Sweep immediately, then sleep between bounded batches."""
+        interval = settings.ephemeral_thread.EPHEMERAL_THREAD_SWEEP_INTERVAL_SECONDS
+        while self._running:
+            try:
+                claimed, deleted, errors = await sweep_orphaned_threads()
+                if claimed:
+                    logger.info(
+                        "Ephemeral thread sweep completed",
+                        claimed=claimed,
+                        deleted=deleted,
+                        errors=errors,
+                    )
+            except asyncio.CancelledError:
+                break
+            except Exception:
+                logger.exception("Error in ephemeral thread sweep")
+            try:
+                await asyncio.sleep(interval)
+            except asyncio.CancelledError:
+                break
+
+
+ephemeral_thread_sweeper = EphemeralThreadSweeper()

--- a/libs/aegra-api/src/aegra_api/services/ephemeral_thread_sweeper.py
+++ b/libs/aegra-api/src/aegra_api/services/ephemeral_thread_sweeper.py
@@ -33,20 +33,11 @@ def _orphaned_threads_stmt(*, cutoff: datetime, limit: int) -> Select[tuple[Thre
     checkpoint/thread deletion. The run foreign key takes a key-share lock and
     therefore waits for this claim transaction to finish.
     """
-    active_runs_exist = (
-        select(RunORM.run_id)
-        .where(
-            RunORM.thread_id == ThreadORM.thread_id,
-            RunORM.status.in_(("pending", "running")),
-        )
-        .exists()
-    )
     return (
         select(ThreadORM)
         .where(
             ThreadORM.is_ephemeral.is_(True),
             ThreadORM.updated_at <= cutoff,
-            ~active_runs_exist,
         )
         .order_by(ThreadORM.updated_at.asc())
         .limit(limit)
@@ -71,6 +62,16 @@ async def sweep_orphaned_threads() -> tuple[int, int, int]:
         errors = 0
         deleted_threads: list[ThreadORM] = []
         for thread in rows:
+            active_run = await session.scalar(
+                select(RunORM.run_id)
+                .where(
+                    RunORM.thread_id == thread.thread_id,
+                    RunORM.status.in_(("pending", "running")),
+                )
+                .limit(1)
+            )
+            if active_run is not None:
+                continue
             try:
                 # Checkpoints are in the LangGraph pool, so delete them first.
                 # A failure leaves the thread row available for a later retry.

--- a/libs/aegra-api/src/aegra_api/services/ephemeral_thread_sweeper.py
+++ b/libs/aegra-api/src/aegra_api/services/ephemeral_thread_sweeper.py
@@ -7,7 +7,6 @@ explicitly marked as ephemeral and old enough to be safely reclaimed.
 """
 
 import asyncio
-from collections.abc import Collection
 from datetime import UTC, datetime, timedelta
 
 import structlog
@@ -27,9 +26,7 @@ logger = structlog.getLogger(__name__)
 _SWEEP_ERRORS: tuple[type[BaseException], ...] = (PsycopgError, SQLAlchemyError, OSError)
 
 
-def _orphaned_threads_stmt(
-    *, cutoff: datetime, limit: int, exclude_ids: Collection[str] = ()
-) -> Select[tuple[ThreadORM]]:
+def _orphaned_threads_stmt(*, cutoff: datetime, limit: int) -> Select[tuple[ThreadORM]]:
     """Claim old ephemeral threads that have no active run.
 
     Locking the thread row prevents a concurrent run insert from racing the
@@ -39,9 +36,13 @@ def _orphaned_threads_stmt(
     conditions = [
         ThreadORM.is_ephemeral.is_(True),
         ThreadORM.updated_at <= cutoff,
+        ~select(RunORM.run_id)
+        .where(
+            RunORM.thread_id == ThreadORM.thread_id,
+            RunORM.status.in_(("pending", "running")),
+        )
+        .exists(),
     ]
-    if exclude_ids:
-        conditions.append(ThreadORM.thread_id.not_in(exclude_ids))
     return (
         select(ThreadORM)
         .where(*conditions)
@@ -59,46 +60,38 @@ async def sweep_orphaned_threads() -> tuple[int, int, int]:
         deleted = 0
         errors = 0
         deleted_threads: list[ThreadORM] = []
-        excluded_ids: set[str] = set()
-        claimed = 0
-        while len(deleted_threads) < settings.ephemeral_thread.EPHEMERAL_THREAD_SWEEP_LIMIT:
-            rows = (
-                await session.scalars(
-                    _orphaned_threads_stmt(
-                        cutoff=cutoff,
-                        limit=settings.ephemeral_thread.EPHEMERAL_THREAD_SWEEP_LIMIT,
-                        exclude_ids=excluded_ids,
-                    )
+        rows = (
+            await session.scalars(
+                _orphaned_threads_stmt(
+                    cutoff=cutoff,
+                    limit=settings.ephemeral_thread.EPHEMERAL_THREAD_SWEEP_LIMIT,
                 )
-            ).all()
-            if not rows:
-                break
-            claimed += len(rows)
-            for thread in rows:
-                active_run = await session.scalar(
-                    select(RunORM.run_id)
-                    .where(
-                        RunORM.thread_id == thread.thread_id,
-                        RunORM.status.in_(("pending", "running")),
-                    )
-                    .limit(1)
+            )
+        ).all()
+        claimed = len(rows)
+        for thread in rows:
+            # Recheck after locking because the claim query's snapshot may predate
+            # a run committed while this transaction waited for the thread lock.
+            active_run = await session.scalar(
+                select(RunORM.run_id)
+                .where(
+                    RunORM.thread_id == thread.thread_id,
+                    RunORM.status.in_(("pending", "running")),
                 )
-                if active_run is not None:
-                    excluded_ids.add(thread.thread_id)
-                    continue
-                try:
-                    # Checkpoints are in the LangGraph pool, so delete them first.
-                    # A failure leaves the thread row available for a later retry.
-                    await db_manager.get_checkpointer().adelete_thread(thread.thread_id)
-                    await session.delete(thread)
-                    deleted_threads.append(thread)
-                except _SWEEP_ERRORS:
-                    excluded_ids.add(thread.thread_id)
-                    errors += 1
-                    EPHEMERAL_THREAD_SWEPT.labels(outcome="error").inc()
-                    logger.exception("Failed to reclaim orphaned ephemeral thread", thread_id=thread.thread_id)
-                if len(deleted_threads) >= settings.ephemeral_thread.EPHEMERAL_THREAD_SWEEP_LIMIT:
-                    break
+                .limit(1)
+            )
+            if active_run is not None:
+                continue
+            try:
+                # Checkpoints are in the LangGraph pool, so delete them first.
+                # A failure leaves the thread row available for a later retry.
+                await db_manager.get_checkpointer().adelete_thread(thread.thread_id)
+                await session.delete(thread)
+                deleted_threads.append(thread)
+            except _SWEEP_ERRORS:
+                errors += 1
+                EPHEMERAL_THREAD_SWEPT.labels(outcome="error").inc()
+                logger.exception("Failed to reclaim orphaned ephemeral thread", thread_id=thread.thread_id)
         try:
             await session.commit()
         except _SWEEP_ERRORS:

--- a/libs/aegra-api/src/aegra_api/services/run_preparation.py
+++ b/libs/aegra-api/src/aegra_api/services/run_preparation.py
@@ -151,6 +151,7 @@ async def update_thread_metadata(
     *,
     user_id: str | None = None,
     input_data: dict[str, Any] | None = None,
+    is_ephemeral: bool = False,
 ) -> None:
     """Update thread metadata with assistant and graph information (dialect agnostic).
 
@@ -181,6 +182,7 @@ async def update_thread_metadata(
             status="idle",
             metadata_json=metadata,
             user_id=user_id,
+            is_ephemeral=is_ephemeral,
         )
         session.add(thread_orm)
         return
@@ -195,9 +197,10 @@ async def update_thread_metadata(
     # Only set thread_name if empty and we have a name from the input
     if thread_name and not md.get("thread_name"):
         md["thread_name"] = thread_name
-    await session.execute(
-        update(ThreadORM).where(ThreadORM.thread_id == thread_id).values(metadata_json=md, updated_at=datetime.now(UTC))
-    )
+    values: dict[str, object] = {"metadata_json": md, "updated_at": datetime.now(UTC)}
+    if is_ephemeral:
+        values["is_ephemeral"] = True
+    await session.execute(update(ThreadORM).where(ThreadORM.thread_id == thread_id).values(**values))
 
 
 async def _prepare_run(

--- a/libs/aegra-api/src/aegra_api/services/run_preparation.py
+++ b/libs/aegra-api/src/aegra_api/services/run_preparation.py
@@ -5,6 +5,8 @@ resume-command validation, and config/context merging logic.
 """
 
 import asyncio
+from contextlib import contextmanager
+from contextvars import ContextVar
 from datetime import UTC, datetime
 from typing import Any
 from uuid import uuid4
@@ -28,6 +30,18 @@ from aegra_api.utils.assistants import resolve_assistant_id
 from aegra_api.utils.run_utils import _merge_jsonb
 
 logger = structlog.getLogger(__name__)
+
+_EPHEMERAL_RUN = ContextVar("aegra_ephemeral_run", default=False)
+
+
+@contextmanager
+def ephemeral_run_context():
+    """Mark the next run prepared in this task as a stateless ephemeral run."""
+    token = _EPHEMERAL_RUN.set(True)
+    try:
+        yield
+    finally:
+        _EPHEMERAL_RUN.reset(token)
 
 
 # The interrupt reaches the client (via the broker/SSE) before the run executor
@@ -246,7 +260,13 @@ async def _prepare_run(
 
     # Mark thread as busy and update metadata
     await update_thread_metadata(
-        session, thread_id, assistant.assistant_id, assistant.graph_id, user_id=user.identity, input_data=request.input
+        session,
+        thread_id,
+        assistant.assistant_id,
+        assistant.graph_id,
+        user_id=user.identity,
+        input_data=request.input,
+        is_ephemeral=_EPHEMERAL_RUN.get(),
     )
     await set_thread_status(session, thread_id, "busy")
 

--- a/libs/aegra-api/src/aegra_api/services/run_preparation.py
+++ b/libs/aegra-api/src/aegra_api/services/run_preparation.py
@@ -5,6 +5,7 @@ resume-command validation, and config/context merging logic.
 """
 
 import asyncio
+from collections.abc import Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
 from datetime import UTC, datetime
@@ -35,7 +36,7 @@ _EPHEMERAL_RUN = ContextVar("aegra_ephemeral_run", default=False)
 
 
 @contextmanager
-def ephemeral_run_context():
+def ephemeral_run_context() -> Iterator[None]:
     """Mark the next run prepared in this task as a stateless ephemeral run."""
     token = _EPHEMERAL_RUN.set(True)
     try:

--- a/libs/aegra-api/src/aegra_api/settings.py
+++ b/libs/aegra-api/src/aegra_api/settings.py
@@ -451,6 +451,14 @@ class ThreadTTLSettings(EnvBase):
     LANGGRAPH_THREAD_TTL: str | None = None
 
 
+class EphemeralThreadSettings(EnvBase):
+    """Retention policy for orphaned threads created by stateless runs."""
+
+    EPHEMERAL_THREAD_RETENTION_SECONDS: int = Field(default=86400, gt=0)
+    EPHEMERAL_THREAD_SWEEP_INTERVAL_SECONDS: int = Field(default=300, gt=0)
+    EPHEMERAL_THREAD_SWEEP_LIMIT: int = Field(default=100, gt=0)
+
+
 class EventStreamingSettings(EnvBase):
     """Agent Protocol v2 event streaming (/threads/{id}/stream/events + /commands).
 
@@ -477,6 +485,7 @@ class Settings:
         self.worker = WorkerSettings()
         self.cron = CronSettings()
         self.thread_ttl = ThreadTTLSettings()
+        self.ephemeral_thread = EphemeralThreadSettings()
         self.event_streaming = EventStreamingSettings()
 
 

--- a/libs/aegra-api/src/aegra_api/settings.py
+++ b/libs/aegra-api/src/aegra_api/settings.py
@@ -452,7 +452,11 @@ class ThreadTTLSettings(EnvBase):
 
 
 class EphemeralThreadSettings(EnvBase):
-    """Retention policy for orphaned threads created by stateless runs."""
+    """Retention policy for orphaned stateless-run threads.
+
+    The sweeper starts with the application and only reclaims explicitly
+    marked, stale threads without pending or running runs.
+    """
 
     EPHEMERAL_THREAD_RETENTION_SECONDS: int = Field(default=86400, gt=0)
     EPHEMERAL_THREAD_SWEEP_INTERVAL_SECONDS: int = Field(default=300, gt=0)

--- a/libs/aegra-api/tests/unit/test_services/test_ephemeral_thread_sweeper.py
+++ b/libs/aegra-api/tests/unit/test_services/test_ephemeral_thread_sweeper.py
@@ -31,7 +31,9 @@ async def test_sweep_deletes_checkpoints_before_thread(monkeypatch: pytest.Monke
     session.scalar.return_value = None
     result = MagicMock()
     result.all.return_value = [thread]
-    session.scalars.return_value = result
+    empty = MagicMock()
+    empty.all.return_value = []
+    session.scalars.side_effect = [result, empty]
     context = MagicMock()
     context.__aenter__ = AsyncMock(return_value=session)
     context.__aexit__ = AsyncMock(return_value=False)
@@ -57,7 +59,9 @@ async def test_sweep_keeps_thread_when_checkpoint_delete_fails(monkeypatch: pyte
     session.scalar.return_value = None
     result = MagicMock()
     result.all.return_value = [thread]
-    session.scalars.return_value = result
+    empty = MagicMock()
+    empty.all.return_value = []
+    session.scalars.side_effect = [result, empty]
     context = MagicMock()
     context.__aenter__ = AsyncMock(return_value=session)
     context.__aexit__ = AsyncMock(return_value=False)
@@ -82,7 +86,9 @@ async def test_sweep_does_not_count_rows_when_commit_fails(monkeypatch: pytest.M
     session.scalar.return_value = None
     result = MagicMock()
     result.all.return_value = [thread]
-    session.scalars.return_value = result
+    empty = MagicMock()
+    empty.all.return_value = []
+    session.scalars.side_effect = [result, empty]
     session.commit.side_effect = OSError("database unavailable")
     context = MagicMock()
     context.__aenter__ = AsyncMock(return_value=session)
@@ -107,7 +113,9 @@ async def test_sweep_skips_thread_with_active_run_after_lock(monkeypatch: pytest
     session.scalar.return_value = "active-run"
     result = MagicMock()
     result.all.return_value = [thread]
-    session.scalars.return_value = result
+    empty = MagicMock()
+    empty.all.return_value = []
+    session.scalars.side_effect = [result, empty]
     context = MagicMock()
     context.__aenter__ = AsyncMock(return_value=session)
     context.__aexit__ = AsyncMock(return_value=False)
@@ -118,3 +126,33 @@ async def test_sweep_skips_thread_with_active_run_after_lock(monkeypatch: pytest
     assert (claimed, deleted, errors) == (1, 0, 0)
     session.delete.assert_not_awaited()
     session.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_sweep_continues_after_active_batch_row(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Active rows do not starve later reclaimable rows in a bounded pass."""
+    monkeypatch.setattr(mod.settings.ephemeral_thread, "EPHEMERAL_THREAD_SWEEP_LIMIT", 1)
+    active_thread = SimpleNamespace(thread_id="active")
+    orphan_thread = SimpleNamespace(thread_id="orphan")
+    session = AsyncMock()
+    session.scalar.side_effect = ["active-run", None]
+    first = MagicMock()
+    first.all.return_value = [active_thread]
+    second = MagicMock()
+    second.all.return_value = [orphan_thread]
+    empty = MagicMock()
+    empty.all.return_value = []
+    session.scalars.side_effect = [first, second, empty]
+    context = MagicMock()
+    context.__aenter__ = AsyncMock(return_value=session)
+    context.__aexit__ = AsyncMock(return_value=False)
+    monkeypatch.setattr(mod, "_get_session_maker", lambda: MagicMock(return_value=context))
+
+    checkpointer = MagicMock()
+    checkpointer.adelete_thread = AsyncMock()
+    monkeypatch.setattr(mod.db_manager, "get_checkpointer", lambda: checkpointer)
+
+    claimed, deleted, errors = await mod.sweep_orphaned_threads()
+
+    assert (claimed, deleted, errors) == (2, 1, 0)
+    checkpointer.adelete_thread.assert_awaited_once_with("orphan")

--- a/libs/aegra-api/tests/unit/test_services/test_ephemeral_thread_sweeper.py
+++ b/libs/aegra-api/tests/unit/test_services/test_ephemeral_thread_sweeper.py
@@ -20,6 +20,7 @@ def test_orphan_claim_requires_ephemeral_old_and_terminal_threads() -> None:
 
     assert "thread.is_ephemeral IS true" in sql
     assert "thread.updated_at <=" in sql
+    assert "runs.status IN ('pending', 'running')" in sql
     assert "FOR UPDATE OF thread SKIP LOCKED" in sql
 
 
@@ -126,33 +127,3 @@ async def test_sweep_skips_thread_with_active_run_after_lock(monkeypatch: pytest
     assert (claimed, deleted, errors) == (1, 0, 0)
     session.delete.assert_not_awaited()
     session.commit.assert_awaited_once()
-
-
-@pytest.mark.asyncio
-async def test_sweep_continues_after_active_batch_row(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Active rows do not starve later reclaimable rows in a bounded pass."""
-    monkeypatch.setattr(mod.settings.ephemeral_thread, "EPHEMERAL_THREAD_SWEEP_LIMIT", 1)
-    active_thread = SimpleNamespace(thread_id="active")
-    orphan_thread = SimpleNamespace(thread_id="orphan")
-    session = AsyncMock()
-    session.scalar.side_effect = ["active-run", None]
-    first = MagicMock()
-    first.all.return_value = [active_thread]
-    second = MagicMock()
-    second.all.return_value = [orphan_thread]
-    empty = MagicMock()
-    empty.all.return_value = []
-    session.scalars.side_effect = [first, second, empty]
-    context = MagicMock()
-    context.__aenter__ = AsyncMock(return_value=session)
-    context.__aexit__ = AsyncMock(return_value=False)
-    monkeypatch.setattr(mod, "_get_session_maker", lambda: MagicMock(return_value=context))
-
-    checkpointer = MagicMock()
-    checkpointer.adelete_thread = AsyncMock()
-    monkeypatch.setattr(mod.db_manager, "get_checkpointer", lambda: checkpointer)
-
-    claimed, deleted, errors = await mod.sweep_orphaned_threads()
-
-    assert (claimed, deleted, errors) == (2, 1, 0)
-    checkpointer.adelete_thread.assert_awaited_once_with("orphan")

--- a/libs/aegra-api/tests/unit/test_services/test_ephemeral_thread_sweeper.py
+++ b/libs/aegra-api/tests/unit/test_services/test_ephemeral_thread_sweeper.py
@@ -20,6 +20,7 @@ def test_orphan_claim_requires_ephemeral_old_and_terminal_threads() -> None:
 
     assert "thread.is_ephemeral IS true" in sql
     assert "thread.updated_at <=" in sql
+    assert "NOT (EXISTS (SELECT" in sql
     assert "runs.status IN ('pending', 'running')" in sql
     assert "FOR UPDATE OF thread SKIP LOCKED" in sql
 

--- a/libs/aegra-api/tests/unit/test_services/test_ephemeral_thread_sweeper.py
+++ b/libs/aegra-api/tests/unit/test_services/test_ephemeral_thread_sweeper.py
@@ -1,0 +1,73 @@
+"""Tests for stale stateless-run thread reclamation."""
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy.dialects import postgresql
+
+from aegra_api.services import ephemeral_thread_sweeper as mod
+
+
+def test_orphan_claim_requires_ephemeral_old_and_terminal_threads() -> None:
+    """The claim query cannot select persistent, fresh, or active threads."""
+    sql = str(
+        mod._orphaned_threads_stmt(cutoff=datetime.now(UTC), limit=10).compile(
+            dialect=postgresql.dialect(), compile_kwargs={"literal_binds": True}
+        )
+    )
+
+    assert "thread.is_ephemeral IS true" in sql
+    assert "thread.updated_at <=" in sql
+    assert "runs.status IN ('pending', 'running')" in sql
+    assert "FOR UPDATE OF thread SKIP LOCKED" in sql
+
+
+@pytest.mark.asyncio
+async def test_sweep_deletes_checkpoints_before_thread(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A reclaimed row deletes LangGraph state before its metadata row."""
+    thread = SimpleNamespace(thread_id="t1")
+    session = AsyncMock()
+    result = MagicMock()
+    result.all.return_value = [thread]
+    session.scalars.return_value = result
+    context = MagicMock()
+    context.__aenter__ = AsyncMock(return_value=session)
+    context.__aexit__ = AsyncMock(return_value=False)
+    monkeypatch.setattr(mod, "_get_session_maker", lambda: MagicMock(return_value=context))
+
+    checkpointer = MagicMock()
+    checkpointer.adelete_thread = AsyncMock()
+    monkeypatch.setattr(mod.db_manager, "get_checkpointer", lambda: checkpointer)
+
+    claimed, deleted, errors = await mod.sweep_orphaned_threads()
+
+    assert (claimed, deleted, errors) == (1, 1, 0)
+    checkpointer.adelete_thread.assert_awaited_once_with("t1")
+    session.delete.assert_awaited_once_with(thread)
+    session.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_sweep_keeps_thread_when_checkpoint_delete_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Checkpoint failures leave the row available for a later retry."""
+    thread = SimpleNamespace(thread_id="t1")
+    session = AsyncMock()
+    result = MagicMock()
+    result.all.return_value = [thread]
+    session.scalars.return_value = result
+    context = MagicMock()
+    context.__aenter__ = AsyncMock(return_value=session)
+    context.__aexit__ = AsyncMock(return_value=False)
+    monkeypatch.setattr(mod, "_get_session_maker", lambda: MagicMock(return_value=context))
+
+    checkpointer = MagicMock()
+    checkpointer.adelete_thread = AsyncMock(side_effect=OSError("checkpoint unavailable"))
+    monkeypatch.setattr(mod.db_manager, "get_checkpointer", lambda: checkpointer)
+
+    claimed, deleted, errors = await mod.sweep_orphaned_threads()
+
+    assert (claimed, deleted, errors) == (1, 0, 1)
+    session.delete.assert_not_awaited()
+    session.commit.assert_awaited_once()

--- a/libs/aegra-api/tests/unit/test_services/test_ephemeral_thread_sweeper.py
+++ b/libs/aegra-api/tests/unit/test_services/test_ephemeral_thread_sweeper.py
@@ -20,7 +20,6 @@ def test_orphan_claim_requires_ephemeral_old_and_terminal_threads() -> None:
 
     assert "thread.is_ephemeral IS true" in sql
     assert "thread.updated_at <=" in sql
-    assert "runs.status IN ('pending', 'running')" in sql
     assert "FOR UPDATE OF thread SKIP LOCKED" in sql
 
 
@@ -29,6 +28,7 @@ async def test_sweep_deletes_checkpoints_before_thread(monkeypatch: pytest.Monke
     """A reclaimed row deletes LangGraph state before its metadata row."""
     thread = SimpleNamespace(thread_id="t1")
     session = AsyncMock()
+    session.scalar.return_value = None
     result = MagicMock()
     result.all.return_value = [thread]
     session.scalars.return_value = result
@@ -54,6 +54,7 @@ async def test_sweep_keeps_thread_when_checkpoint_delete_fails(monkeypatch: pyte
     """Checkpoint failures leave the row available for a later retry."""
     thread = SimpleNamespace(thread_id="t1")
     session = AsyncMock()
+    session.scalar.return_value = None
     result = MagicMock()
     result.all.return_value = [thread]
     session.scalars.return_value = result
@@ -78,6 +79,7 @@ async def test_sweep_does_not_count_rows_when_commit_fails(monkeypatch: pytest.M
     """A rolled-back metadata transaction is reported as an error, not a deletion."""
     thread = SimpleNamespace(thread_id="t1")
     session = AsyncMock()
+    session.scalar.return_value = None
     result = MagicMock()
     result.all.return_value = [thread]
     session.scalars.return_value = result
@@ -95,3 +97,24 @@ async def test_sweep_does_not_count_rows_when_commit_fails(monkeypatch: pytest.M
 
     assert (claimed, deleted, errors) == (1, 0, 1)
     session.rollback.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_sweep_skips_thread_with_active_run_after_lock(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A fresh active-run check protects a thread committed during lock wait."""
+    thread = SimpleNamespace(thread_id="t1")
+    session = AsyncMock()
+    session.scalar.return_value = "active-run"
+    result = MagicMock()
+    result.all.return_value = [thread]
+    session.scalars.return_value = result
+    context = MagicMock()
+    context.__aenter__ = AsyncMock(return_value=session)
+    context.__aexit__ = AsyncMock(return_value=False)
+    monkeypatch.setattr(mod, "_get_session_maker", lambda: MagicMock(return_value=context))
+
+    claimed, deleted, errors = await mod.sweep_orphaned_threads()
+
+    assert (claimed, deleted, errors) == (1, 0, 0)
+    session.delete.assert_not_awaited()
+    session.commit.assert_awaited_once()

--- a/libs/aegra-api/tests/unit/test_services/test_ephemeral_thread_sweeper.py
+++ b/libs/aegra-api/tests/unit/test_services/test_ephemeral_thread_sweeper.py
@@ -71,3 +71,27 @@ async def test_sweep_keeps_thread_when_checkpoint_delete_fails(monkeypatch: pyte
     assert (claimed, deleted, errors) == (1, 0, 1)
     session.delete.assert_not_awaited()
     session.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_sweep_does_not_count_rows_when_commit_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A rolled-back metadata transaction is reported as an error, not a deletion."""
+    thread = SimpleNamespace(thread_id="t1")
+    session = AsyncMock()
+    result = MagicMock()
+    result.all.return_value = [thread]
+    session.scalars.return_value = result
+    session.commit.side_effect = OSError("database unavailable")
+    context = MagicMock()
+    context.__aenter__ = AsyncMock(return_value=session)
+    context.__aexit__ = AsyncMock(return_value=False)
+    monkeypatch.setattr(mod, "_get_session_maker", lambda: MagicMock(return_value=context))
+
+    checkpointer = MagicMock()
+    checkpointer.adelete_thread = AsyncMock()
+    monkeypatch.setattr(mod.db_manager, "get_checkpointer", lambda: checkpointer)
+
+    claimed, deleted, errors = await mod.sweep_orphaned_threads()
+
+    assert (claimed, deleted, errors) == (1, 0, 1)
+    session.rollback.assert_awaited_once()

--- a/libs/aegra-api/tests/unit/test_services/test_run_preparation.py
+++ b/libs/aegra-api/tests/unit/test_services/test_run_preparation.py
@@ -76,3 +76,24 @@ class TestValidateResumeCommand:
         session = _session_returning(_thread("idle"))
         await _validate_resume_command(session, "t1", None)
         session.scalar.assert_not_awaited()
+
+
+async def test_update_thread_metadata_persists_ephemeral_marker() -> None:
+    """Stateless preparation marks newly auto-created threads in the same transaction."""
+    session = AsyncMock()
+    session.scalar.return_value = None
+    session.add = MagicMock()
+
+    await mod.update_thread_metadata(
+        session,
+        "thread-1",
+        "assistant-1",
+        "graph-1",
+        user_id="user-1",
+        is_ephemeral=True,
+    )
+
+    created_thread = session.add.call_args.args[0]
+    assert created_thread.thread_id == "thread-1"
+    assert created_thread.user_id == "user-1"
+    assert created_thread.is_ephemeral is True

--- a/libs/aegra-api/tests/unit/test_settings.py
+++ b/libs/aegra-api/tests/unit/test_settings.py
@@ -10,6 +10,7 @@ from aegra_api.settings import (
     AppSettings,
     CronSettings,
     DatabaseSettings,
+    EphemeralThreadSettings,
     RedisSettings,
     ThreadTTLSettings,
     WorkerSettings,
@@ -44,6 +45,7 @@ class TestAppSettingsServerURL:
         assert app.HOST == "0.0.0.0"
         assert app.PORT == 2026
         assert app.SERVER_URL == "http://localhost:2026"
+
 
     def test_derives_localhost_when_host_is_loopback(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """SERVER_URL uses localhost when HOST=127.0.0.1."""
@@ -689,3 +691,12 @@ class TestMaxSearchLimit:
         monkeypatch.setenv("MAX_SEARCH_LIMIT", "-1")
         with pytest.raises(ValidationError):
             AppSettings(_env_file=None)
+
+
+def test_ephemeral_thread_settings_have_safe_defaults() -> None:
+    """Orphan cleanup is bounded and enabled with conservative defaults."""
+    config = EphemeralThreadSettings(_env_file=None)
+
+    assert config.EPHEMERAL_THREAD_RETENTION_SECONDS == 86400
+    assert config.EPHEMERAL_THREAD_SWEEP_INTERVAL_SECONDS == 300
+    assert config.EPHEMERAL_THREAD_SWEEP_LIMIT == 100

--- a/libs/aegra-api/tests/unit/test_settings.py
+++ b/libs/aegra-api/tests/unit/test_settings.py
@@ -46,7 +46,6 @@ class TestAppSettingsServerURL:
         assert app.PORT == 2026
         assert app.SERVER_URL == "http://localhost:2026"
 
-
     def test_derives_localhost_when_host_is_loopback(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """SERVER_URL uses localhost when HOST=127.0.0.1."""
         self._clear_app_env(monkeypatch)

--- a/libs/aegra-api/tests/unit/test_settings.py
+++ b/libs/aegra-api/tests/unit/test_settings.py
@@ -700,3 +700,24 @@ def test_ephemeral_thread_settings_have_safe_defaults() -> None:
     assert config.EPHEMERAL_THREAD_RETENTION_SECONDS == 86400
     assert config.EPHEMERAL_THREAD_SWEEP_INTERVAL_SECONDS == 300
     assert config.EPHEMERAL_THREAD_SWEEP_LIMIT == 100
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("EPHEMERAL_THREAD_RETENTION_SECONDS", "0"),
+        ("EPHEMERAL_THREAD_RETENTION_SECONDS", "-1"),
+        ("EPHEMERAL_THREAD_SWEEP_INTERVAL_SECONDS", "0"),
+        ("EPHEMERAL_THREAD_SWEEP_INTERVAL_SECONDS", "-1"),
+        ("EPHEMERAL_THREAD_SWEEP_LIMIT", "0"),
+        ("EPHEMERAL_THREAD_SWEEP_LIMIT", "-1"),
+    ],
+)
+def test_ephemeral_thread_settings_reject_non_positive_values(
+    monkeypatch: pytest.MonkeyPatch, field: str, value: str
+) -> None:
+    """Retention, interval, and batch limits must all be positive."""
+    monkeypatch.setenv(field, value)
+
+    with pytest.raises(ValidationError):
+        EphemeralThreadSettings(_env_file=None)

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.10.5"
+version = "0.11.0"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -24,7 +24,7 @@ dependencies = [
     "python-dotenv>=1.2.2",
 
     # Server (always included)
-    "aegra-api~=0.10.0",
+    "aegra-api~=0.11.0",
 ]
 
 [project.optional-dependencies]

--- a/libs/aegra-cli/src/aegra_cli/templates/env.example.template
+++ b/libs/aegra-cli/src/aegra_cli/templates/env.example.template
@@ -112,6 +112,14 @@ CRON_ENABLED=true
 # AEGRA_THREAD_TTL=43200
 # AEGRA_THREAD_TTL={"strategy": "keep_latest", "default_ttl": 1440, "sweep_interval_minutes": 5, "sweep_limit": 10000}
 
+# --- Stateless orphan thread cleanup ---
+# Reclaims stateless-run threads left behind by client disconnects after they
+# have no pending/running runs. Persistent threads and on_completion=keep are
+# never marked for this cleanup.
+# EPHEMERAL_THREAD_RETENTION_SECONDS=86400
+# EPHEMERAL_THREAD_SWEEP_INTERVAL_SECONDS=300
+# EPHEMERAL_THREAD_SWEEP_LIMIT=100
+
 # --- Event Streaming (Agent Protocol v2) ---
 # The v2 thread streaming endpoints (/threads/{id}/stream/events and
 # /threads/{id}/commands) used by the latest LangGraph JS/Python SDKs.

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.10.5"
+version = "0.11.0"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -100,7 +100,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.10.5"
+version = "0.11.0"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
 ## Summary

  Fixes #588.

  Stateless runs can leave orphaned ephemeral thread rows when clients
  disconnect before terminal-event cleanup completes, especially in Redis
  worker mode.

  This PR:

  - Adds an explicit `is_ephemeral` thread marker.
  - Adds a background sweeper for stale orphaned ephemeral threads.
  - Deletes only threads with no pending or running runs.
  - Uses row locking to prevent cleanup races with new runs.
  - Deletes LangGraph checkpoints before deleting thread metadata.
  - Preserves persistent threads and `on_completion="keep"`.
  - Adds configurable retention, interval, and batch limits.
  - Adds metrics, migration, documentation, and regression tests.

  ## Testing

  - Ruff checks passed.
  - Stateless run tests passed.
  - New ephemeral-thread sweeper tests passed.
  - Settings tests passed.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Abandoned temporary threads from stateless runs are automatically cleaned up after a configurable retention period.
  * Cleanup skips threads with active runs and preserves persistent threads and runs configured to be kept.
  * Added settings for retention duration, sweep frequency, and cleanup batch size.

* **Documentation**
  * Added configuration examples and environment variable descriptions for temporary thread cleanup.

* **Monitoring**
  * Added metrics for successful and failed cleanup operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->











<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR introduces lifecycle management for ephemeral stateless-run threads.
- Marks auto-created stateless threads as ephemeral during run preparation.
- Periodically deletes stale ephemeral threads without active runs, using row locks and bounded batches.
- Deletes checkpoint state before thread metadata and records cleanup metrics.
- Adds configuration, migration, documentation, synchronized package versions, and unit tests.
- The sole change since the previous review strengthens the claim-query test to verify exclusion of active runs.

<h3>Confidence Score: 4/5</h3>

The implementation appears functionally sound, but the explicit repository testing and documentation requirements remain outstanding and must be satisfied before merging.

The previously reported runtime failures, metric overcounting, starvation, unbounded sweep behavior, missing annotation, environment-template synchronization, and version synchronization are fixed or manually resolved. The unresolved regression-coverage thread remains outstanding because the feature still has only mocked unit coverage and does not exercise ephemeral marker persistence, row locking, checkpoint deletion, and application lifecycle against real services. The documentation thread also remains outstanding under the repository requirement because the environment-variable reference was updated, but the required root/package README and CLAUDE.md locations were not.

**Files Needing Attention:** libs/aegra-api/tests/unit/test_services/test_ephemeral_thread_sweeper.py, libs/aegra-api/src/aegra_api/services/ephemeral_thread_sweeper.py

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/services/ephemeral_thread_sweeper.py | Adds bounded, lock-aware reclamation of stale ephemeral threads with checkpoint-first deletion and post-commit metrics. |
| libs/aegra-api/src/aegra_api/services/run_preparation.py | Propagates stateless-run context into thread creation and persists the ephemeral marker. |
| libs/aegra-api/src/aegra_api/api/stateless_runs.py | Marks delete-on-completion stateless run preparation as ephemeral while preserving keep behavior. |
| libs/aegra-api/alembic/versions/20260908000000_add_ephemeral_thread_marker.py | Adds the non-null ephemeral marker and cleanup lookup index. |
| libs/aegra-api/tests/unit/test_services/test_ephemeral_thread_sweeper.py | Covers query construction and mocked cleanup behavior, including the newly asserted active-run exclusion, but does not provide the previously requested database and lifecycle regression coverage. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Stateless request] --> B{on_completion = keep?}
    B -- Yes --> C[Prepare persistent thread]
    B -- No --> D[Prepare thread in ephemeral context]
    D --> E[Persist is_ephemeral marker]
    E --> F{Normal terminal cleanup succeeds?}
    F -- Yes --> G[Delete checkpoint and thread]
    F -- No / disconnect --> H[Thread remains]
    H --> I[Periodic sweeper]
    I --> J{Stale and no pending/running run?}
    J -- No --> K[Preserve thread]
    J -- Yes --> L[Lock thread row]
    L --> M[Delete LangGraph checkpoints]
    M --> N[Delete thread metadata]
    N --> O[Commit and record deletion metric]
```
</details>

<sub>Reviews (7): Last reviewed commit: ["test(api): assert orphan query excludes ..."](https://github.com/aegra/aegra/commit/bfdf827fc6fc716cd80fab0d2e8bff0352034599) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61601468)</sub>

<!-- /greptile_comment -->