### PR TITLE
fix(api): report failed runs in the join/wait body instead of {}

### DIFF
--- a/docs/guides/streaming.mdx
+++ b/docs/guides/streaming.mdx
@@ -170,6 +170,18 @@ print(result)
 
 This calls `POST /threads/{thread_id}/runs/wait` and returns the final output.
 
+If the run fails, the body is an error envelope instead of an output:
+
+```json
+{"__error__": {"error": "Error", "message": "KeyError: 'topic'"}}
+```
+
+`client.runs.wait()` raises on that envelope by default; pass `raise_error=False` to get it
+back as a dict. The same envelope is returned when the wait gives up before the run reaches a
+terminal state (`TimeoutError` or `IncompleteRun`), and by `client.runs.join()`, which returns it
+rather than raising. An interrupted run is not a failure — it returns its partial output with
+`__interrupt__`.
+
 ## Subgraph streaming
 
 If your graph uses subgraphs, you can stream events from them too:

--- a/libs/aegra-api/src/aegra_api/api/runs.py
+++ b/libs/aegra-api/src/aegra_api/api/runs.py
@@ -26,7 +26,7 @@ from aegra_api.models.errors import CONFLICT, NOT_FOUND, SSE_RESPONSE
 from aegra_api.services.broker import broker_manager
 from aegra_api.services.run_preparation import _prepare_run
 from aegra_api.services.run_status import interrupt_unowned_run
-from aegra_api.services.run_waiters import TERMINAL_STATES, encode_output, heartbeat_wait_body
+from aegra_api.services.run_waiters import TERMINAL_STATES, encode_output, heartbeat_wait_body, run_result_body
 from aegra_api.services.streaming_service import streaming_service
 from aegra_api.settings import settings
 from aegra_api.utils.status_compat import validate_run_status
@@ -320,6 +320,10 @@ async def join_run(
     If the run is already in a terminal state, the output is returned
     immediately with no heartbeat overhead.
 
+    A run that failed, or that the wait gave up on, returns
+    ``{"__error__": {"error": ..., "message": ...}}`` instead of an output;
+    the LangGraph SDK reads that key and raises.
+
     Sessions are managed manually (not via ``Depends``) to avoid holding a
     pool connection during the long wait.
     """
@@ -339,7 +343,7 @@ async def join_run(
 
         if run_orm.status in TERMINAL_STATES:
             return StreamingResponse(
-                iter([encode_output(run_orm.output or {})]),
+                iter([encode_output(run_result_body(run_orm, str(run_id)))]),
                 media_type="application/json",
             )
 
@@ -370,6 +374,10 @@ async def wait_for_run(
     heartbeat bytes to keep the connection alive. The final chunk is the
     JSON result. Uses ``BG_JOB_TIMEOUT_SECS`` (default 1 hour) as the
     safety-net timeout.
+
+    A run that failed, or that the wait gave up on, returns
+    ``{"__error__": {"error": ..., "message": ...}}`` instead of an output;
+    the LangGraph SDK reads that key and raises.
 
     Sessions are managed manually (not via ``Depends``) to avoid holding a
     pool connection during the long wait.

--- a/libs/aegra-api/src/aegra_api/services/run_waiters.py
+++ b/libs/aegra-api/src/aegra_api/services/run_waiters.py
@@ -24,13 +24,49 @@ logger = structlog.getLogger(__name__)
 # Terminal run states — used by join/wait to skip waiting
 TERMINAL_STATES = {"success", "error", "interrupted"}
 
+# The key the LangGraph SDK looks for in a wait/join body: `runs.wait()` raises
+# on it by default. Same payload shape as the SSE `error` event that
+# `streaming_service.signal_run_error` emits.
+ERROR_KEY = "__error__"
 
-async def read_run_output(
+
+def error_envelope(error: str, message: str) -> dict[str, Any]:
+    """Build the body that reports a run did not produce a result."""
+    return {ERROR_KEY: {"error": error, "message": message}}
+
+
+def run_result_body(run_orm: RunORM | None, run_id: str, *, timed_out: bool = False) -> dict[str, Any]:
+    """The join/wait response body for a run in its current state.
+
+    ``success`` and ``interrupted`` return the run's output. An interrupt is a
+    human-review pause rather than a failure, and its partial output is the
+    whole point of the call. Every other state has no output worth returning —
+    a failed run finalizes with ``{}`` — so the body says why instead.
+    """
+    if run_orm is None:
+        return error_envelope("RunNotFound", f"Run '{run_id}' no longer exists")
+    if run_orm.status == "error":
+        return error_envelope("Error", run_orm.error_message or "Run failed")
+    if run_orm.status == "timeout":
+        return error_envelope("TimeoutError", run_orm.error_message or f"Run '{run_id}' timed out")
+    if run_orm.status in TERMINAL_STATES:
+        return run_orm.output or {}
+    if timed_out:
+        return error_envelope("TimeoutError", f"Run '{run_id}' did not finish within the wait timeout")
+    return error_envelope(
+        "IncompleteRun",
+        f"Wait ended before run '{run_id}' completed (status: {run_orm.status})",
+    )
+
+
+async def read_run_result(
     run_id: str,
     thread_id: str,
     user_id: str,
+    *,
+    timed_out: bool = False,
 ) -> dict[str, Any]:
-    """Open a short-lived DB session and read the run's final output."""
+    """Open a short-lived DB session and build the run's final response body."""
     maker = _get_session_maker()
     async with maker() as session:
         run_orm = await session.scalar(
@@ -40,9 +76,7 @@ async def read_run_output(
                 RunORM.user_id == user_id,
             )
         )
-        if not run_orm:
-            return {}
-        return run_orm.output or {}
+    return run_result_body(run_orm, run_id, timed_out=timed_out)
 
 
 def encode_output(output: dict[str, Any]) -> bytes:
@@ -64,11 +98,14 @@ async def heartbeat_wait_body(
     is ignored by JSON parsers so clients parse the concatenated body normally.
     """
     done = asyncio.Event()
+    timed_out = False
 
     async def _wait_for_run() -> None:
+        nonlocal timed_out
         try:
             await executor.wait_for_completion(run_id, timeout=timeout)
         except TimeoutError:
+            timed_out = True
             logger.warning("heartbeat_wait timeout", run_id=run_id, timeout=timeout)
         except Exception:
             logger.exception("heartbeat_wait error", run_id=run_id)
@@ -98,5 +135,5 @@ async def heartbeat_wait_body(
                     exc_info=task.exception(),
                 )
 
-    output = await read_run_output(run_id, thread_id, user_id)
-    yield encode_output(output)
+    result = await read_run_result(run_id, thread_id, user_id, timed_out=timed_out)
+    yield encode_output(result)

--- a/libs/aegra-api/tests/integration/test_api/test_runs_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_runs_crud.py
@@ -783,13 +783,13 @@ class TestCreateRunValidation:
 class TestWaitForRunTimeouts:
     """Test wait_for_run timeout behavior.
 
-    wait_for_run now returns a StreamingResponse wrapping heartbeat_wait_body.
-    On timeout, the heartbeat generator reads the run's current output from DB
-    and yields it as the final JSON chunk.
+    wait_for_run returns a StreamingResponse wrapping heartbeat_wait_body.
+    On timeout the run never reached a terminal state, so the generator yields
+    an ``__error__`` envelope rather than whatever partial output is on the row.
     """
 
     def test_wait_for_run_timeout(self):
-        """Test that wait_for_run returns current state on timeout."""
+        """Test that wait_for_run reports the timeout instead of partial state."""
         app = create_test_app(include_runs=True, include_threads=False)
 
         # Mock assistant and run
@@ -853,4 +853,4 @@ class TestWaitForRunTimeouts:
 
             assert resp.status_code == 200
             # StreamingResponse: body is heartbeat newlines + final JSON
-            assert resp.json() == {"partial": "data"}
+            assert resp.json()["__error__"]["error"] == "TimeoutError"

--- a/libs/aegra-api/tests/unit/test_api/test_heartbeat_keepalive.py
+++ b/libs/aegra-api/tests/unit/test_api/test_heartbeat_keepalive.py
@@ -1,6 +1,6 @@
 """Unit tests for heartbeat keep-alive on join/wait endpoints.
 
-Tests the heartbeat_wait_body generator, read_run_output helper,
+Tests the heartbeat_wait_body generator, read_run_result helper,
 and the join_run endpoint's streaming behavior.
 """
 
@@ -15,7 +15,7 @@ import pytest
 from aegra_api.api.runs import join_run
 from aegra_api.core.orm import Run as RunORM
 from aegra_api.models import User
-from aegra_api.services.run_waiters import heartbeat_wait_body, read_run_output
+from aegra_api.services.run_waiters import heartbeat_wait_body, read_run_result
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -63,11 +63,11 @@ async def _collect_body(gen: AsyncGenerator[bytes, None]) -> tuple[list[bytes], 
 
 
 # ---------------------------------------------------------------------------
-# read_run_output
+# read_run_result
 # ---------------------------------------------------------------------------
 
 
-class TestReadRunOutput:
+class TestReadRunResult:
     @pytest.mark.asyncio
     async def test_returns_output_for_success(self) -> None:
         session = AsyncMock()
@@ -75,20 +75,21 @@ class TestReadRunOutput:
         maker = _make_session_maker(session)
 
         with patch("aegra_api.services.run_waiters._get_session_maker", return_value=maker):
-            result = await read_run_output("run-1", "thread-1", "test-user")
+            result = await read_run_result("run-1", "thread-1", "test-user")
 
         assert result == {"result": "ok"}
 
     @pytest.mark.asyncio
-    async def test_returns_empty_dict_when_run_not_found(self) -> None:
+    async def test_reports_not_found_when_the_run_row_is_gone(self) -> None:
+        """A row deleted mid-wait must not read as a run that produced nothing."""
         session = AsyncMock()
         session.scalar.return_value = None
         maker = _make_session_maker(session)
 
         with patch("aegra_api.services.run_waiters._get_session_maker", return_value=maker):
-            result = await read_run_output("run-1", "thread-1", "test-user")
+            result = await read_run_result("run-1", "thread-1", "test-user")
 
-        assert result == {}
+        assert result == {"__error__": {"error": "RunNotFound", "message": "Run 'run-1' no longer exists"}}
 
     @pytest.mark.asyncio
     async def test_returns_empty_dict_when_output_is_none(self) -> None:
@@ -97,25 +98,74 @@ class TestReadRunOutput:
         maker = _make_session_maker(session)
 
         with patch("aegra_api.services.run_waiters._get_session_maker", return_value=maker):
-            result = await read_run_output("run-1", "thread-1", "test-user")
+            result = await read_run_result("run-1", "thread-1", "test-user")
 
         assert result == {}
 
     @pytest.mark.asyncio
-    async def test_returns_error_output_as_is(self) -> None:
-        """Error run output is returned without transformation."""
+    async def test_error_run_reports_its_error_message(self) -> None:
+        """A failed run finalizes with an empty output; the reason lives on the row."""
         session = AsyncMock()
         session.scalar.return_value = _make_run_orm(
             status="error",
-            output={"error": "something broke"},
-            error_message="Graph crashed",
+            output={},
+            error_message="KeyError: 'topic'",
         )
         maker = _make_session_maker(session)
 
         with patch("aegra_api.services.run_waiters._get_session_maker", return_value=maker):
-            result = await read_run_output("run-1", "thread-1", "test-user")
+            result = await read_run_result("run-1", "thread-1", "test-user")
 
-        assert result == {"error": "something broke"}
+        assert result == {"__error__": {"error": "Error", "message": "KeyError: 'topic'"}}
+
+    @pytest.mark.asyncio
+    async def test_error_run_without_a_message_falls_back(self) -> None:
+        session = AsyncMock()
+        session.scalar.return_value = _make_run_orm(status="error", output={}, error_message=None)
+        maker = _make_session_maker(session)
+
+        with patch("aegra_api.services.run_waiters._get_session_maker", return_value=maker):
+            result = await read_run_result("run-1", "thread-1", "test-user")
+
+        assert result == {"__error__": {"error": "Error", "message": "Run failed"}}
+
+    @pytest.mark.asyncio
+    async def test_interrupted_run_keeps_its_partial_output(self) -> None:
+        """An interrupt is a human-review pause, not a failure."""
+        session = AsyncMock()
+        session.scalar.return_value = _make_run_orm(
+            status="interrupted",
+            output={"__interrupt__": [{"value": "approve?"}]},
+        )
+        maker = _make_session_maker(session)
+
+        with patch("aegra_api.services.run_waiters._get_session_maker", return_value=maker):
+            result = await read_run_result("run-1", "thread-1", "test-user")
+
+        assert result == {"__interrupt__": [{"value": "approve?"}]}
+
+    @pytest.mark.asyncio
+    async def test_non_terminal_run_reports_incomplete(self) -> None:
+        session = AsyncMock()
+        session.scalar.return_value = _make_run_orm(status="running", output={"partial": "data"})
+        maker = _make_session_maker(session)
+
+        with patch("aegra_api.services.run_waiters._get_session_maker", return_value=maker):
+            result = await read_run_result("run-1", "thread-1", "test-user")
+
+        assert result["__error__"]["error"] == "IncompleteRun"
+        assert "running" in result["__error__"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_non_terminal_run_after_a_timeout_reports_the_timeout(self) -> None:
+        session = AsyncMock()
+        session.scalar.return_value = _make_run_orm(status="running", output={"partial": "data"})
+        maker = _make_session_maker(session)
+
+        with patch("aegra_api.services.run_waiters._get_session_maker", return_value=maker):
+            result = await read_run_result("run-1", "thread-1", "test-user", timed_out=True)
+
+        assert result["__error__"]["error"] == "TimeoutError"
 
 
 # ---------------------------------------------------------------------------
@@ -186,8 +236,8 @@ class TestHeartbeatWaitBody:
         assert json.loads(full) == {"result": "final"}
 
     @pytest.mark.asyncio
-    async def test_timeout_yields_current_output(self) -> None:
-        """When wait_for_completion times out, the current run output is returned."""
+    async def test_timeout_yields_an_error_envelope(self) -> None:
+        """A wait that gave up must not look like a run that returned nothing."""
         session = AsyncMock()
         session.scalar.return_value = _make_run_orm(status="running", output={"partial": "data"})
         maker = _make_session_maker(session)
@@ -207,7 +257,7 @@ class TestHeartbeatWaitBody:
             body = heartbeat_wait_body("run-1", "thread-1", "test-user", timeout=3600)
             chunks, full = await _collect_body(body)
 
-        assert json.loads(full) == {"partial": "data"}
+        assert json.loads(full)["__error__"]["error"] == "TimeoutError"
 
     @pytest.mark.asyncio
     async def test_leading_whitespace_ignored_by_json_parser(self) -> None:
@@ -301,7 +351,7 @@ class TestJoinRunEndpoint:
         session.scalar.return_value = run_orm
         user = User(identity="test-user", scopes=[])
 
-        # For read_run_output called inside the generator
+        # For read_run_result called inside the generator
         fetch_session = AsyncMock()
         fetch_session.scalar.return_value = _make_run_orm(status="success", output={"done": True})
 
@@ -337,9 +387,9 @@ class TestJoinRunEndpoint:
         assert "Location" in response.headers
 
     @pytest.mark.asyncio
-    async def test_error_run_returns_immediately(self) -> None:
-        """Error-state run returns immediately (it's terminal)."""
-        run_orm = _make_run_orm(status="error", output={"err": "failed"})
+    async def test_error_run_returns_an_envelope_immediately(self) -> None:
+        """The fast path reports a failure the same way the waiting path does."""
+        run_orm = _make_run_orm(status="error", output={}, error_message="Graph crashed")
         session = AsyncMock()
         session.scalar.return_value = run_orm
         maker = _make_session_maker(session)
@@ -351,4 +401,4 @@ class TestJoinRunEndpoint:
         body = b""
         async for chunk in response.body_iterator:
             body += chunk if isinstance(chunk, bytes) else chunk.encode()
-        assert json.loads(body) == {"err": "failed"}
+        assert json.loads(body) == {"__error__": {"error": "Error", "message": "Graph crashed"}}

--- a/libs/aegra-api/tests/unit/test_api/test_runs_wait.py
+++ b/libs/aegra-api/tests/unit/test_api/test_runs_wait.py
@@ -120,7 +120,7 @@ class TestWaitForRunExceptionPaths:
 
     @pytest.mark.asyncio
     async def test_wait_for_run_timeout(self) -> None:
-        """Test that TimeoutError is handled gracefully and returns current state."""
+        """A wait that timed out reports it instead of passing off partial state."""
         thread_id = "test-thread-123"
         run_id = str(uuid4())
         user = User(identity="test-user", scopes=[])
@@ -162,7 +162,7 @@ class TestWaitForRunExceptionPaths:
             response = await wait_for_run(thread_id, request, user)
             result = await _consume_streaming_response(response)
 
-        assert result == {"partial": "output"}
+        assert result["__error__"]["error"] == "TimeoutError"
 
     @pytest.mark.asyncio
     async def test_wait_for_run_success(self) -> None:
@@ -207,7 +207,7 @@ class TestWaitForRunExceptionPaths:
 
     @pytest.mark.asyncio
     async def test_wait_for_run_failed_status(self) -> None:
-        """Test that failed runs return their output as-is."""
+        """A failed run reports its error message, not the empty output it stored."""
         thread_id = "test-thread-123"
         run_id = str(uuid4())
         user = User(identity="test-user", scopes=[])
@@ -222,7 +222,7 @@ class TestWaitForRunExceptionPaths:
             run_id,
             thread_id,
             status="error",
-            output={"error": "execution failed"},
+            output={},
             error_message="Graph execution error",
         )
 
@@ -250,7 +250,7 @@ class TestWaitForRunExceptionPaths:
             response = await wait_for_run(thread_id, request, user)
             result = await _consume_streaming_response(response)
 
-        assert result == {"error": "execution failed"}
+        assert result == {"__error__": {"error": "Error", "message": "Graph execution error"}}
 
     @pytest.mark.asyncio
     async def test_wait_for_run_interrupted_status(self) -> None:


### PR DESCRIPTION
## Problem

A run that fails finalizes with `output={}` and its reason in `error_message` (`run_executor.py`). Neither `POST /threads/{thread_id}/runs/wait` nor `GET /threads/{thread_id}/runs/{run_id}/join` carries `error_message`, so both answer a failed run with `{}` — byte-for-byte what a run that produced no output returns.

Because the wait endpoint streams, the 200 is committed before the run finishes, so there is no status code left to signal with either. The result is a silent failure: `client.runs.wait()` returns normally and the caller gets nothing back, with no way to tell a crash from an empty result.

The same `{}` comes back when the wait gives up before the run reaches a terminal state, and when the run row disappears mid-wait.

## Why `__error__`

The LangGraph SDK already expects this and Aegra already speaks it:

- `langgraph_sdk`'s `runs.wait()` inspects the response for `__error__` and raises on it — `raise_error=True` is the default. Today that check never fires against Aegra.
- Aegra's own SSE path emits exactly this payload: `streaming_service.signal_run_error` puts `{"error": error_type, "message": error_message}` on the broker. Join/wait were the one path that dropped it.

So this is the response-side counterpart of the API-compatibility rule in `CLAUDE.md`: a client that moves from LangSmith Deployments to Aegra loses error reporting on `runs.wait()` without any signal that it did.

## Change

`run_waiters.run_result_body` classifies the run row and builds the body:

| state | body |
| --- | --- |
| `success` | output (unchanged) |
| `interrupted` | output (unchanged) |
| `error` | `{"__error__": {"error": "Error", "message": <error_message>}}` |
| `timeout` | `{"__error__": {"error": "TimeoutError", ...}}` |
| non-terminal after the wait gave up | `{"__error__": {"error": "TimeoutError" \| "IncompleteRun", ...}}` |
| row gone | `{"__error__": {"error": "RunNotFound", ...}}` |

An interrupt is a human-review pause, not a failure — it keeps returning its partial output and `__interrupt__`, which is the whole point of that call.

`heartbeat_wait_body` now tracks whether `wait_for_completion` raised `TimeoutError`, so a real timeout and an early return are reported distinctly instead of both landing as "not finished".

`join_run`'s already-terminal fast path goes through the same function, so join answers identically whether or not it had to wait. `POST /runs/wait` delegates to `wait_for_run` and inherits the fix.

Nothing else changes: same 200, same heartbeats, same headers, and every pre-execution error still raises before the response starts.

## Disclosure

`error_message` holds `str(exc)`, and `GET /threads/{thread_id}/runs/{run_id}` already returns it to the same authenticated owner via the `Run` model. No new detail is exposed — only a new place to read it.

Worth flagging for review: the SSE path deliberately sends a sanitized `f"{type(exc).__name__}: execution failed"` while persisting the raw `str(exc)`. If you'd rather join/wait match SSE's sanitized message, say so and I'll switch it.

## Out of scope

`run_waiters.TERMINAL_STATES` omits `"timeout"`, while `event_streaming/session.py` treats it as terminal. That makes `join_run` take the waiting path for a run already marked `timeout`. This PR reports such a run correctly but leaves the waiting behaviour alone — the inconsistency is about *when to wait*, not *what to report*, and is worth its own change.

## Tests

- `test_heartbeat_keepalive.py`: `read_run_result` over every state, plus the join fast path.
- `test_runs_wait.py` / `test_runs_crud.py`: the two tests that pinned the old `{}`-shaped behaviour now pin the envelope.
- `make lint` / `ruff format --check` clean; `ty` adds no diagnostics in the changed files.
- Full unit + integration suite passes locally except `test_assistant_large_config_db.py`, which needs a live Postgres.

This has been running in production against 0.10.4 as an out-of-tree shadow of the wait route; this is the in-tree version, without the wrapper machinery that shadowing required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Standardized run failure responses with an `__error__` envelope.
  - Wait and join operations now clearly report failed, timed-out, incomplete, missing, and interrupted runs.
  - Timeouts return a `TimeoutError` response instead of partial output.
  - Successful runs continue to return their results, while interrupted runs can include partial output.

- **Documentation**
  - Added guidance on error responses, timeout behavior, opt-out error handling, and interrupted runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR changes run wait and join responses so failed, timed-out, incomplete, or missing runs return LangGraph-compatible `__error__` envelopes instead of appearing to have completed with an empty result.
- Centralizes result classification in `run_result_body`.
- Applies the same classification to join’s terminal fast path and heartbeat-based waits.
- Distinguishes LocalExecutor timeouts that are returned rather than raised.
- Preserves successful and interrupted outputs.
- Documents the client-visible behavior and adds regression coverage.

<h3>Confidence Score: 4/5</h3>

The behavioral fix appears sound, but the unresolved repository requirement limiting comments and docstrings to two lines must be satisfied before merging.

The previously reported timeout misclassification was manually resolved and the current elapsed-time handling correctly covers LocalExecutor’s suppressed timeout while preserving terminal results. The prior comment-length finding remains outstanding: the long `run_result_body`, `join_run`, and `wait_for_run` explanations are still present, and the new module-level explanation also exceeds the repository’s normal two-line limit.

**Files Needing Attention:** libs/aegra-api/src/aegra_api/services/run_waiters.py, libs/aegra-api/src/aegra_api/api/runs.py

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/services/run_waiters.py | Centralizes run-result classification and detects LocalExecutor waits that consume their timeout without propagating an exception; the existing comment-length rule violation remains. |
| libs/aegra-api/src/aegra_api/api/runs.py | Routes terminal join responses through the shared result classifier and documents wait/join error-envelope behavior. |
| libs/aegra-api/tests/unit/test_api/test_heartbeat_keepalive.py | Adds coverage for each result state, propagated and swallowed timeouts, and join’s terminal fast path. |
| docs/guides/streaming.mdx | Documents failure envelopes, timeout behavior, SDK error handling, join behavior, and interrupted results. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Client[LangGraph SDK client] --> Route[Wait or join route]
    Route --> Waiter[Wait for completion]
    Waiter --> Read[Read persisted run]
    Read --> Classify{Run state}
    Classify -->|success or interrupted| Output[Return run output]
    Classify -->|error| Error[Return Error envelope]
    Classify -->|timeout or wait exhausted| Timeout[Return TimeoutError envelope]
    Classify -->|non-terminal early return| Incomplete[Return IncompleteRun envelope]
    Classify -->|row missing| Missing[Return RunNotFound envelope]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(api): report a swallowed wait timeou..."](https://github.com/aegra/aegra/commit/26edea0d4d8ed14a7f721b3a057176a3f6a4e83b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63626392)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Aegra API platform](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/api-platform.md)
- Knowledge Base — [HTTP API contracts](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/api-contracts.md)
- Knowledge Base — [Agent run execution](https://app.greptile.com/aegra/-/custom-context/knowledge-base/aegra/aegra/-/docs/run-execution.md)
</details>


<!-- /greptile_comment -->