### PR TITLE
fix(api): make PATCH /assistants a partial update

### DIFF
--- a/docs/guides/assistants.mdx
+++ b/docs/guides/assistants.mdx
@@ -100,6 +100,18 @@ assistant = await client.assistants.update(
 )
 ```
 
+Updates are partial: a field you leave out keeps the value it already has, and
+`metadata` is merged into the assistant's existing metadata rather than
+replacing it. To clear a field, send it explicitly empty:
+
+```python
+# Drop the config, and the context that mirrors config["configurable"]
+assistant = await client.assistants.update(
+    assistant_id="your-assistant-id",
+    config={},
+)
+```
+
 ## Versioning
 
 Assistants are versioned. Each update creates a new version while preserving the history:

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3693,7 +3693,7 @@
               }
             ],
             "title": "Name",
-            "description": "The name of the assistant (auto-generated if not provided)"
+            "description": "The name of the assistant. Unchanged when omitted."
           },
           "description": {
             "anyOf": [
@@ -3705,7 +3705,7 @@
               }
             ],
             "title": "Description",
-            "description": "The description of the assistant. Defaults to null."
+            "description": "The description of the assistant. Unchanged when omitted."
           },
           "config": {
             "anyOf": [
@@ -3718,13 +3718,19 @@
               }
             ],
             "title": "Config",
-            "description": "Configuration to use for the graph."
+            "description": "Configuration to use for the graph. Unchanged when omitted."
           },
           "graph_id": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Graph Id",
-            "description": "The ID of the graph",
-            "default": "agent"
+            "description": "The ID of the graph. Unchanged when omitted."
           },
           "context": {
             "anyOf": [
@@ -3737,7 +3743,7 @@
               }
             ],
             "title": "Context",
-            "description": "The context to use for the graph. Useful when graph is configurable."
+            "description": "The context to use for the graph. Useful when graph is configurable. Unchanged when omitted."
           },
           "metadata": {
             "anyOf": [
@@ -3750,12 +3756,12 @@
               }
             ],
             "title": "Metadata",
-            "description": "Metadata to use for searching and filtering assistants."
+            "description": "Metadata to merge into the assistant's existing metadata."
           }
         },
         "type": "object",
         "title": "AssistantUpdate",
-        "description": "Request model for creating assistants"
+        "description": "Request model for partially updating assistants.\n\nEvery field is optional and defaults to ``None`` so that an omitted field\nis distinguishable from an explicit one via ``model_dump(exclude_unset=True)``:\nomitting ``config`` keeps the stored config, sending ``{\"config\": {}}`` clears it."
       },
       "Body_set_assistant_latest_assistants__assistant_id__latest_post": {
         "properties": {

--- a/libs/aegra-api/src/aegra_api/models/assistants.py
+++ b/libs/aegra-api/src/aegra_api/models/assistants.py
@@ -47,18 +47,25 @@ class Assistant(BaseModel):
 
 
 class AssistantUpdate(BaseModel):
-    """Request model for creating assistants"""
+    """Request model for partially updating assistants.
 
-    name: str | None = Field(None, description="The name of the assistant (auto-generated if not provided)")
-    description: str | None = Field(None, description="The description of the assistant. Defaults to null.")
-    config: dict[str, Any] | None = Field(default_factory=dict, description="Configuration to use for the graph.")
-    graph_id: str = Field("agent", description="The ID of the graph")
+    Every field is optional and defaults to ``None`` so that an omitted field
+    is distinguishable from an explicit one via ``model_dump(exclude_unset=True)``:
+    omitting ``config`` keeps the stored config, sending ``{"config": {}}`` clears it.
+    """
+
+    name: str | None = Field(None, description="The name of the assistant. Unchanged when omitted.")
+    description: str | None = Field(None, description="The description of the assistant. Unchanged when omitted.")
+    config: dict[str, Any] | None = Field(
+        None, description="Configuration to use for the graph. Unchanged when omitted."
+    )
+    graph_id: str | None = Field(None, description="The ID of the graph. Unchanged when omitted.")
     context: dict[str, Any] | None = Field(
-        default_factory=dict,
-        description="The context to use for the graph. Useful when graph is configurable.",
+        None,
+        description="The context to use for the graph. Useful when graph is configurable. Unchanged when omitted.",
     )
     metadata: dict[str, Any] | None = Field(
-        default_factory=dict, description="Metadata to use for searching and filtering assistants."
+        None, description="Metadata to merge into the assistant's existing metadata."
     )
 
 

--- a/libs/aegra-api/src/aegra_api/services/assistant_service.py
+++ b/libs/aegra-api/src/aegra_api/services/assistant_service.py
@@ -390,26 +390,25 @@ class AssistantService(Authenticated):
         return to_pydantic(await self._read_owned_assistant(assistant_id))
 
     async def update_assistant(self, assistant_id: str, request: AssistantUpdate) -> Assistant:
-        """Update assistant by ID"""
-        value = {**request.model_dump(), "assistant_id": assistant_id}
+        """Partially update an assistant.
+
+        Fields the caller omitted keep their stored value; supplied ``metadata``
+        is merged into the stored metadata, matching the LangGraph SDK contract.
+        Omission is read from ``exclude_unset`` rather than from ``None``, so a
+        caller can still clear a field by sending it empty (``{"config": {}}``).
+        """
+        supplied = request.model_dump(exclude_unset=True)
+        # Handlers inject by mutating value["metadata"] in place, so the dispatch
+        # payload keeps the dict shape the auth API documents even when unset.
+        value = {
+            **request.model_dump(),
+            "config": request.config or {},
+            "context": request.context or {},
+            "metadata": request.metadata or {},
+            "assistant_id": assistant_id,
+        }
         filters = await self._dispatch("update", value)
         request.metadata = _injected_metadata(request.metadata, value)
-
-        metadata = request.metadata or {}
-        config = request.config or {}
-        context = request.context or {}
-
-        if config.get("configurable") and context:
-            raise HTTPException(
-                status_code=400,
-                detail="Cannot specify both configurable and context. Use only one.",
-            )
-
-        # Keep config and context up to date with one another
-        if config.get("configurable"):
-            context = config["configurable"]
-        elif context:
-            config["configurable"] = context
 
         stmt = select(AssistantORM).where(
             AssistantORM.assistant_id == assistant_id,
@@ -421,6 +420,30 @@ class AssistantService(Authenticated):
         assistant = await self.session.scalar(stmt)
         if not assistant:
             raise HTTPException(404, f"Assistant '{assistant_id}' not found")
+
+        config = (supplied["config"] or {}) if "config" in supplied else (assistant.config or {})
+        context = (supplied["context"] or {}) if "context" in supplied else (assistant.context or {})
+
+        if "config" in supplied and "context" in supplied and config.get("configurable") and context:
+            raise HTTPException(
+                status_code=400,
+                detail="Cannot specify both configurable and context. Use only one.",
+            )
+
+        metadata = {**(assistant.metadata_dict or {}), **(request.metadata or {})}
+
+        # Keep config and context up to date with one another. context mirrors
+        # config["configurable"], so whichever one the caller supplied wins and the
+        # other is derived from it; when neither was supplied both come from the
+        # stored row and are already consistent.
+        if "context" in supplied:
+            config = {**config, "configurable": context}
+        elif "config" in supplied:
+            context = config.get("configurable") or {}
+        elif config.get("configurable"):
+            context = config["configurable"]
+        elif context:
+            config = {**config, "configurable": context}
 
         now = datetime.now(UTC)
         version_stmt = select(func.max(AssistantVersionORM.version)).where(

--- a/libs/aegra-api/tests/integration/test_services/test_assistant_service_db.py
+++ b/libs/aegra-api/tests/integration/test_services/test_assistant_service_db.py
@@ -4,6 +4,7 @@ These tests verify service interactions with real database operations.
 """
 
 from datetime import UTC, datetime
+from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
@@ -153,10 +154,13 @@ class TestAssistantServiceDatabase:
             graph_id="test-graph",
         )
         original_assistant = await assistant_service.create_assistant(create_request)
+        # The update resolves omitted fields against the stored row through ORM
+        # attributes (metadata_dict), so that row has to be ORM-shaped.
+        stored_row = SimpleNamespace(**original_assistant.model_dump(by_alias=True))
 
         # Mock scalar calls: first returns assistant, second returns max version, third returns updated assistant
         assistant_service.session.scalar.side_effect = [
-            original_assistant,
+            stored_row,
             1,
             original_assistant,
         ]  # max version = 1

--- a/libs/aegra-api/tests/unit/test_models/test_assistant_update_sdk_drift.py
+++ b/libs/aegra-api/tests/unit/test_models/test_assistant_update_sdk_drift.py
@@ -1,0 +1,74 @@
+"""Pin AssistantUpdate to what ``langgraph_sdk`` actually PATCHes.
+
+The SDK builds a sparse body: a rename sends ``{"name": ...}`` and nothing
+else, and documents metadata as merged rather than replaced. Driving the real
+client here means an SDK that starts sending a field (or stops omitting one)
+fails this test instead of silently changing what the server writes.
+"""
+
+from typing import Any
+
+import pytest
+from langgraph_sdk.client import AssistantsClient
+
+from aegra_api.models.assistants import AssistantUpdate
+
+
+class RecordingHttp:
+    """Stands in for the SDK's HttpClient, capturing the request body."""
+
+    def __init__(self) -> None:
+        self.path: str | None = None
+        self.payload: dict[str, Any] | None = None
+
+    async def patch(self, path: str, *, json: dict[str, Any], **_: Any) -> dict[str, Any]:
+        self.path = path
+        self.payload = json
+        return {}
+
+
+@pytest.fixture
+def http() -> RecordingHttp:
+    return RecordingHttp()
+
+
+@pytest.fixture
+def assistants(http: RecordingHttp) -> AssistantsClient:
+    return AssistantsClient(http)
+
+
+async def test_sdk_rename_sends_only_the_name(http: RecordingHttp, assistants: AssistantsClient) -> None:
+    await assistants.update("asst-1", name="Renamed")
+
+    assert http.path == "/assistants/asst-1"
+    assert http.payload == {"name": "Renamed"}
+
+
+async def test_sdk_rename_leaves_every_other_field_unset(http: RecordingHttp, assistants: AssistantsClient) -> None:
+    """The server must not be able to tell a rename apart from a rename plus
+    'and reset everything else', which is what a defaulted field would mean."""
+    await assistants.update("asst-1", name="Renamed")
+
+    request = AssistantUpdate.model_validate(http.payload)
+
+    assert request.model_dump(exclude_unset=True) == {"name": "Renamed"}
+    assert request.graph_id is None
+    assert request.config is None
+    assert request.context is None
+    assert request.metadata is None
+
+
+async def test_every_sdk_field_is_declared_on_the_model(http: RecordingHttp, assistants: AssistantsClient) -> None:
+    await assistants.update(
+        "asst-1",
+        graph_id="other-graph",
+        config={"recursion_limit": 7},
+        context={"model_name": "anthropic"},
+        metadata={"number": 2},
+        name="Renamed",
+        description="Described",
+    )
+
+    assert http.payload is not None
+    assert set(http.payload) <= set(AssistantUpdate.model_fields)
+    assert AssistantUpdate.model_validate(http.payload).model_dump(exclude_unset=True) == http.payload

--- a/libs/aegra-api/tests/unit/test_models/test_assistants_defaults.py
+++ b/libs/aegra-api/tests/unit/test_models/test_assistants_defaults.py
@@ -1,9 +1,15 @@
-"""Regression: AssistantCreate / AssistantUpdate must not share mutable default dicts.
+"""Regression: AssistantCreate must not share mutable default dicts, and
+AssistantUpdate must leave every field unset by default.
 
 Pydantic v2 currently deep-copies on assignment so the historical
-`Field({})` shape hasn't bitten us, but the pattern is brittle. These tests
-pin the safe `default_factory=dict` behavior so a future revert can't sneak
-shared state across instances.
+`Field({})` shape hasn't bitten us on create, but the pattern is brittle. These
+tests pin the safe `default_factory=dict` behavior so a future revert can't
+sneak shared state across instances.
+
+AssistantUpdate is a patch document, where a default is not merely brittle but
+wrong: a defaulted `graph_id` or `config` is written to the row as though the
+caller had asked for it. Its fields default to None and must stay out of
+`model_dump(exclude_unset=True)`, which is what the service resolves against.
 """
 
 from aegra_api.models.assistants import AssistantCreate, AssistantUpdate
@@ -12,22 +18,6 @@ from aegra_api.models.assistants import AssistantCreate, AssistantUpdate
 def test_assistant_create_defaults_do_not_share_state() -> None:
     a = AssistantCreate(graph_id="agent")
     b = AssistantCreate(graph_id="agent")
-    assert a.config is not None
-    assert a.context is not None
-    assert a.metadata is not None
-
-    a.config["x"] = 1
-    a.context["y"] = 2
-    a.metadata["z"] = 3
-
-    assert b.config == {}
-    assert b.context == {}
-    assert b.metadata == {}
-
-
-def test_assistant_update_defaults_do_not_share_state() -> None:
-    a = AssistantUpdate()
-    b = AssistantUpdate()
     assert a.config is not None
     assert a.context is not None
     assert a.metadata is not None
@@ -50,10 +40,25 @@ def test_assistant_create_defaults_are_distinct_instances() -> None:
     assert a.metadata is not b.metadata
 
 
-def test_assistant_update_defaults_are_distinct_instances() -> None:
-    a = AssistantUpdate()
-    b = AssistantUpdate()
+def test_assistant_update_defaults_every_field_to_none() -> None:
+    request = AssistantUpdate()
 
-    assert a.config is not b.config
-    assert a.context is not b.context
-    assert a.metadata is not b.metadata
+    assert request.name is None
+    assert request.description is None
+    assert request.graph_id is None
+    assert request.config is None
+    assert request.context is None
+    assert request.metadata is None
+
+
+def test_assistant_update_omits_unsent_fields() -> None:
+    request = AssistantUpdate.model_validate({"name": "Renamed"})
+
+    assert request.model_dump(exclude_unset=True) == {"name": "Renamed"}
+
+
+def test_assistant_update_keeps_explicit_empties() -> None:
+    """An empty dict is a request to clear, not the absence of a request."""
+    request = AssistantUpdate.model_validate({"config": {}, "context": {}, "metadata": {}})
+
+    assert request.model_dump(exclude_unset=True) == {"config": {}, "context": {}, "metadata": {}}

--- a/libs/aegra-api/tests/unit/test_services/test_assistant_service.py
+++ b/libs/aegra-api/tests/unit/test_services/test_assistant_service.py
@@ -715,6 +715,151 @@ class TestAssistantServiceUpdate:
         assert "Cannot specify both configurable and context" in str(exc_info.value.detail)
 
 
+class TestAssistantServicePartialUpdate:
+    """PATCH /assistants/{id} is a partial update: a field the caller left out
+    keeps its stored value, and supplied metadata merges into what is stored,
+    which is the contract langgraph_sdk's assistants.update documents."""
+
+    @staticmethod
+    def stored_row() -> Mock:
+        """A row whose every field differs from the request payloads below."""
+        row = Mock()
+        row.assistant_id = "asst-1"
+        row.name = "Stored Assistant"
+        row.description = "Stored description"
+        row.user_id = "user-123"
+        row.graph_id = "stored-graph"
+        row.version = 1
+        row.created_at = datetime.now(UTC)
+        row.updated_at = datetime.now(UTC)
+        row.config = {"configurable": {"model": "stored"}, "recursion_limit": 7}
+        row.context = {"model": "stored"}
+        row.metadata_dict = {"owner": "team-a"}
+        return row
+
+    @staticmethod
+    async def send_patch(service: AssistantService, payload: dict[str, Any], row: Mock) -> tuple[Any, dict[str, Any]]:
+        """PATCH ``payload`` over ``row``; return its version row and UPDATE values.
+
+        The payload goes through ``model_validate`` rather than the constructor
+        so that omitted fields are genuinely unset, as they are over HTTP.
+        """
+        service.session.scalar.side_effect = [row, 1, row]
+        service.session.execute = AsyncMock()
+        service.session.commit = AsyncMock()
+
+        await service.update_assistant(row.assistant_id, AssistantUpdate.model_validate(payload))
+
+        version_row = service.session.add.call_args.args[0]
+        executed_stmt = service.session.execute.call_args.args[0]
+        values = {
+            getattr(column, "name", None): getattr(value, "value", value)
+            for column, value in executed_stmt._values.items()
+        }
+        return version_row, values
+
+    @pytest.mark.asyncio
+    async def test_rename_keeps_every_omitted_field(self, assistant_service: AssistantService) -> None:
+        """What the SDK sends for client.assistants.update(id, name=...)."""
+        row = self.stored_row()
+
+        _, values = await self.send_patch(assistant_service, {"name": "Renamed"}, row)
+
+        assert values["name"] == "Renamed"
+        assert values["description"] == "Stored description"
+        assert values["graph_id"] == "stored-graph"
+        assert values["config"] == {"configurable": {"model": "stored"}, "recursion_limit": 7}
+        assert values["context"] == {"model": "stored"}
+        assert values["metadata"] == {"owner": "team-a"}
+
+    @pytest.mark.asyncio
+    async def test_version_row_records_the_merged_result(self, assistant_service: AssistantService) -> None:
+        """The version history has to be replayable: it stores the assistant as
+        it now is, not the sparse payload that produced it."""
+        row = self.stored_row()
+
+        version_row, _ = await self.send_patch(assistant_service, {"name": "Renamed"}, row)
+
+        assert version_row.name == "Renamed"
+        assert version_row.graph_id == "stored-graph"
+        assert version_row.config == {"configurable": {"model": "stored"}, "recursion_limit": 7}
+        assert version_row.context == {"model": "stored"}
+        assert version_row.metadata_dict == {"owner": "team-a"}
+
+    @pytest.mark.asyncio
+    async def test_supplied_metadata_merges_into_stored_metadata(self, assistant_service: AssistantService) -> None:
+        row = self.stored_row()
+
+        _, values = await self.send_patch(assistant_service, {"metadata": {"env": "prod"}}, row)
+
+        assert values["metadata"] == {"owner": "team-a", "env": "prod"}
+
+    @pytest.mark.asyncio
+    async def test_supplied_metadata_overwrites_only_the_keys_it_names(
+        self, assistant_service: AssistantService
+    ) -> None:
+        row = self.stored_row()
+        row.metadata_dict = {"owner": "team-a", "env": "staging"}
+
+        _, values = await self.send_patch(assistant_service, {"metadata": {"env": "prod"}}, row)
+
+        assert values["metadata"] == {"owner": "team-a", "env": "prod"}
+
+    @pytest.mark.asyncio
+    async def test_handler_injected_metadata_merges_too(self, assistant_service: AssistantService) -> None:
+        """An @auth.on handler injects by mutating value["metadata"] in place,
+        which must land on top of the stored metadata like a caller's would."""
+        row = self.stored_row()
+
+        async def inject(_ctx: Any, value: dict[str, Any]) -> None:
+            value["metadata"]["updated_by"] = "user-123"
+
+        with patch(_DISPATCH, new=AsyncMock(side_effect=inject)):
+            _, values = await self.send_patch(assistant_service, {"name": "Renamed"}, row)
+
+        assert values["metadata"] == {"owner": "team-a", "updated_by": "user-123"}
+
+    @pytest.mark.asyncio
+    async def test_empty_config_clears_config(self, assistant_service: AssistantService) -> None:
+        """An explicitly empty dict is a request to clear, which is the
+        distinction a defaulted field cannot express."""
+        row = self.stored_row()
+
+        _, values = await self.send_patch(assistant_service, {"config": {}}, row)
+
+        assert values["config"] == {}
+        assert values["context"] == {}
+
+    @pytest.mark.asyncio
+    async def test_supplied_context_updates_the_config_mirror(self, assistant_service: AssistantService) -> None:
+        row = self.stored_row()
+
+        _, values = await self.send_patch(assistant_service, {"context": {"model": "sonnet"}}, row)
+
+        assert values["context"] == {"model": "sonnet"}
+        assert values["config"] == {"configurable": {"model": "sonnet"}, "recursion_limit": 7}
+
+    @pytest.mark.asyncio
+    async def test_supplied_configurable_updates_the_context_mirror(self, assistant_service: AssistantService) -> None:
+        row = self.stored_row()
+
+        _, values = await self.send_patch(assistant_service, {"config": {"configurable": {"model": "sonnet"}}}, row)
+
+        assert values["context"] == {"model": "sonnet"}
+        assert values["config"] == {"configurable": {"model": "sonnet"}}
+
+    @pytest.mark.asyncio
+    async def test_graph_id_survives_a_config_only_update(self, assistant_service: AssistantService) -> None:
+        """The pre-fix default repointed the assistant at a graph called "agent"
+        on any request that did not name one."""
+        row = self.stored_row()
+
+        version_row, values = await self.send_patch(assistant_service, {"config": {"recursion_limit": 1}}, row)
+
+        assert values["graph_id"] == "stored-graph"
+        assert version_row.graph_id == "stored-graph"
+
+
 class TestAssistantServiceDelete:
     """Test assistant deletion business logic"""
 


### PR DESCRIPTION
## What breaks today

The route documents itself as *"Partial update: only fields included in the request body are changed"*, but an omitted field is currently written as though the caller had asked to reset it.

`AssistantUpdate` gives four fields a non-`None` default:

```python
config: dict[str, Any] | None = Field(default_factory=dict, ...)
graph_id: str = Field("agent", description="The ID of the graph")
context: dict[str, Any] | None = Field(default_factory=dict, ...)
metadata: dict[str, Any] | None = Field(default_factory=dict, ...)
```

and `AssistantService.update_assistant` writes all of them unconditionally. `"agent"` is truthy, so the `request.graph_id or assistant.graph_id` fallback never fires; `config`, `context` and `metadata` are read off the request and land on the row as empty dicts.

`name` and `description` are the exceptions: they default to `None` and are guarded with `or assistant.name`, which is the shape the other four wanted.

So `PATCH {"name": "Renamed"}` — a rename — repoints the assistant at a graph called `agent`, which on most deployments does not exist, so every later run on that assistant fails to resolve its graph; clears config, context and metadata; and writes all of that into a new `assistant_versions` row, so the loss is versioned as though it were intended and `set_latest` on the previous version is the only way back.

This is the payload the first-party SDK sends. `langgraph_sdk`'s `AssistantsClient.update` builds a sparse body — `if graph_id:`, `if config is not None:`, `if name:` — so `await client.assistants.update(id, name="Renamed")` puts `{"name": "Renamed"}` on the wire and nothing else. Its docstring is explicit about both halves of the contract: *"If `None`, assistant will keep pointing to same graph"*, and metadata is *"Metadata to merge with existing assistant metadata"*. Aegra replaces metadata rather than merging it even when it is supplied.

We hit this on a deployment we run: a rename through the SDK silently detached live assistants from their graphs. We have been working around it downstream by shadowing the route with a request model that re-defaults `graph_id` to `""` so the service's `or` falls through, and by requiring every client that sends `metadata` to send the whole document with it. Both workarounds belong in the server.

This also lands under the compatibility rule added in #575: *"Follow the public LangGraph Platform names and defaults for config keys, env vars and enum values."*

## Reproduction

Against a server whose graph is **not** named `agent` (say `chatbot` in `aegra.json`):

```bash
ID=$(curl -sX POST localhost:8000/assistants \
  -H 'content-type: application/json' \
  -d '{"graph_id":"chatbot","name":"Support","config":{"configurable":{"model":"gpt-4o"}},"metadata":{"owner":"team-a"}}' \
  | jq -r .assistant_id)

curl -sX PATCH localhost:8000/assistants/$ID \
  -H 'content-type: application/json' -d '{"name":"Renamed"}' | jq
```

Before this change:

```json
{
  "name": "Renamed",
  "graph_id": "agent",
  "config": {},
  "context": {},
  "metadata": {},
  "version": 2
}
```

After:

```json
{
  "name": "Renamed",
  "graph_id": "chatbot",
  "config": { "configurable": { "model": "gpt-4o" } },
  "context": { "model": "gpt-4o" },
  "metadata": { "owner": "team-a" },
  "version": 2
}
```

The same thing through the SDK is `await client.assistants.update(id, name="Renamed")`.

## What changed

`AssistantUpdate` now defaults every field to `None`, and `update_assistant` resolves each one against the stored row using `model_dump(exclude_unset=True)` rather than a `None` check. That keeps the distinction the old model could not express: an **omitted** field is left alone, while an **explicitly empty** one still clears — `{"config": {}}` empties the config.

- `graph_id`, `config`, `context`: omitted means unchanged.
- `metadata`: supplied keys are merged onto the stored metadata, per the SDK contract. Metadata injected by an `@auth.on` handler is folded into `request.metadata` before this point, so it merges the same way rather than replacing what is stored.
- `config` and `context` stay mirrors of one another (`context` is `config["configurable"]`). Whichever one the caller supplied wins and the other is derived from it; when neither is supplied both come from the stored row, which is already consistent. Sending both with conflicting values still 400s, but only when both were actually sent — a `config` update no longer collides with a stored `context`.
- The new `assistant_versions` row records the merged result, so version history stays replayable.
- Resolving against the stored row means the row is now loaded before the `configurable`/`context` conflict check, so a conflicting payload aimed at an assistant that does not exist returns 404 rather than 400.
- `name` and `description` are untouched by this PR; they already preserved.

The dispatch `value` handed to `@auth.on` handlers keeps `config`, `context` and `metadata` as dicts even when the caller omitted them, so handlers that inject by mutating `value["metadata"]` in place — the documented pattern — do not have to learn about `None`.

## Compatibility

Callers that already send complete state are unaffected: a full payload sets every field either way. The change is visible only to callers that omit fields, which today are the ones losing data.

Two things worth calling out for anyone who adapted to the current behaviour:

1. **Metadata is merged, not replaced.** A caller that removed a metadata key by PATCHing the document without it will no longer remove it. That matches LangGraph Platform and the SDK's documented contract, but it is a real change of meaning for an existing request.
2. **Clearing is now explicit.** `{"config": {}}` clears config (and the `context` mirror); omitting `config` no longer does. Anything relying on omission to reset a field needs to send the empty value.

No migration is needed. Rows already damaged by the old behaviour are not repaired by this change; they can be recovered by pinning the last good version with `POST /assistants/{assistant_id}/latest` (`client.assistants.set_latest`).

## Verification

- `AssistantUpdate` unit tests pin that a validated `{"name": ...}` body leaves every other field unset and that `{}` stays distinguishable from omission.
- New service tests cover: a rename preserving `graph_id`, `config`, `context` and `metadata`; the version row recording the merged result; supplied metadata merging (and overwriting only the keys it names); handler-injected metadata merging onto stored metadata; `{"config": {}}` clearing; and the `config`/`context` mirror in both directions.
- A drift test drives the real `langgraph_sdk` `AssistantsClient` against a recording transport, asserting that a rename sends only `{"name": ...}` and that every field the SDK can send is declared on the model. An SDK that starts sending a new field, or stops omitting one, fails CI here.
- `make format`, `make lint`, and the aegra-api unit and integration suites pass (2088 tests). `docs/openapi.json` is regenerated; `graph_id` on `AssistantUpdate` is now nullable with no `"agent"` default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Assistant updates now support partial changes; omitted fields retain existing values.
  * Metadata merges with existing metadata rather than replacing it.
  * Explicitly empty configuration or context clears those values.
  * Explicit null descriptions clear the description; empty descriptions are preserved.
  * Empty name or graph ID values return a 422 error.
  * Graph selection is preserved when omitted.

* **Documentation**
  * Updated API documentation to explain partial-update behavior, field clearing, and metadata merging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes assistant PATCH requests preserve omitted fields while retaining explicit clearing semantics.
- Defaults all `AssistantUpdate` fields to `None` so omitted fields remain distinguishable through `exclude_unset`.
- Resolves sparse updates against stored assistant state and records the merged result in version history.
- Merges supplied or authorization-injected metadata with existing metadata.
- Keeps `config` and `context` synchronized and validates empty non-null fields.
- Adds SDK contract, model, service, and database regression coverage.
- Updates the assistant guide and generated OpenAPI schema.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no outstanding correctness or security findings.

Sparse updates now preserve stored assistant state, explicit empty values retain their documented meaning, metadata is merged, and version rows capture the resolved result. The previous comment-length thread was manually resolved without explanation.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| libs/aegra-api/src/aegra_api/models/assistants.py | Makes every assistant update field optional so sparse PATCH payloads preserve omitted state. |
| libs/aegra-api/src/aegra_api/services/assistant_service.py | Resolves supplied fields against stored values, merges metadata, synchronizes config and context, and versions the resulting state. |
| libs/aegra-api/tests/unit/test_services/test_assistant_service.py | Adds regression coverage for sparse updates, metadata merging, clearing behavior, mirror synchronization, and validation. |
| libs/aegra-api/tests/unit/test_models/test_assistant_update_sdk_drift.py | Pins the request model to the sparse payload contract exposed by the LangGraph SDK. |
| docs/guides/assistants.mdx | Documents partial-update, clearing, metadata merge, and nullable-field behavior. |

</details>

<sub>Reviews (3): Last reviewed commit: ["style(api): bring the update\_assistant c..."](https://github.com/aegra/aegra/commit/51121bb0f9847f7c59a5a83b3d329b110df17693) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63531039)</sub>

<!-- /greptile_comment -->