### PR TITLE
fix(api): plug memory leaks in dev SSE broker and event counters

### DIFF
--- a/docs/guides/streaming.mdx
+++ b/docs/guides/streaming.mdx
@@ -254,7 +254,7 @@ Aegra stores streaming events in a replay buffer (Redis Lists when `REDIS_BROKER
 2. Reconnect to `GET /threads/{thread_id}/runs/{run_id}/stream` with `Last-Event-ID` header
 3. You'll receive all events from where you left off
 
-Events are retained for 1 hour after the run completes.
+In dev mode, replay buffers for finished runs are retained in memory for 5 minutes after completion to keep memory bounded, while production Redis replay buffers use safety-net TTLs.
 
 <Note>
   In production deployments, SSE events are delivered via Redis pub/sub from workers — the client's SSE connection and the worker executing the run can be on different instances. See the [worker architecture guide](/guides/worker-architecture) for details on how this works.

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Aegra",
     "description": "Production-ready Agent Protocol server",
-    "version": "0.10.5"
+    "version": "0.10.6"
   },
   "paths": {
     "/info": {

--- a/libs/aegra-api/pyproject.toml
+++ b/libs/aegra-api/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-api"
-version = "0.10.5"
+version = "0.10.6"
 description = "Aegra core API - Self-hosted Agent Protocol server"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/libs/aegra-api/src/aegra_api/services/broker.py
+++ b/libs/aegra-api/src/aegra_api/services/broker.py
@@ -35,6 +35,7 @@ class RunBroker(BaseRunBroker):
         self._replay_buffer: list[tuple[str, Any]] = []
         self._subscribers: set[asyncio.Queue[tuple[str, Any]]] = set()
         self._created_at = asyncio.get_running_loop().time()
+        self._finished_at: float | None = None
 
     async def put(self, event_id: str, payload: Any, *, resumable: bool = True) -> None:
         if self.finished.is_set():
@@ -92,8 +93,10 @@ class RunBroker(BaseRunBroker):
         return list(self._replay_buffer)
 
     def mark_finished(self) -> None:
-        self.finished.set()
-        logger.debug(f"Broker for run {self.run_id} marked as finished")
+        if not self.finished.is_set():
+            self._finished_at = asyncio.get_running_loop().time()
+            self.finished.set()
+            logger.debug(f"Broker for run {self.run_id} marked as finished")
 
     def is_finished(self) -> bool:
         return self.finished.is_set()
@@ -103,6 +106,14 @@ class RunBroker(BaseRunBroker):
 
     def get_age(self) -> float:
         return asyncio.get_running_loop().time() - self._created_at
+
+    def get_finished_age(self) -> float | None:
+        """Return elapsed seconds since finish, or None if unfinished."""
+        if not self.finished.is_set():
+            return None
+        if self._finished_at is None:
+            return self.get_age()
+        return asyncio.get_running_loop().time() - self._finished_at
 
 
 class BrokerManager(BaseBrokerManager):
@@ -181,11 +192,14 @@ class BrokerManager(BaseBrokerManager):
         return self._event_counters.get(run_id, 0)
 
     def cleanup_finished_brokers(self, max_age_seconds: float = FINISHED_BROKER_TTL_SECONDS) -> list[str]:
-        """Remove finished and empty brokers older than max_age_seconds."""
+        """Remove finished and empty brokers older than max_age_seconds since completion."""
         to_remove = [
             run_id
             for run_id, broker in self._brokers.items()
-            if broker.is_finished() and broker.is_empty() and broker.get_age() > max_age_seconds
+            if broker.is_finished()
+            and broker.is_empty()
+            and (finished_age := broker.get_finished_age()) is not None
+            and finished_age > max_age_seconds
         ]
         for run_id in to_remove:
             self.remove_broker(run_id)

--- a/libs/aegra-api/src/aegra_api/services/broker.py
+++ b/libs/aegra-api/src/aegra_api/services/broker.py
@@ -108,6 +108,9 @@ class RunBroker(BaseRunBroker):
 class BrokerManager(BaseBrokerManager):
     """Manages multiple RunBroker instances with periodic cleanup."""
 
+    CLEANUP_INTERVAL_SECONDS: float = 60.0
+    FINISHED_BROKER_TTL_SECONDS: float = 300.0
+
     def __init__(self) -> None:
         self._brokers: dict[str, RunBroker] = {}
         self._event_counters: dict[str, int] = {}
@@ -177,19 +180,24 @@ class BrokerManager(BaseBrokerManager):
         """Return the current event sequence from the in-memory counter."""
         return self._event_counters.get(run_id, 0)
 
+    def cleanup_finished_brokers(self, max_age_seconds: float = FINISHED_BROKER_TTL_SECONDS) -> list[str]:
+        """Remove finished and empty brokers older than max_age_seconds."""
+        to_remove = [
+            run_id
+            for run_id, broker in self._brokers.items()
+            if broker.is_finished() and broker.is_empty() and broker.get_age() > max_age_seconds
+        ]
+        for run_id in to_remove:
+            self.remove_broker(run_id)
+            logger.info(f"Cleaned up old broker for run {run_id}")
+        return to_remove
+
     async def _cleanup_old_brokers(self) -> None:
-        """Remove finished brokers older than 1 hour every 5 minutes."""
+        """Periodically remove finished brokers older than retention window."""
         while True:
             try:
-                await asyncio.sleep(300)
-                to_remove = [
-                    run_id
-                    for run_id, broker in self._brokers.items()
-                    if broker.is_finished() and broker.is_empty() and broker.get_age() > 3600
-                ]
-                for run_id in to_remove:
-                    self.remove_broker(run_id)
-                    logger.info(f"Cleaned up old broker for run {run_id}")
+                await asyncio.sleep(self.CLEANUP_INTERVAL_SECONDS)
+                self.cleanup_finished_brokers(self.FINISHED_BROKER_TTL_SECONDS)
             except asyncio.CancelledError:
                 break
             except Exception:

--- a/libs/aegra-api/src/aegra_api/services/streaming_service.py
+++ b/libs/aegra-api/src/aegra_api/services/streaming_service.py
@@ -194,6 +194,7 @@ class StreamingService:
 
     async def cleanup_run(self, run_id: str) -> None:
         """Clean up streaming resources for a run."""
+        self.event_counters.pop(run_id, None)
         broker_manager.cleanup_broker(run_id)
 
     async def _convert_raw_to_sse(self, event_id: str, raw_event: Any) -> str | None:

--- a/libs/aegra-api/tests/unit/test_services/test_broker.py
+++ b/libs/aegra-api/tests/unit/test_services/test_broker.py
@@ -1,6 +1,7 @@
 """Unit tests for RunBroker and BrokerManager"""
 
 import asyncio
+from typing import Self
 
 import pytest
 
@@ -238,3 +239,60 @@ class TestBrokerManager:
         await manager.stop()
 
         assert manager._cleanup_task.cancelled() or manager._cleanup_task.done()
+
+    def test_cleanup_constants(self: Self) -> None:
+        """Test configured cleanup interval and finished TTL constants."""
+        assert BrokerManager.CLEANUP_INTERVAL_SECONDS == 60.0
+        assert BrokerManager.FINISHED_BROKER_TTL_SECONDS == 300.0
+
+    @pytest.mark.asyncio
+    async def test_cleanup_finished_brokers_removes_old_empty_broker(self: Self) -> None:
+        """Test that finished and empty brokers older than TTL are purged."""
+        manager = BrokerManager()
+        broker = manager.get_or_create_broker("run-old")
+        broker.mark_finished()
+        broker._created_at = asyncio.get_running_loop().time() - 301.0
+        manager._event_counters["run-old"] = 42
+
+        removed = manager.cleanup_finished_brokers()
+        assert removed == ["run-old"]
+        assert manager.get_broker("run-old") is None
+        assert "run-old" not in manager._event_counters
+
+    @pytest.mark.asyncio
+    async def test_cleanup_finished_brokers_retains_young_broker(self: Self) -> None:
+        """Test that finished brokers within the TTL window are kept for reconnect."""
+        manager = BrokerManager()
+        broker = manager.get_or_create_broker("run-recent")
+        broker.mark_finished()
+        broker._created_at = asyncio.get_running_loop().time() - 100.0
+
+        removed = manager.cleanup_finished_brokers()
+        assert removed == []
+        assert manager.get_broker("run-recent") is not None
+
+    @pytest.mark.asyncio
+    async def test_cleanup_finished_brokers_retains_unfinished_broker(self: Self) -> None:
+        """Test that active runs older than TTL are not purged."""
+        manager = BrokerManager()
+        broker = manager.get_or_create_broker("run-active")
+        broker._created_at = asyncio.get_running_loop().time() - 400.0
+
+        removed = manager.cleanup_finished_brokers()
+        assert removed == []
+        assert manager.get_broker("run-active") is not None
+
+    @pytest.mark.asyncio
+    async def test_cleanup_finished_brokers_retains_broker_with_subscribers(self: Self) -> None:
+        """Test that finished brokers with queued subscriber events are not purged."""
+        manager = BrokerManager()
+        broker = manager.get_or_create_broker("run-busy")
+        broker.mark_finished()
+        broker._created_at = asyncio.get_running_loop().time() - 400.0
+        sub_queue: asyncio.Queue[tuple[str, object]] = asyncio.Queue()
+        sub_queue.put_nowait(("evt-1", {"status": "ok"}))
+        broker._subscribers.add(sub_queue)
+
+        removed = manager.cleanup_finished_brokers()
+        assert removed == []
+        assert manager.get_broker("run-busy") is not None

--- a/libs/aegra-api/tests/unit/test_services/test_broker.py
+++ b/libs/aegra-api/tests/unit/test_services/test_broker.py
@@ -129,6 +129,17 @@ class TestRunBroker:
         assert got_a == got_b
         assert [eid for eid, _ in got_a] == ["evt-1", "evt-2", "evt-end"]
 
+    @pytest.mark.asyncio
+    async def test_get_finished_age(self: Self) -> None:
+        """Test finished age is None until marked finished and tracks completion time."""
+        broker = RunBroker("run-123")
+        assert broker.get_finished_age() is None
+
+        broker.mark_finished()
+        finished_age = broker.get_finished_age()
+        assert finished_age is not None
+        assert finished_age >= 0.0
+
 
 class TestBrokerManager:
     """Test BrokerManager class"""
@@ -247,11 +258,11 @@ class TestBrokerManager:
 
     @pytest.mark.asyncio
     async def test_cleanup_finished_brokers_removes_old_empty_broker(self: Self) -> None:
-        """Test that finished and empty brokers older than TTL are purged."""
+        """Test that brokers whose finish time exceeds TTL are purged."""
         manager = BrokerManager()
         broker = manager.get_or_create_broker("run-old")
         broker.mark_finished()
-        broker._created_at = asyncio.get_running_loop().time() - 301.0
+        broker._finished_at = asyncio.get_running_loop().time() - 301.0
         manager._event_counters["run-old"] = 42
 
         removed = manager.cleanup_finished_brokers()
@@ -265,11 +276,25 @@ class TestBrokerManager:
         manager = BrokerManager()
         broker = manager.get_or_create_broker("run-recent")
         broker.mark_finished()
-        broker._created_at = asyncio.get_running_loop().time() - 100.0
+        broker._finished_at = asyncio.get_running_loop().time() - 100.0
 
         removed = manager.cleanup_finished_brokers()
         assert removed == []
         assert manager.get_broker("run-recent") is not None
+
+    @pytest.mark.asyncio
+    async def test_cleanup_finished_brokers_retains_long_running_run_finished_recently(self: Self) -> None:
+        """Test that long-running runs finished recently retain their full replay TTL."""
+        manager = BrokerManager()
+        broker = manager.get_or_create_broker("run-long")
+        # Run was created 600s ago but completed only 10s ago
+        broker._created_at = asyncio.get_running_loop().time() - 600.0
+        broker.mark_finished()
+        broker._finished_at = asyncio.get_running_loop().time() - 10.0
+
+        removed = manager.cleanup_finished_brokers()
+        assert removed == []
+        assert manager.get_broker("run-long") is not None
 
     @pytest.mark.asyncio
     async def test_cleanup_finished_brokers_retains_unfinished_broker(self: Self) -> None:
@@ -288,7 +313,7 @@ class TestBrokerManager:
         manager = BrokerManager()
         broker = manager.get_or_create_broker("run-busy")
         broker.mark_finished()
-        broker._created_at = asyncio.get_running_loop().time() - 400.0
+        broker._finished_at = asyncio.get_running_loop().time() - 400.0
         sub_queue: asyncio.Queue[tuple[str, object]] = asyncio.Queue()
         sub_queue.put_nowait(("evt-1", {"status": "ok"}))
         broker._subscribers.add(sub_queue)

--- a/libs/aegra-api/tests/unit/test_services/test_streaming_service.py
+++ b/libs/aegra-api/tests/unit/test_services/test_streaming_service.py
@@ -380,10 +380,12 @@ class TestStreamingService:
 
     @pytest.mark.asyncio
     async def test_cleanup_run(self) -> None:
-        """Test run cleanup"""
+        """Test run cleanup removes event_counters and delegates to broker_manager."""
         service = StreamingService()
         run_id = "run-123"
+        service.event_counters[run_id] = 5
 
         with patch("aegra_api.services.streaming_service.broker_manager") as mock_manager:
             await service.cleanup_run(run_id)
+            assert run_id not in service.event_counters
             mock_manager.cleanup_broker.assert_called_with(run_id)

--- a/libs/aegra-cli/pyproject.toml
+++ b/libs/aegra-cli/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegra-cli"
-version = "0.10.5"
+version = "0.10.6"
 description = "Aegra CLI - Manage your self-hosted agent deployments"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
 
 [[package]]
 name = "aegra-api"
-version = "0.10.5"
+version = "0.10.6"
 source = { editable = "libs/aegra-api" }
 dependencies = [
     { name = "alembic" },
@@ -100,7 +100,7 @@ dev = [
 
 [[package]]
 name = "aegra-cli"
-version = "0.10.5"
+version = "0.10.6"
 source = { editable = "libs/aegra-cli" }
 dependencies = [
     { name = "aegra-api" },


### PR DESCRIPTION
## Description
Plugs memory leaks in dev mode (`REDIS_BROKER_ENABLED=false`) caused by unbounded retention in `StreamingService.event_counters` and long retention of finished in-memory SSE broker replay buffers.

## Type of Change
- [x] `fix`: Bug fix
- [x] `docs`: Documentation changes
- [x] `test`: Tests added/updated
- [x] `chore`: Maintenance (dependencies, build, etc.)

## Related Issues
Closes #592

## Changes Made
- **`StreamingService.cleanup_run`**: Pop `run_id` from `self.event_counters` when streaming resources are cleaned up for a run.
- **`BrokerManager`**:
  - Reduced finished broker retention window (`FINISHED_BROKER_TTL_SECONDS`) from 3600s (1 hour) to 300s (5 minutes).
  - Reduced periodic sweep interval (`CLEANUP_INTERVAL_SECONDS`) from 300s to 60s.
  - Extracted `cleanup_finished_brokers()` method for deterministic, direct cleanup execution and testing.
- **Documentation**: Updated `docs/guides/streaming.mdx` to reflect the 5-minute replay retention window for dev mode.
- **Versioning**: Synchronized patch version bump to `0.10.6` across `libs/aegra-api/pyproject.toml`, `libs/aegra-cli/pyproject.toml`, `uv.lock`, and `docs/openapi.json`.
- **Tests**:
  - Updated `test_cleanup_run` to assert `run_id` removal from `event_counters`.
  - Added unit test suite in `test_broker.py` testing cleanup constants and lifecycle filtering (age, finished status, active subscribers).

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing performed

Ran unit tests:
```bash
pytest libs/aegra-api/tests/unit/test_services/test_broker.py libs/aegra-api/tests/unit/test_services/test_streaming_service.py
# 37 passed in 0.72s
```

## Checklist
- [x] Code follows project style (Ruff formatting)
- [x] All linting checks pass (`make lint`)
- [x] Type checking passes (`make type-check`)
- [x] All tests pass (`make test`)
- [x] Documentation updated (if needed)
- [x] Commit messages follow Conventional Commits
- [x] PR title follows Conventional Commits format

## Screenshots (if applicable)
N/A

## Additional Notes
- Follows all guidelines from `CLAUDE.md`, including strict typing (`-> None`, `Self`), comment length <= 2 lines, synchronized versions, and regenerated OpenAPI spec.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Replay buffers for finished runs are now retained for five minutes after completion in development mode, preventing premature cleanup while keeping memory usage bounded.
  - Per-run event tracking is cleared when a run is cleaned up.

- **Documentation**
  - Updated streaming guidance to reflect completion-based replay-buffer retention and production safety-net expiration.

- **Chores**
  - Updated the API and package versions to 0.10.6.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bounds development-mode streaming memory usage while preserving the documented replay window.
- Removes per-run event counters during streaming cleanup.
- Retains finished in-memory brokers for five minutes from completion rather than creation.
- Adds lifecycle regression tests and updates streaming documentation.
- Synchronizes the API, CLI, lockfile, and OpenAPI versions to 0.10.6.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; the earlier replay-retention defect is fixed and no new actionable failures remain.

Broker retention is now measured from the first completion signal, preserving the full five-minute reconnection window for long-running runs, while cleanup still retains unfinished brokers and brokers with active subscriber queues. The previous thread was manually resolved without an explanatory reply, and the current implementation fully addresses its finding.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/services/broker.py | Tracks broker completion time and removes inactive finished brokers after the configured post-completion retention period. |
| libs/aegra-api/src/aegra_api/services/streaming_service.py | Removes the per-run event counter when streaming resources are cleaned up. |
| libs/aegra-api/tests/unit/test_services/test_broker.py | Adds regression coverage for completion-based retention and broker cleanup eligibility. |
| docs/guides/streaming.mdx | Documents the five-minute development-mode replay-buffer retention window. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[RunBroker created] --> B[Run streams events]
    B --> C[mark_finished records completion time]
    C --> D{Broker older than 5 minutes?}
    D -- No --> E[Retain replay buffer]
    D -- Yes --> F{Subscribers still active?}
    F -- Yes --> E
    F -- No --> G[Remove broker and event counter]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(api): base finished broker TTL on co..."](https://github.com/aegra/aegra/commit/015605f8cdce090c56d48c8e581ba88a70b05b53) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62686289)</sub>

<!-- /greptile_comment -->