### PR TITLE
fix(api): refresh Redis replay buffer TTL on worker lease heartbeat (#599)

### DIFF
--- a/docs/guides/streaming.mdx
+++ b/docs/guides/streaming.mdx
@@ -254,7 +254,7 @@ Aegra stores streaming events in a replay buffer (Redis Lists when `REDIS_BROKER
 2. Reconnect to `GET /threads/{thread_id}/runs/{run_id}/stream` with `Last-Event-ID` header
 3. You'll receive all events from where you left off
 
-Events are retained for 1 hour after the run completes.
+In production mode, the worker lease heartbeat periodically refreshes the replay buffer and sequence counter TTL throughout run execution so early events remain available even during quiet stretches (e.g. slow model generation or long tool execution). Events are retained in the replay buffer for 10 minutes after the run completes. In dev mode, in-memory brokers retain events for 5 minutes after completion.
 
 <Note>
   In production deployments, SSE events are delivered via Redis pub/sub from workers — the client's SSE connection and the worker executing the run can be on different instances. See the [worker architecture guide](/guides/worker-architecture) for details on how this works.

--- a/docs/guides/worker-architecture.mdx
+++ b/docs/guides/worker-architecture.mdx
@@ -138,7 +138,7 @@ Key details:
 
 1. **Execution params** are stored in PostgreSQL alongside the run, so any worker can reconstruct the full job context (user identity, config, trace metadata, interrupt settings, etc.).
 2. **Lease acquisition** is atomic — `UPDATE ... WHERE claimed_by IS NULL` ensures only one worker wins the race.
-3. **Heartbeats** extend the lease every 10 seconds. If a worker crashes, the lease expires and the run becomes eligible for recovery.
+3. **Heartbeats** extend the lease in PostgreSQL and refresh the Redis replay buffer and counter TTL every 10 seconds. If a worker crashes, the lease expires and the run becomes eligible for recovery; while alive, quiet runs retain their replay buffer without mid-run expiration.
 4. **OpenTelemetry trace context** propagates across the Redis queue boundary, so traces span the full request lifecycle.
 
 ### Streaming run with crash recovery
@@ -294,8 +294,8 @@ sequenceDiagram
 |:----|:--------|:-----------|:--------|
 | `aegra:jobs` | Job queue (BLPOP) | API (RPUSH) | Worker (BLPOP) |
 | `aegra:run:{run_id}` | SSE live events | Worker (PUBLISH) | API (SUBSCRIBE) |
-| `aegra:run:cache:{run_id}` | SSE replay buffer | Worker (RPUSH) | API (LRANGE) |
-| `aegra:run:counter:{run_id}` | Event sequence counter | Worker (INCR) | API (GET) |
+| `aegra:run:cache:{run_id}` | SSE replay buffer (refreshed by heartbeat while active; 10m TTL after completion) | Worker (RPUSH) | API (LRANGE) |
+| `aegra:run:counter:{run_id}` | Event sequence counter (refreshed by heartbeat while active; 10m TTL after completion) | Worker (INCR) | API (GET) |
 | `aegra:run:cancel` | Cancel commands | API (PUBLISH) | Worker (SUBSCRIBE) |
 | `aegra:run:done:{run_id}` | Completion signal (TTL 1h) | Worker (SET) | API (EXISTS) |
 

--- a/libs/aegra-api/src/aegra_api/services/base_broker.py
+++ b/libs/aegra-api/src/aegra_api/services/base_broker.py
@@ -110,3 +110,7 @@ class BaseBrokerManager(ABC):
 
         counter = await self.get_event_sequence(run_id) + 1
         return generate_event_id(run_id, counter)
+
+    @abstractmethod
+    async def refresh_replay_ttl(self, run_id: str) -> None:
+        """Refresh replay buffer retention for an active run."""

--- a/libs/aegra-api/src/aegra_api/services/broker.py
+++ b/libs/aegra-api/src/aegra_api/services/broker.py
@@ -177,6 +177,10 @@ class BrokerManager(BaseBrokerManager):
         """Return the current event sequence from the in-memory counter."""
         return self._event_counters.get(run_id, 0)
 
+    async def refresh_replay_ttl(self, run_id: str) -> None:
+        """No-op for in-memory broker; unfinished runs are never swept."""
+        return None
+
     async def _cleanup_old_brokers(self) -> None:
         """Remove finished brokers older than 1 hour every 5 minutes."""
         while True:

--- a/libs/aegra-api/src/aegra_api/services/redis_broker.py
+++ b/libs/aegra-api/src/aegra_api/services/redis_broker.py
@@ -149,6 +149,17 @@ class RedisRunBroker(BaseRunBroker):
         pipe.expire(self._counter_key, _REPLAY_TTL_SECONDS)
         await pipe.execute()
 
+    async def refresh_ttl(self, ttl_seconds: int = _REPLAY_TTL_SECONDS) -> None:
+        """Extend TTL on replay buffer and counter keys while run is alive."""
+        try:
+            client = redis_manager.get_client()
+            pipe = client.pipeline()
+            pipe.expire(self._cache_key, ttl_seconds)
+            pipe.expire(self._counter_key, ttl_seconds)
+            await pipe.execute()
+        except RedisError as e:
+            logger.warning(f"Failed refreshing replay TTL for run {self.run_id}: {e}")
+
     async def _publish_event(self, message: str) -> None:
         """Broadcast the event to live subscribers."""
         client = redis_manager.get_client()
@@ -429,6 +440,24 @@ class RedisBrokerManager(BaseBrokerManager):
             logger.warning(f"Failed to allocate event_id for run {run_id}: {e}")
             # Fallback: use timestamp-based ID (unique but not sequential)
             return generate_event_id(run_id, int(time.time() * 1000))
+
+    async def refresh_replay_ttl(self, run_id: str) -> None:
+        """Extend replay buffer and counter TTL for an active run."""
+        broker = self.get_broker(run_id)
+        if broker is not None:
+            await broker.refresh_ttl()
+            return
+
+        cache_key = f"{self._cache_prefix}{run_id}"
+        counter_key = f"{self._counter_prefix}{run_id}"
+        try:
+            client = redis_manager.get_client()
+            pipe = client.pipeline()
+            pipe.expire(cache_key, _REPLAY_TTL_SECONDS)
+            pipe.expire(counter_key, _REPLAY_TTL_SECONDS)
+            await pipe.execute()
+        except RedisError as e:
+            logger.warning(f"Failed to refresh replay TTL for run {run_id}: {e}")
 
     async def _listen_for_cancel_commands(self) -> None:
         """Background task: subscribe to cancel channel with reconnect backoff."""

--- a/libs/aegra-api/src/aegra_api/services/worker_executor.py
+++ b/libs/aegra-api/src/aegra_api/services/worker_executor.py
@@ -29,6 +29,7 @@ from aegra_api.core.redis_manager import redis_manager
 from aegra_api.models.run_job import RunJob
 from aegra_api.observability.span_enrichment import merge_run_metadata, set_trace_context
 from aegra_api.services.base_executor import BaseExecutor
+from aegra_api.services.broker import broker_manager
 from aegra_api.services.run_executor import (
     _lease_loss_cancellations,
     _shutdown_cancellations,
@@ -578,6 +579,11 @@ async def _heartbeat_loop(
             logger.debug("Lease extended", run_id=run_id, worker=worker_name)
         except Exception:
             logger.warning("Heartbeat lease extension failed", run_id=run_id, worker=worker_name)
+
+        try:
+            await broker_manager.refresh_replay_ttl(run_id)
+        except Exception:
+            logger.warning("Failed refreshing replay TTL during heartbeat", run_id=run_id)
 
 
 async def _is_run_terminal(run_id: str) -> bool:

--- a/libs/aegra-api/src/aegra_api/services/worker_executor.py
+++ b/libs/aegra-api/src/aegra_api/services/worker_executor.py
@@ -44,6 +44,7 @@ logger = structlog.getLogger(__name__)
 # Terminal run states (kept local to avoid circular import with run_waiters -> executor)
 _TERMINAL_STATUSES = frozenset({"success", "error", "interrupted"})
 _RUN_ID_PATTERN = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$")
+_HEARTBEAT_TTL_REFRESH_TIMEOUT_SECONDS = 5.0
 
 
 def _is_valid_run_id(value: str) -> bool:
@@ -581,7 +582,10 @@ async def _heartbeat_loop(
             logger.warning("Heartbeat lease extension failed", run_id=run_id, worker=worker_name)
 
         try:
-            await broker_manager.refresh_replay_ttl(run_id)
+            await asyncio.wait_for(
+                broker_manager.refresh_replay_ttl(run_id),
+                timeout=_HEARTBEAT_TTL_REFRESH_TIMEOUT_SECONDS,
+            )
         except Exception:
             logger.warning("Failed refreshing replay TTL during heartbeat", run_id=run_id)
 

--- a/libs/aegra-api/tests/unit/test_services/test_broker.py
+++ b/libs/aegra-api/tests/unit/test_services/test_broker.py
@@ -238,3 +238,10 @@ class TestBrokerManager:
         await manager.stop()
 
         assert manager._cleanup_task.cancelled() or manager._cleanup_task.done()
+
+    @pytest.mark.asyncio
+    async def test_refresh_replay_ttl_is_noop(self) -> None:
+        """Test that refresh_replay_ttl is a safe no-op on in-memory broker manager."""
+        manager = BrokerManager()
+        result = await manager.refresh_replay_ttl("run-123")
+        assert result is None

--- a/libs/aegra-api/tests/unit/test_services/test_redis_broker.py
+++ b/libs/aegra-api/tests/unit/test_services/test_redis_broker.py
@@ -562,6 +562,36 @@ class TestRedisRunBroker:
         broker = self._make_broker()
         assert not broker.is_finished()
 
+    @pytest.mark.asyncio
+    async def test_refresh_ttl_extends_cache_and_counter(self) -> None:
+        """Test that refresh_ttl extends expiration on cache and counter keys."""
+        broker = self._make_broker()
+        mock_pipe = MagicMock()
+        mock_pipe.execute = AsyncMock()
+        mock_client = MagicMock()
+        mock_client.pipeline.return_value = mock_pipe
+
+        with patch("aegra_api.services.redis_broker.redis_manager") as mock_rm:
+            mock_rm.get_client.return_value = mock_client
+            await broker.refresh_ttl(120)
+
+        mock_pipe.expire.assert_any_call("aegra:run:cache:run-123", 120)
+        mock_pipe.expire.assert_any_call("aegra:run:counter:run-123", 120)
+        mock_pipe.execute.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_refresh_ttl_handles_redis_error(self) -> None:
+        """Test that refresh_ttl logs warning and does not raise on RedisError."""
+        broker = self._make_broker()
+        mock_pipe = MagicMock()
+        mock_pipe.execute = AsyncMock(side_effect=RedisConnectionError("Redis down"))
+        mock_client = MagicMock()
+        mock_client.pipeline.return_value = mock_pipe
+
+        with patch("aegra_api.services.redis_broker.redis_manager") as mock_rm:
+            mock_rm.get_client.return_value = mock_client
+            await broker.refresh_ttl()
+
 
 class TestRedisBrokerManager:
     """Test RedisBrokerManager class"""
@@ -772,3 +802,51 @@ class TestRedisBrokerManager:
 
             await manager.stop()
             assert manager._running is False
+
+    @pytest.mark.asyncio
+    async def test_refresh_replay_ttl_delegates_to_cached_broker(self) -> None:
+        """Test that refresh_replay_ttl calls refresh_ttl on active cached broker."""
+        manager = self._make_manager()
+        mock_broker = MagicMock()
+        mock_broker.refresh_ttl = AsyncMock()
+
+        with patch.object(manager, "get_broker", return_value=mock_broker):
+            await manager.refresh_replay_ttl("run-123")
+
+        mock_broker.refresh_ttl.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_refresh_replay_ttl_refreshes_keys_directly_when_no_broker(self) -> None:
+        """Test that refresh_replay_ttl pipelines key expiration when broker is not in memory."""
+        manager = self._make_manager()
+        mock_pipe = MagicMock()
+        mock_pipe.execute = AsyncMock()
+        mock_client = MagicMock()
+        mock_client.pipeline.return_value = mock_pipe
+
+        with (
+            patch.object(manager, "get_broker", return_value=None),
+            patch("aegra_api.services.redis_broker.redis_manager") as mock_rm,
+        ):
+            mock_rm.get_client.return_value = mock_client
+            await manager.refresh_replay_ttl("run-123")
+
+        mock_pipe.expire.assert_any_call("aegra:run:cache:run-123", 600)
+        mock_pipe.expire.assert_any_call("aegra:run:counter:run-123", 600)
+        mock_pipe.execute.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_refresh_replay_ttl_handles_redis_error(self) -> None:
+        """Test that refresh_replay_ttl catches RedisError gracefully when executing pipeline."""
+        manager = self._make_manager()
+        mock_pipe = MagicMock()
+        mock_pipe.execute = AsyncMock(side_effect=RedisConnectionError("Redis down"))
+        mock_client = MagicMock()
+        mock_client.pipeline.return_value = mock_pipe
+
+        with (
+            patch.object(manager, "get_broker", return_value=None),
+            patch("aegra_api.services.redis_broker.redis_manager") as mock_rm,
+        ):
+            mock_rm.get_client.return_value = mock_client
+            await manager.refresh_replay_ttl("run-123")

--- a/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
+++ b/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
@@ -318,6 +318,40 @@ class TestHeartbeatLoop:
         assert session.execute.await_count == 1
         assert session.commit.await_count == 1
 
+    @pytest.mark.asyncio
+    async def test_heartbeat_continues_when_refresh_replay_ttl_times_out(self) -> None:
+        session = AsyncMock()
+        session.execute = AsyncMock()
+        session.commit = AsyncMock()
+        maker = _make_session_maker(session)
+
+        call_count = 0
+
+        async def counting_sleep(delay: float) -> None:
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 2:
+                raise asyncio.CancelledError
+
+        async def slow_refresh(run_id: str) -> None:
+            await asyncio.sleep(10)
+
+        with (
+            patch(f"{MODULE}._get_session_maker", return_value=maker),
+            patch(f"{MODULE}.settings") as mock_settings,
+            patch(f"{MODULE}.asyncio.sleep", side_effect=counting_sleep),
+            patch(f"{MODULE}._HEARTBEAT_TTL_REFRESH_TIMEOUT_SECONDS", 0.01),
+            patch(f"{MODULE}.broker_manager.refresh_replay_ttl", side_effect=slow_refresh),
+        ):
+            mock_settings.worker.HEARTBEAT_INTERVAL_SECONDS = 1
+            mock_settings.worker.LEASE_DURATION_SECONDS = 30
+
+            with pytest.raises(asyncio.CancelledError):
+                await _heartbeat_loop("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", "worker-0")
+
+        assert session.execute.await_count == 1
+        assert session.commit.await_count == 1
+
 
 # ------------------------------------------------------------------
 # _is_run_terminal

--- a/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
+++ b/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
@@ -255,6 +255,69 @@ class TestHeartbeatLoop:
         # Loop continued despite DB errors (2 iterations before cancel on 3rd sleep)
         assert session.execute.await_count == 2
 
+    @pytest.mark.asyncio
+    async def test_heartbeat_refreshes_replay_ttl(self) -> None:
+        session = AsyncMock()
+        session.execute = AsyncMock()
+        session.commit = AsyncMock()
+        maker = _make_session_maker(session)
+
+        call_count = 0
+
+        async def counting_sleep(delay: float) -> None:
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 2:
+                raise asyncio.CancelledError
+
+        with (
+            patch(f"{MODULE}._get_session_maker", return_value=maker),
+            patch(f"{MODULE}.settings") as mock_settings,
+            patch(f"{MODULE}.asyncio.sleep", side_effect=counting_sleep),
+            patch(f"{MODULE}.broker_manager.refresh_replay_ttl", new_callable=AsyncMock) as mock_refresh,
+        ):
+            mock_settings.worker.HEARTBEAT_INTERVAL_SECONDS = 1
+            mock_settings.worker.LEASE_DURATION_SECONDS = 30
+
+            with pytest.raises(asyncio.CancelledError):
+                await _heartbeat_loop("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", "worker-0")
+
+        mock_refresh.assert_awaited_once_with("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_continues_when_refresh_replay_ttl_fails(self) -> None:
+        session = AsyncMock()
+        session.execute = AsyncMock()
+        session.commit = AsyncMock()
+        maker = _make_session_maker(session)
+
+        call_count = 0
+
+        async def counting_sleep(delay: float) -> None:
+            nonlocal call_count
+            call_count += 1
+            if call_count >= 2:
+                raise asyncio.CancelledError
+
+        with (
+            patch(f"{MODULE}._get_session_maker", return_value=maker),
+            patch(f"{MODULE}.settings") as mock_settings,
+            patch(f"{MODULE}.asyncio.sleep", side_effect=counting_sleep),
+            patch(
+                f"{MODULE}.broker_manager.refresh_replay_ttl",
+                new_callable=AsyncMock,
+                side_effect=Exception("Redis connection lost"),
+            ),
+        ):
+            mock_settings.worker.HEARTBEAT_INTERVAL_SECONDS = 1
+            mock_settings.worker.LEASE_DURATION_SECONDS = 30
+
+            with pytest.raises(asyncio.CancelledError):
+                await _heartbeat_loop("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee", "worker-0")
+
+        assert session.execute.await_count == 1
+        assert session.commit.await_count == 1
+
 
 # ------------------------------------------------------------------
 # _is_run_terminal

--- a/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
+++ b/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
@@ -257,6 +257,7 @@ class TestHeartbeatLoop:
 
     @pytest.mark.asyncio
     async def test_heartbeat_refreshes_replay_ttl(self) -> None:
+        """Test that _heartbeat_loop refreshes broker replay TTL on each tick."""
         session = AsyncMock()
         session.execute = AsyncMock()
         session.commit = AsyncMock()
@@ -265,6 +266,7 @@ class TestHeartbeatLoop:
         call_count = 0
 
         async def counting_sleep(delay: float) -> None:
+            """Cancel after counting iterations."""
             nonlocal call_count
             call_count += 1
             if call_count >= 2:
@@ -286,6 +288,7 @@ class TestHeartbeatLoop:
 
     @pytest.mark.asyncio
     async def test_heartbeat_continues_when_refresh_replay_ttl_fails(self) -> None:
+        """Test that _heartbeat_loop continues even when TTL refresh raises."""
         session = AsyncMock()
         session.execute = AsyncMock()
         session.commit = AsyncMock()
@@ -294,6 +297,7 @@ class TestHeartbeatLoop:
         call_count = 0
 
         async def counting_sleep(delay: float) -> None:
+            """Cancel after counting iterations."""
             nonlocal call_count
             call_count += 1
             if call_count >= 2:
@@ -320,6 +324,7 @@ class TestHeartbeatLoop:
 
     @pytest.mark.asyncio
     async def test_heartbeat_continues_when_refresh_replay_ttl_times_out(self) -> None:
+        """Test that _heartbeat_loop continues when TTL refresh times out."""
         session = AsyncMock()
         session.execute = AsyncMock()
         session.commit = AsyncMock()
@@ -328,12 +333,14 @@ class TestHeartbeatLoop:
         call_count = 0
 
         async def counting_sleep(delay: float) -> None:
+            """Cancel after counting iterations."""
             nonlocal call_count
             call_count += 1
             if call_count >= 2:
                 raise asyncio.CancelledError
 
         async def slow_refresh(run_id: str) -> None:
+            """Simulate a hanging refresh operation."""
             await asyncio.sleep(10)
 
         with (


### PR DESCRIPTION
Closes #599

### Problem
In production mode (`REDIS_BROKER_ENABLED=true`), `RedisRunBroker` caches resumable events in a Redis list with a TTL (`_REPLAY_TTL_SECONDS = 600`). Previously, the TTL was only refreshed when an event was written to Redis (`_cache_event`). If a run went quiet for longer than 600 seconds (such as during a slow LLM call, long-running tool execution, or human interrupt), Redis expired the replay buffer and sequence counter mid-run. Subsequent events recreated the list, silently dropping early events from reconnecting clients.

### Solution
- Added `refresh_replay_ttl(run_id: str) -> None` to `BaseBrokerManager`.
- Implemented `refresh_ttl(ttl_seconds: int = _REPLAY_TTL_SECONDS) -> None` on `RedisRunBroker` and `refresh_replay_ttl(run_id: str) -> None` on `RedisBrokerManager` to extend TTL on active replay buffers and counters.
- Kept in-memory `BrokerManager.refresh_replay_ttl` as a safe no-op since dev-mode brokers are never swept while unfinished.
- In `_heartbeat_loop` within `worker_executor.py`, invoke `await broker_manager.refresh_replay_ttl(run_id)` on each worker lease extension tick (every 10 seconds), bounded with try/except so transient Redis failures never interrupt the worker lease heartbeat.
- Added comprehensive unit tests covering `RedisRunBroker.refresh_ttl`, `RedisBrokerManager.refresh_replay_ttl`, in-memory no-op behavior, and `_heartbeat_loop` TTL extension and error resilience.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replay data retention now refreshes during worker heartbeats, keeping active run data available through quiet periods.
  * Redis-backed runs automatically extend replay-buffer and event-counter expiration times.
  * Completed, empty run data is cleaned up after the retention window.
  * Retention refresh failures and timeouts do not interrupt heartbeat processing.

* **Documentation**
  * Updated streaming and worker architecture guidance, including retention behavior and cancelling multiple runs.

* **Tests**
  * Added coverage for retention renewal, cleanup, Redis error handling, and heartbeat continuity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->









<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR keeps Redis replay buffers and event sequence counters alive during quiet, long-running worker executions.
- Adds replay-TTL refresh operations to the broker-manager contract and Redis implementation.
- Refreshes replay TTLs alongside worker lease heartbeats without allowing Redis failures or timeouts to interrupt lease renewal.
- Documents replay retention behavior and adds regression coverage for refresh, failure, timeout, and in-memory behavior.

<h3>Confidence Score: 4/5</h3>

The behavior appears functionally safe, but the two outstanding repository-style requirements must be addressed before merging.

The replay-TTL implementation and revised timeout test do not introduce a new actionable defect. Two earlier rule-linked findings remain outstanding: the heartbeat refresh still catches broad `Exception`, and redundant self-describing docstrings remain in the broker interface and implementations. The missing-documentation finding was addressed and resolved. The timeout-test thread was manually resolved without explanation, and the current test now blocks on an `asyncio.Event`, allowing `asyncio.wait_for` to exercise the intended timeout path.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/services/worker_executor.py | Adds a bounded replay-TTL refresh to each worker heartbeat; the previously reported broad exception handler remains outstanding. |
| libs/aegra-api/src/aegra_api/services/redis_broker.py | Adds pipelined TTL renewal for cached brokers and direct Redis-key access. |
| libs/aegra-api/src/aegra_api/services/base_broker.py | Extends the broker-manager interface with replay-TTL renewal; the previously reported redundant docstring remains outstanding. |
| libs/aegra-api/src/aegra_api/services/broker.py | Implements replay-TTL renewal as an intentional no-op for the in-memory backend. |
| libs/aegra-api/tests/unit/test_services/test_worker_executor.py | Covers successful renewal, refresh failures, and genuine wait-for timeout behavior using a non-sleeping blocked coroutine. |
| docs/guides/streaming.mdx | Documents active-run TTL renewal and the replay-retention window. |

</details>

<sub>Reviews (5): Last reviewed commit: ["Merge upstream/main into fix/redis-repla..."](https://github.com/aegra/aegra/commit/8b59873c665b4dedc9417c60dd46462b14b223d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63422860)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Agent run execution](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/run-execution.md)
- Knowledge Base — [Event streaming protocol](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/event-streaming.md)
- Knowledge Base — [Persistence and distributed coordination](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/persistence-and-coordination.md)
</details>


<!-- /greptile_comment -->