### PR TITLE
feat(config): support object-form graph entries

### DIFF
--- a/aegra.json
+++ b/aegra.json
@@ -1,7 +1,10 @@
 {
   "dependencies": ["./examples"],
   "graphs": {
-    "agent": "./examples/react_agent/graph.py:graph",
+    "agent": {
+      "path": "./examples/react_agent/graph.py:graph",
+      "description": "ReAct agent with tools"
+    },
     "agent_hitl": "./examples/react_agent_hitl/graph.py:graph",
     "subgraph_agent": "./examples/subgraph_agent/graph.py:graph",
     "subgraph_hitl_agent": "./examples/subgraph_hitl_agent/graph.py:graph",

--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -88,15 +88,22 @@ Define your LangGraph agents.
 {
   "graphs": {
     "agent": "./src/react_agent/graph.py:graph",
-    "custom_agent": "./src/custom/graph.py:my_graph"
+    "custom_agent": {
+      "path": "./src/custom/graph.py:my_graph",
+      "description": "Handles custom workflows"
+    }
   }
 }
 ```
 
+Each value can be a string import path or an object with a required `path` and optional `description`. The string form remains supported for backwards compatibility.
+
 | Field | Type | Description |
 |-------|------|-------------|
 | Key | `string` | Graph ID (used in API calls to identify the graph) |
-| Value | `string` | Import path in format `./path/to/file.py:variable` |
+| Value | `string \| object` | String import path or graph configuration object |
+| `path` | `string` | Required in object form; import path in format `./path/to/file.py:variable` |
+| `description` | `string` | Optional graph description available to adapters and discovery tooling |
 
 The variable can be:
 

--- a/libs/aegra-api/README.md
+++ b/libs/aegra-api/README.md
@@ -72,13 +72,18 @@ Define your agent graphs in `aegra.json`:
 {
   "graphs": {
     "agent": "./graphs/my_agent/graph.py:graph",
-    "assistant": "./graphs/assistant/graph.py:graph"
+    "assistant": {
+      "path": "./graphs/assistant/graph.py:graph",
+      "description": "Assistant for support workflows"
+    }
   },
   "http": {
     "app": "./custom_routes.py:app"
   }
 }
 ```
+
+Graph entries accept either the legacy string import path or an object with a required `path` and optional `description`.
 
 ### Environment Variables
 

--- a/libs/aegra-api/src/aegra_api/services/langgraph_service.py
+++ b/libs/aegra-api/src/aegra_api/services/langgraph_service.py
@@ -15,7 +15,7 @@ import sys
 from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager
 from pathlib import Path
-from typing import Any, TypeVar
+from typing import Any, NotRequired, TypedDict, TypeVar, cast
 from uuid import uuid5
 
 import structlog
@@ -45,6 +45,21 @@ State = TypeVar("State")
 logger = structlog.get_logger(__name__)
 
 
+class GraphConfigEntry(TypedDict):
+    """Object form of a graph configuration entry."""
+
+    path: str
+    description: NotRequired[str]
+
+
+class GraphRegistryEntry(TypedDict):
+    """Normalized graph metadata used by graph consumers."""
+
+    file_path: str
+    export_name: str
+    description: NotRequired[str]
+
+
 def _module_name_for(graph_id: str) -> str:
     """Return a safe ``sys.modules`` key for a dynamically loaded graph.
 
@@ -54,6 +69,35 @@ def _module_name_for(graph_id: str) -> str:
     """
     safe_id = graph_id.replace(".", "_").replace("/", "_").replace("-", "_")
     return f"aegra_graphs.{safe_id}"
+
+
+def _parse_graph_config_entry(graph_id: str, graph_config: object) -> GraphRegistryEntry:
+    """Validate and normalize one graph configuration entry."""
+    description: str | None = None
+    if isinstance(graph_config, str):
+        graph_path = graph_config
+    elif isinstance(graph_config, dict):
+        graph_config_data = cast(dict[str, object], graph_config)
+        if "path" not in graph_config_data:
+            raise ValueError(f"Graph '{graph_id}' configuration is missing required 'path'")
+        graph_path = graph_config_data["path"]
+        raw_description = graph_config_data.get("description")
+        if not isinstance(graph_path, str):
+            raise ValueError(f"Graph '{graph_id}' field 'path' must be a string")
+        if raw_description is not None and not isinstance(raw_description, str):
+            raise ValueError(f"Graph '{graph_id}' field 'description' must be a string")
+        description = raw_description
+    else:
+        raise ValueError(f"Graph '{graph_id}' configuration must be a string or object")
+
+    if ":" not in graph_path:
+        raise ValueError(f"Invalid graph path format for '{graph_id}': {graph_path}")
+
+    file_path, export_name = graph_path.split(":", 1)
+    registry_entry = GraphRegistryEntry(file_path=file_path, export_name=export_name)
+    if description is not None:
+        registry_entry["description"] = description
+    return registry_entry
 
 
 class LangGraphService:
@@ -69,7 +113,7 @@ class LangGraphService:
         self.config_path = Path(config_path) if config_path else Path("aegra.json")
         self._explicit_config = config_path is not None
         self.config: dict[str, Any] | None = None
-        self._graph_registry: dict[str, Any] = {}
+        self._graph_registry: dict[str, GraphRegistryEntry] = {}
         # Cache for base graph definitions (without checkpointer/store).
         # For factory graphs, this holds the default-compiled graph (for schema extraction).
         self._base_graph_cache: dict[str, Pregel] = {}
@@ -127,7 +171,10 @@ class LangGraphService:
         """Load graph definitions from aegra.json"""
         if self.config is None:
             raise ValueError("Configuration not loaded")
-        graphs_config = self.config.get("graphs", {})
+        raw_graphs_config = self.config.get("graphs", {})
+        if not isinstance(raw_graphs_config, dict):
+            raise ValueError("Configuration field 'graphs' must be an object")
+        graphs_config = cast(dict[str, str | GraphConfigEntry], raw_graphs_config)
 
         # Detect graph_ids that collide after sanitisation (e.g. "a.b" and
         # "a_b" both map to aegra_graphs.a_b in sys.modules).
@@ -141,16 +188,8 @@ class LangGraphService:
                 )
             seen_modules[mod_name] = graph_id
 
-        for graph_id, graph_path in graphs_config.items():
-            # Parse path format: "./graphs/weather_agent.py:graph"
-            if ":" not in graph_path:
-                raise ValueError(f"Invalid graph path format: {graph_path}")
-
-            file_path, export_name = graph_path.split(":", 1)
-            self._graph_registry[graph_id] = {
-                "file_path": file_path,
-                "export_name": export_name,
-            }
+        for graph_id, graph_config in graphs_config.items():
+            self._graph_registry[graph_id] = _parse_graph_config_entry(graph_id, graph_config)
 
     async def _load_all_graph_modules(self) -> None:
         """Eagerly load all graph modules, classifying factories without calling them.
@@ -479,7 +518,7 @@ class LangGraphService:
 
         return await self._get_base_graph(graph_id)
 
-    async def _load_graph_from_file(self, graph_id: str, graph_info: dict[str, str]) -> Pregel | StateGraph | None:
+    async def _load_graph_from_file(self, graph_id: str, graph_info: GraphRegistryEntry) -> Pregel | StateGraph | None:
         """Load graph from filesystem.
 
         Paths are resolved relative to the config file's directory.

--- a/libs/aegra-api/src/aegra_api/services/langgraph_service.py
+++ b/libs/aegra-api/src/aegra_api/services/langgraph_service.py
@@ -81,12 +81,13 @@ def _parse_graph_config_entry(graph_id: str, graph_config: object) -> GraphRegis
         if "path" not in graph_config_data:
             raise ValueError(f"Graph '{graph_id}' configuration is missing required 'path'")
         graph_path = graph_config_data["path"]
-        raw_description = graph_config_data.get("description")
         if not isinstance(graph_path, str):
             raise ValueError(f"Graph '{graph_id}' field 'path' must be a string")
-        if raw_description is not None and not isinstance(raw_description, str):
-            raise ValueError(f"Graph '{graph_id}' field 'description' must be a string")
-        description = raw_description
+        if "description" in graph_config_data:
+            raw_description = graph_config_data["description"]
+            if not isinstance(raw_description, str):
+                raise ValueError(f"Graph '{graph_id}' field 'description' must be a string")
+            description = raw_description
     else:
         raise ValueError(f"Graph '{graph_id}' configuration must be a string or object")
 
@@ -94,6 +95,8 @@ def _parse_graph_config_entry(graph_id: str, graph_config: object) -> GraphRegis
         raise ValueError(f"Invalid graph path format for '{graph_id}': {graph_path}")
 
     file_path, export_name = graph_path.split(":", 1)
+    if not file_path or not export_name:
+        raise ValueError(f"Invalid graph path format for '{graph_id}': {graph_path}")
     registry_entry = GraphRegistryEntry(file_path=file_path, export_name=export_name)
     if description is not None:
         registry_entry["description"] = description

--- a/libs/aegra-api/tests/integration/test_services/test_langgraph_service_integration.py
+++ b/libs/aegra-api/tests/integration/test_services/test_langgraph_service_integration.py
@@ -47,6 +47,34 @@ class TestLangGraphServiceRealFiles:
                 assert service.get_dependencies() == ["dep1", "dep2"]
 
     @pytest.mark.asyncio
+    async def test_initialize_with_object_graph_config(self) -> None:
+        config_data = {
+            "graphs": {
+                "test_graph": {
+                    "path": "./graphs/test.py:graph",
+                    "description": "Graph loaded from an object entry",
+                }
+            }
+        }
+
+        with TemporaryDirectory() as temp_dir:
+            config_path = Path(temp_dir) / "aegra.json"
+            config_path.write_text(json.dumps(config_data))
+
+            with (
+                patch("aegra_api.services.langgraph_service.LangGraphService._ensure_default_assistants"),
+                patch("aegra_api.services.langgraph_service.LangGraphService._load_all_graph_modules"),
+            ):
+                service = LangGraphService(str(config_path))
+                await service.initialize()
+
+        assert service._graph_registry["test_graph"] == {
+            "file_path": "./graphs/test.py",
+            "export_name": "graph",
+            "description": "Graph loaded from an object entry",
+        }
+
+    @pytest.mark.asyncio
     async def test_initialize_env_var_with_real_file(self, monkeypatch):
         """Test initialization with AEGRA_CONFIG pointing to real file"""
         config_data = {"graphs": {"env_graph": "./graphs/env.py:graph"}}

--- a/libs/aegra-api/tests/unit/test_services/test_langgraph_service.py
+++ b/libs/aegra-api/tests/unit/test_services/test_langgraph_service.py
@@ -239,8 +239,11 @@ class TestLoadGraphRegistry:
             ({"description": "Missing path"}, "missing required 'path'"),
             ({"path": 42}, "field 'path' must be a string"),
             ({"path": "./agent.py:graph", "description": 42}, "field 'description' must be a string"),
+            ({"path": "./agent.py:graph", "description": None}, "field 'description' must be a string"),
             (42, "configuration must be a string or object"),
             ({"path": "./agent.py"}, "Invalid graph path format"),
+            ({"path": ":graph"}, "Invalid graph path format"),
+            ({"path": "./agent.py:"}, "Invalid graph path format"),
         ],
     )
     def test_rejects_invalid_graph_entry(self, graph_config: object, message: str) -> None:

--- a/libs/aegra-api/tests/unit/test_services/test_langgraph_service.py
+++ b/libs/aegra-api/tests/unit/test_services/test_langgraph_service.py
@@ -189,6 +189,75 @@ class TestLangGraphServiceConfig:
         assert service.get_dependencies() == []
 
 
+class TestLoadGraphRegistry:
+    """Tests for supported graph configuration forms and validation."""
+
+    def test_loads_legacy_string_entry(self) -> None:
+        service = LangGraphService()
+        service.config = {"graphs": {"agent": "./graphs/agent.py:graph"}}
+
+        service._load_graph_registry()
+
+        assert service._graph_registry["agent"] == {
+            "file_path": "./graphs/agent.py",
+            "export_name": "graph",
+        }
+
+    def test_loads_object_entry_with_description(self) -> None:
+        service = LangGraphService()
+        service.config = {
+            "graphs": {
+                "agent": {
+                    "path": "./graphs/agent.py:graph",
+                    "description": "ReAct agent with tools",
+                }
+            }
+        }
+
+        service._load_graph_registry()
+
+        assert service._graph_registry["agent"] == {
+            "file_path": "./graphs/agent.py",
+            "export_name": "graph",
+            "description": "ReAct agent with tools",
+        }
+
+    def test_loads_object_entry_without_description(self) -> None:
+        service = LangGraphService()
+        service.config = {"graphs": {"agent": {"path": "./graphs/agent.py:graph"}}}
+
+        service._load_graph_registry()
+
+        assert service._graph_registry["agent"] == {
+            "file_path": "./graphs/agent.py",
+            "export_name": "graph",
+        }
+
+    @pytest.mark.parametrize(
+        ("graph_config", "message"),
+        [
+            ({"description": "Missing path"}, "missing required 'path'"),
+            ({"path": 42}, "field 'path' must be a string"),
+            ({"path": "./agent.py:graph", "description": 42}, "field 'description' must be a string"),
+            (42, "configuration must be a string or object"),
+            ({"path": "./agent.py"}, "Invalid graph path format"),
+        ],
+    )
+    def test_rejects_invalid_graph_entry(self, graph_config: object, message: str) -> None:
+        service = LangGraphService()
+        service.config = {"graphs": {"broken": graph_config}}
+
+        with pytest.raises(ValueError, match=message):
+            service._load_graph_registry()
+
+    def test_rejects_non_object_graphs_section(self) -> None:
+        service = LangGraphService()
+        service.config = {"graphs": ["./graphs/agent.py:graph"]}
+
+        with pytest.raises(ValueError, match="field 'graphs' must be an object"):
+            service._load_graph_registry()
+
+
 class TestLangGraphServiceGraphs:
     """Test graph management"""
 


### PR DESCRIPTION
## Description

Adds LangGraph Platform-compatible object-form graph entries with a required `path` and optional `description`, while preserving the existing string format.

Graph metadata is normalized and stored in the graph registry for downstream adapters and discovery tooling. This is implemented independently from #383 to keep the change small and reviewable.

## Type of Change

- [x] `feat`: New feature
- [ ] `fix`: Bug fix
- [ ] `docs`: Documentation changes
- [ ] `style`: Code style/formatting
- [ ] `refactor`: Code refactoring
- [ ] `perf`: Performance improvement
- [ ] `test`: Tests added/updated
- [ ] `chore`: Maintenance (dependencies, build, etc.)
- [ ] `ci`: CI/CD changes

## Related Issues

Closes #593

## Changes Made

- Accept graph entries as either legacy string paths or objects containing `path` and optional `description`.
- Validate malformed graph sections, missing paths, invalid field types, and invalid import paths with clear errors.
- Store normalized graph metadata in typed registry entries.
- Update the configuration reference, API README, and root E2E configuration example.
- Keep MCP/OpenAPI adapter work outside this PR.

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] E2E tests added/updated
- [ ] Manual testing performed

Results:

- API unit and integration: 2060 passed, 1 skipped
- CLI: 192 passed
- Assistant graph E2E against a real server: 8 passed
- Ruff format and lint: passed
- Bandit: passed
- Pre-commit hooks for all changed files: passed
- Targeted ty check for the changed source file: passed

## Checklist

- [x] Code follows project style (Ruff formatting)
- [x] All linting checks pass (`make lint`)
- [ ] Type checking passes (`make type-check`)
- [x] All tests pass (`make test`)
- [x] Documentation updated (if needed)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] PR title follows Conventional Commits format

## Screenshots (if applicable)

Not applicable.

## Additional Notes

The full repository type check currently reports 57 pre-existing diagnostics, all outside the files changed by this PR. The changed source file passes `ty` independently.

Per the maintainer-approved batched-release direction in #575, this feature PR does not change package versions, `uv.lock`, or `docs/openapi.json`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Graph configurations now support object entries with a required import path and optional description.
  - Existing string-based graph configurations remain supported for compatibility.

- **Bug Fixes**
  - Improved validation for malformed graph configurations, including invalid paths, missing fields, and explicitly null descriptions.
  - Added clearer errors for incorrectly typed configuration values.

- **Documentation**
  - Updated configuration references and examples to document both supported graph entry formats and optional descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extends graph configuration parsing to accept LangGraph-compatible object entries while preserving legacy string entries.
- Normalizes graph paths and optional descriptions into typed registry metadata.
- Adds validation for malformed graph sections, entries, paths, and descriptions.
- Adds unit and integration coverage for the new representation and validation behavior.
- Updates configuration documentation and the root example.
- The previously reported null-description and empty-path issues are fixed.

<h3>Confidence Score: 4/5</h3>

The implementation appears functionally sound, but the repository’s explicit synchronized version-bump requirement must be satisfied before merging.

The two previously reported validation defects are fully fixed: explicit null descriptions are rejected, and paths with an empty file or export segment now fail during configuration parsing. The remaining issue is that this non-breaking feature was added without the required patch-version bump for both packages.

**Files Needing Attention:** libs/aegra-api/src/aegra_api/services/langgraph_service.py and the two package pyproject.toml files

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/services/langgraph_service.py | Adds typed parsing, validation, and metadata normalization for string and object graph entries; the implementation fixes both previous findings, but the feature lacks the required package version bump. |
| libs/aegra-api/tests/unit/test_services/test_langgraph_service.py | Covers both supported graph-entry forms and malformed graph, path, and description inputs, including the previous review edge cases. |
| libs/aegra-api/tests/integration/test_services/test_langgraph_service_integration.py | Verifies that object-form graph metadata is normalized into the registry during initialization. |
| docs/reference/configuration.mdx | Documents string and object graph entry forms, including the required path and optional description. |
| libs/aegra-api/README.md | Updates the API package configuration example and explains object-form graph entries. |
| aegra.json | Exercises the new object form in the repository’s root graph configuration. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Config["aegra.json graphs entry"] --> Form{Entry form}
  Form -->|String| Parse["Parse path"]
  Form -->|Object| Validate["Validate path and description"]
  Validate --> Parse
  Parse --> Segments["Validate file and export segments"]
  Segments --> Registry["Normalized graph registry entry"]
  Registry --> Loader["Graph module loader"]
```
</details>

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20aegra%2Faegra%20PR%20%23594%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=aegra%2Faegra&pr=594&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fservices%2Flanggraph_service.py%3A74-105%0A**Package%20versions%20not%20bumped**%0A%0AThis%20code%20adds%20a%20non-breaking%2C%20user-facing%20graph%20configuration%20feature%2C%20but%20neither%20package%20version%20was%20bumped.%20The%20repository%20requires%20every%20PR%20to%20bump%20both%20%60aegra-api%60%20and%20%60aegra-cli%60%2C%20using%20a%20patch%20bump%20for%20non-breaking%20features.%20This%20requirement%20must%20be%20satisfied%20before%20merging.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=aegra%2Faegra&pr=594&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fservices%2Flanggraph_service.py%3A74-105%0A**Package%20versions%20not%20bumped**%0A%0AThis%20code%20adds%20a%20non-breaking%2C%20user-facing%20graph%20configuration%20feature%2C%20but%20neither%20package%20version%20was%20bumped.%20The%20repository%20requires%20every%20PR%20to%20bump%20both%20%60aegra-api%60%20and%20%60aegra-cli%60%2C%20using%20a%20patch%20bump%20for%20non-breaking%20features.%20This%20requirement%20must%20be%20satisfied%20before%20merging.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=594&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22aegra%2Faegra%22%20on%20the%20existing%20branch%20%22feat%2Fgraph-config-metadata%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fgraph-config-metadata%22.%0A%0A%23%23%23%20Issue%201%0Alibs%2Faegra-api%2Fsrc%2Faegra_api%2Fservices%2Flanggraph_service.py%3A74-105%0A**Package%20versions%20not%20bumped**%0A%0AThis%20code%20adds%20a%20non-breaking%2C%20user-facing%20graph%20configuration%20feature%2C%20but%20neither%20package%20version%20was%20bumped.%20The%20repository%20requires%20every%20PR%20to%20bump%20both%20%60aegra-api%60%20and%20%60aegra-cli%60%2C%20using%20a%20patch%20bump%20for%20non-breaking%20features.%20This%20requirement%20must%20be%20satisfied%20before%20merging.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=aegra%2Faegra&pr=594&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix(config): tighten graph entry validat..."](https://github.com/aegra/aegra/commit/d7852b0909639a398d8b20527b589e1d2ff4e55b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62154125)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/aegra/aegra/blob/main/CLAUDE.md))

<!-- /greptile_comment -->