### PR TITLE
fix(api): merge thread metadata in one statement so concurrent writes cannot clobber each other

### DIFF
--- a/libs/aegra-api/src/aegra_api/api/threads.py
+++ b/libs/aegra-api/src/aegra_api/api/threads.py
@@ -10,7 +10,7 @@ from uuid import uuid4
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -44,6 +44,7 @@ from aegra_api.models.search_limit import effective_search_limit
 from aegra_api.services.streaming_service import streaming_service
 from aegra_api.services.thread_state_service import ThreadStateService
 from aegra_api.services.thread_ttl import get_thread_ttl_config, prune_expired_threads_for_user
+from aegra_api.utils.jsonb import jsonb_patch, jsonb_shallow_merge
 from aegra_api.utils.run_utils import strip_pinned_config_keys
 
 router = APIRouter(tags=["Threads"], dependencies=auth_dependency)
@@ -355,18 +356,27 @@ async def update_thread(
         if isinstance(handler_meta, dict):
             request.metadata = {**(request.metadata or {}), **handler_meta}
 
+    # This read is the 404 probe and the ownership check; the merge below does
+    # not read the column into Python, so it cannot lose a concurrent writer's
+    # keys no matter how long this request takes.
     stmt = select(ThreadORM).where(ThreadORM.thread_id == thread_id, ThreadORM.user_id == user.identity)
     thread = await session.scalar(stmt)
 
     if not thread:
         raise HTTPException(404, f"Thread '{thread_id}' not found")
 
-    thread.updated_at = datetime.now(UTC)
-
+    values: dict[str, Any] = {"updated_at": datetime.now(UTC)}
     if request.metadata:
-        current_metadata = dict(thread.metadata_json or {})
-        current_metadata.update(request.metadata)
-        thread.metadata_json = current_metadata
+        values["metadata_json"] = jsonb_shallow_merge(
+            ThreadORM.metadata_json, jsonb_patch(request.metadata, "metadata_patch")
+        )
+
+    await session.execute(
+        update(ThreadORM)
+        .where(ThreadORM.thread_id == thread_id, ThreadORM.user_id == user.identity)
+        .values(**values)
+        .execution_options(synchronize_session=False)
+    )
 
     await session.commit()
     await session.refresh(thread)

--- a/libs/aegra-api/src/aegra_api/services/run_preparation.py
+++ b/libs/aegra-api/src/aegra_api/services/run_preparation.py
@@ -12,7 +12,7 @@ from uuid import uuid4
 import structlog
 from asgi_correlation_id import correlation_id
 from fastapi import HTTPException
-from sqlalchemy import or_, select, update
+from sqlalchemy import ColumnElement, case, func, literal_column, or_, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from aegra_api.core.orm import Assistant as AssistantORM
@@ -25,6 +25,7 @@ from aegra_api.services.executor import executor
 from aegra_api.services.langgraph_service import get_langgraph_service
 from aegra_api.services.run_status import set_thread_status
 from aegra_api.utils.assistants import resolve_assistant_id
+from aegra_api.utils.jsonb import jsonb_patch, jsonb_shallow_merge
 from aegra_api.utils.run_utils import _merge_jsonb
 
 logger = structlog.getLogger(__name__)
@@ -138,14 +139,16 @@ async def update_thread_metadata(
     user_id: str | None = None,
     input_data: dict[str, Any] | None = None,
 ) -> None:
-    """Update thread metadata with assistant and graph information (dialect agnostic).
+    """Update thread metadata with assistant and graph information.
 
     If thread doesn't exist, auto-creates it.
     When *input_data* is provided and the thread has no name yet, the first
     human message content is used as ``thread_name``.
     Does NOT commit — the caller controls the transaction boundary.
     """
-    # Read-modify-write to avoid DB-specific JSON concat operators
+    # This read decides whether to auto-create; the update below merges in the
+    # database, so a PATCH /threads/{id} racing this run cannot drop the keys
+    # written here (or have its own dropped).
     thread = await session.scalar(select(ThreadORM).where(ThreadORM.thread_id == thread_id))
 
     thread_name = _extract_thread_name(input_data or {})
@@ -171,18 +174,30 @@ async def update_thread_metadata(
         session.add(thread_orm)
         return
 
-    md = dict(getattr(thread, "metadata_json", {}) or {})
-    md.update(
-        {
-            "assistant_id": str(assistant_id),
-            "graph_id": graph_id,
-        }
-    )
-    # Only set thread_name if empty and we have a name from the input
-    if thread_name and not md.get("thread_name"):
-        md["thread_name"] = thread_name
+    patches: list[ColumnElement[Any]] = [
+        jsonb_patch({"assistant_id": str(assistant_id), "graph_id": graph_id}, "metadata_patch")
+    ]
+    if thread_name:
+        # Only name a thread that has no name yet. The condition is evaluated at
+        # write time against the row the UPDATE locks, not against the read above.
+        patches.append(
+            case(
+                (
+                    func.coalesce(ThreadORM.metadata_json["thread_name"].astext, "") == "",
+                    jsonb_patch({"thread_name": thread_name}, "thread_name_patch"),
+                ),
+                else_=literal_column("'{}'::jsonb"),
+            )
+        )
+
     await session.execute(
-        update(ThreadORM).where(ThreadORM.thread_id == thread_id).values(metadata_json=md, updated_at=datetime.now(UTC))
+        update(ThreadORM)
+        .where(ThreadORM.thread_id == thread_id)
+        .values(
+            metadata_json=jsonb_shallow_merge(ThreadORM.metadata_json, *patches),
+            updated_at=datetime.now(UTC),
+        )
+        .execution_options(synchronize_session=False)
     )
 
 

--- a/libs/aegra-api/src/aegra_api/utils/jsonb.py
+++ b/libs/aegra-api/src/aegra_api/utils/jsonb.py
@@ -1,0 +1,41 @@
+"""SQL helpers for merging into JSONB columns."""
+
+from typing import Any
+
+from sqlalchemy import BindParameter, ColumnElement, bindparam, case, func, literal_column
+from sqlalchemy.orm import InstrumentedAttribute
+
+from aegra_api.core.orm import JsonbSafe
+
+
+def jsonb_patch(patch: dict[str, Any], name: str) -> BindParameter[Any]:
+    """Bind *patch* as a JSONB parameter.
+
+    ``JsonbSafe`` strips NUL bytes, which Postgres rejects in ``jsonb``; binding
+    a patch any other way would fail writes that the columns themselves accept.
+
+    *name* must be unique within the statement the parameter is used in.
+    """
+    return bindparam(name, value=patch, type_=JsonbSafe)
+
+
+def jsonb_shallow_merge(column: InstrumentedAttribute[Any], *patches: ColumnElement[Any]) -> ColumnElement[Any]:
+    """Merge *patches* into a JSONB *column*, top level only, inside the database.
+
+    Renders ``CASE WHEN jsonb_typeof(col) = 'object' THEN col ELSE '{}'::jsonb
+    END || :patch``. Postgres reads and writes the column in one statement, so
+    the row lock the ``UPDATE`` takes serializes concurrent writers instead of
+    letting them overwrite each other's keys. Later *patches* win over earlier
+    ones, as successive ``dict.update`` calls do.
+
+    The type guard matters because ``'[1,2]'::jsonb || '{"a":1}'::jsonb`` appends
+    to an array instead of merging: a column holding a non-object (or SQL NULL)
+    starts from ``{}``, which is what ``dict(value or {})`` meant in Python.
+    """
+    merged: ColumnElement[Any] = case(
+        (func.jsonb_typeof(column) == "object", column),
+        else_=literal_column("'{}'::jsonb"),
+    )
+    for patch in patches:
+        merged = merged.op("||", return_type=JsonbSafe)(patch)
+    return merged

--- a/libs/aegra-api/tests/fixtures/database.py
+++ b/libs/aegra-api/tests/fixtures/database.py
@@ -5,7 +5,7 @@ from datetime import UTC, datetime
 from types import SimpleNamespace
 from typing import Any
 
-from sqlalchemy import DateTime, Insert, inspect
+from sqlalchemy import DateTime, Insert, Update, inspect
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.exc import NoInspectionAvailable
 
@@ -98,3 +98,20 @@ def override_get_session_dep(
         yield session_factory()
 
     return _dep
+
+
+def apply_thread_metadata_merge(stmt: Update, row: Any) -> None:
+    """Apply a thread UPDATE to *row* the way Postgres would.
+
+    ``PATCH /threads/{id}`` merges metadata in SQL (``metadata_json ||
+    :metadata_patch``) so that concurrent writers cannot overwrite each other,
+    which leaves a session mock standing in for the database: bound scalars are
+    assigned and the bound patch is merged over the row's existing metadata,
+    as ``jsonb || jsonb`` does at the top level.
+    """
+    params = stmt.compile(dialect=postgresql.dialect()).params
+    patch = params.get("metadata_patch")
+    if patch is not None:
+        row.metadata_json = {**(getattr(row, "metadata_json", None) or {}), **patch}
+    if "updated_at" in params:
+        row.updated_at = params["updated_at"]

--- a/libs/aegra-api/tests/integration/test_api/test_threads_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_threads_crud.py
@@ -18,6 +18,7 @@ from tests.fixtures.clients import create_test_app, make_client
 from tests.fixtures.database import (
     DummyScalarResult,
     DummySessionBase,
+    apply_thread_metadata_merge,
     override_get_session_dep,
 )
 from tests.fixtures.session_fixtures import BasicSession, ThreadSession, override_session_dependency
@@ -1194,11 +1195,14 @@ class TestUpdateThread:
             async def scalar(self, _stmt):
                 return thread
 
+            async def execute(self, stmt, *args, **kwargs):
+                # The merge happens in the database; stand in for it.
+                apply_thread_metadata_merge(stmt, thread)
+
             async def commit(self):
                 pass
 
             async def refresh(self, obj):
-                # In a real DB, refresh updates the object; here we just simulate it
                 pass
 
         app.dependency_overrides[core_get_session] = override_get_session_dep(Session)
@@ -1230,6 +1234,9 @@ class TestUpdateThread:
         class Session(DummySessionBase):
             async def scalar(self, _stmt):
                 return thread
+
+            async def execute(self, stmt, *args, **kwargs):
+                apply_thread_metadata_merge(stmt, thread)
 
             async def commit(self):
                 pass
@@ -1271,6 +1278,9 @@ class TestUpdateThread:
         class Session(DummySessionBase):
             async def scalar(self, _stmt):
                 return thread
+
+            async def execute(self, stmt, *args, **kwargs):
+                apply_thread_metadata_merge(stmt, thread)
 
             async def commit(self):
                 pass

--- a/libs/aegra-api/tests/integration/test_thread_metadata_merge_db.py
+++ b/libs/aegra-api/tests/integration/test_thread_metadata_merge_db.py
@@ -1,0 +1,246 @@
+"""Thread metadata merge tests that need a real PostgreSQL.
+
+The interesting property is what two *concurrent* transactions do to the same
+``thread.metadata_json`` row, which no session fake can show: these tests drive
+the real handlers on separate sessions and interleave their reads and commits
+the way two HTTP requests do. They skip when no database is reachable.
+"""
+
+import asyncio
+from collections.abc import AsyncIterator, Callable
+from typing import Any
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import delete, select, text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from aegra_api.api.threads import update_thread
+from aegra_api.core.orm import Thread as ThreadORM
+from aegra_api.models import ThreadUpdate, User
+from aegra_api.services.run_preparation import update_thread_metadata
+from aegra_api.settings import settings
+
+_USER_ID = "thread-metadata-merge-test-user"
+_WAIT_TIMEOUT = 10.0
+
+SessionFactory = Callable[[], AsyncSession]
+
+
+def _user() -> User:
+    return User(identity=_USER_ID)
+
+
+class PausedBeforeWrite:
+    """Session proxy that holds a request between its read and its write.
+
+    Concurrent writers interleave like this: both read the row, then both write
+    it. Every write entry point is gated, not just one, so the pause lands in
+    the same place whether the handler writes through a statement or through
+    the flush its commit triggers. Everything else goes to the real session.
+    """
+
+    def __init__(self, session: AsyncSession, read_done: asyncio.Event, resume: asyncio.Event) -> None:
+        self._session = session
+        self._read_done = read_done
+        self._resume = resume
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._session, name)
+
+    async def scalar(self, *args: Any, **kwargs: Any) -> Any:
+        result = await self._session.scalar(*args, **kwargs)
+        self._read_done.set()
+        return result
+
+    async def execute(self, *args: Any, **kwargs: Any) -> Any:
+        await self._resume.wait()
+        return await self._session.execute(*args, **kwargs)
+
+    async def flush(self, *args: Any, **kwargs: Any) -> Any:
+        await self._resume.wait()
+        return await self._session.flush(*args, **kwargs)
+
+    async def commit(self) -> None:
+        await self._resume.wait()
+        await self._session.commit()
+
+
+@pytest.fixture
+async def sessions() -> AsyncIterator[SessionFactory]:
+    """Hand out sessions on independent connections, or skip without a database."""
+    engine = create_async_engine(settings.db.database_url)
+    try:
+        try:
+            async with engine.begin() as conn:
+                thread_table = await conn.scalar(text("SELECT to_regclass('public.thread')"))
+        except Exception as exc:  # noqa: BLE001 - any connect failure means "no database here"
+            pytest.skip(f"PostgreSQL test database is unavailable: {exc}")
+
+        if thread_table is None:
+            pytest.skip("thread table is unavailable; run Alembic migrations before this DB test")
+
+        maker = async_sessionmaker(engine, expire_on_commit=False)
+        try:
+            yield maker
+        finally:
+            async with maker() as cleanup:
+                await cleanup.execute(delete(ThreadORM).where(ThreadORM.user_id == _USER_ID))
+                await cleanup.commit()
+    finally:
+        await engine.dispose()
+
+
+async def _create_thread(sessions: SessionFactory, metadata: dict[str, Any]) -> str:
+    thread_id = f"metadata-merge-{uuid4()}"
+    async with sessions() as session:
+        session.add(ThreadORM(thread_id=thread_id, status="idle", metadata_json=metadata, user_id=_USER_ID))
+        await session.commit()
+    return thread_id
+
+
+async def _read_metadata(sessions: SessionFactory, thread_id: str) -> Any:
+    async with sessions() as session:
+        return await session.scalar(select(ThreadORM.metadata_json).where(ThreadORM.thread_id == thread_id))
+
+
+@pytest.mark.asyncio
+async def test_concurrent_patches_keep_both_sets_of_keys(sessions: SessionFactory) -> None:
+    """Two PATCHes that read the same row must not discard each other's keys."""
+    thread_id = await _create_thread(sessions, {"graph_id": "agent"})
+    read_done = asyncio.Event()
+    resume = asyncio.Event()
+
+    async with sessions() as slow, sessions() as fast:
+        slow_patch = asyncio.create_task(
+            update_thread(
+                thread_id,
+                ThreadUpdate(metadata={"from_slow": "one"}),
+                user=_user(),
+                session=PausedBeforeWrite(slow, read_done, resume),
+            )
+        )
+        # The slow request has read the row; the fast one now writes and commits
+        # underneath it, so the slow request's write is based on a stale read.
+        await asyncio.wait_for(read_done.wait(), timeout=_WAIT_TIMEOUT)
+        await update_thread(thread_id, ThreadUpdate(metadata={"from_fast": "two"}), user=_user(), session=fast)
+        resume.set()
+        await asyncio.wait_for(slow_patch, timeout=_WAIT_TIMEOUT)
+
+    metadata = await _read_metadata(sessions, thread_id)
+    assert metadata["from_slow"] == "one"
+    assert metadata["from_fast"] == "two"
+    assert metadata["graph_id"] == "agent"
+
+
+@pytest.mark.asyncio
+async def test_patch_racing_a_starting_run_keeps_graph_id(sessions: SessionFactory) -> None:
+    """A PATCH landing on a starting run must not drop the run's own keys.
+
+    Losing ``graph_id`` is not cosmetic: POST /threads/{id}/state refuses a
+    thread whose metadata has none.
+    """
+    thread_id = await _create_thread(sessions, {"owner": _USER_ID})
+    read_done = asyncio.Event()
+    resume = asyncio.Event()
+
+    async with sessions() as run, sessions() as client:
+        # Run preparation writes assistant_id/graph_id but does not commit —
+        # the caller owns the transaction, and it stays open for the rest of
+        # run creation.
+        await update_thread_metadata(run, thread_id, assistant_id="asst-1", graph_id="agent", user_id=_USER_ID)
+
+        client_patch = asyncio.create_task(
+            update_thread(
+                thread_id,
+                ThreadUpdate(metadata={"client_key": "keep me"}),
+                user=_user(),
+                session=PausedBeforeWrite(client, read_done, resume),
+            )
+        )
+        await asyncio.wait_for(read_done.wait(), timeout=_WAIT_TIMEOUT)
+        resume.set()
+        # Let the PATCH reach the row lock the run is holding before releasing it.
+        await asyncio.sleep(0.1)
+        await run.commit()
+        await asyncio.wait_for(client_patch, timeout=_WAIT_TIMEOUT)
+
+    metadata = await _read_metadata(sessions, thread_id)
+    assert metadata["client_key"] == "keep me"
+    assert metadata["graph_id"] == "agent"
+    assert metadata["assistant_id"] == "asst-1"
+
+
+@pytest.mark.asyncio
+async def test_patch_merge_is_shallow(sessions: SessionFactory) -> None:
+    """A supplied key replaces that key wholesale; nested objects are not merged."""
+    thread_id = await _create_thread(sessions, {"nested": {"a": 1}, "keep": True})
+
+    async with sessions() as session:
+        await update_thread(thread_id, ThreadUpdate(metadata={"nested": {"b": 2}}), user=_user(), session=session)
+
+    metadata = await _read_metadata(sessions, thread_id)
+    assert metadata == {"nested": {"b": 2}, "keep": True}
+
+
+@pytest.mark.asyncio
+async def test_patch_metadata_containing_a_null_byte_is_written(sessions: SessionFactory) -> None:
+    """Postgres rejects NUL in jsonb, so the patch binds through JsonbSafe."""
+    thread_id = await _create_thread(sessions, {})
+
+    async with sessions() as session:
+        await update_thread(thread_id, ThreadUpdate(metadata={"note": "be\x00fore"}), user=_user(), session=session)
+
+    metadata = await _read_metadata(sessions, thread_id)
+    assert metadata["note"] == "before"
+
+
+@pytest.mark.asyncio
+async def test_patch_replaces_metadata_that_is_not_an_object(sessions: SessionFactory) -> None:
+    """``'[1,2]'::jsonb || '{"a":1}'::jsonb`` appends instead of merging."""
+    thread_id = await _create_thread(sessions, {})
+    async with sessions() as session:
+        await session.execute(
+            text("UPDATE thread SET metadata_json = '[1, 2]'::jsonb WHERE thread_id = :thread_id"),
+            {"thread_id": thread_id},
+        )
+        await session.commit()
+
+    async with sessions() as session:
+        await update_thread(thread_id, ThreadUpdate(metadata={"a": 1}), user=_user(), session=session)
+
+    metadata = await _read_metadata(sessions, thread_id)
+    assert metadata == {"a": 1}
+
+
+@pytest.mark.asyncio
+async def test_run_preparation_names_only_an_unnamed_thread(sessions: SessionFactory) -> None:
+    """thread_name is derived from the first run's input and then left alone."""
+    thread_id = await _create_thread(sessions, {"thread_name": ""})
+
+    async with sessions() as session:
+        await update_thread_metadata(
+            session,
+            thread_id,
+            assistant_id="asst-1",
+            graph_id="agent",
+            input_data={"messages": [{"role": "human", "content": "First question"}]},
+        )
+        await session.commit()
+
+    assert (await _read_metadata(sessions, thread_id))["thread_name"] == "First question"
+
+    async with sessions() as session:
+        await update_thread_metadata(
+            session,
+            thread_id,
+            assistant_id="asst-2",
+            graph_id="other",
+            input_data={"messages": [{"role": "human", "content": "Second question"}]},
+        )
+        await session.commit()
+
+    metadata = await _read_metadata(sessions, thread_id)
+    assert metadata["thread_name"] == "First question"
+    assert metadata["assistant_id"] == "asst-2"
+    assert metadata["graph_id"] == "other"

--- a/libs/aegra-api/tests/unit/test_utils/test_jsonb.py
+++ b/libs/aegra-api/tests/unit/test_utils/test_jsonb.py
@@ -1,0 +1,56 @@
+"""Unit tests for the JSONB merge SQL helpers.
+
+The merge exists so that Postgres, not Python, reads the column being written:
+these tests pin the rendered statement and the bind type. What the statement
+then does under concurrency is covered by
+``tests/integration/test_thread_metadata_merge_db.py``, which needs a database.
+"""
+
+from sqlalchemy import update
+from sqlalchemy.dialects import postgresql
+
+from aegra_api.core.orm import Thread as ThreadORM
+from aegra_api.utils.jsonb import jsonb_patch, jsonb_shallow_merge
+
+
+def _compile(expression) -> str:
+    return str(
+        update(ThreadORM)
+        .where(ThreadORM.thread_id == "t")
+        .values(metadata_json=expression)
+        .compile(dialect=postgresql.dialect())
+    )
+
+
+class TestJsonbPatch:
+    def test_binds_under_the_given_name(self) -> None:
+        param = jsonb_patch({"a": 1}, "metadata_patch")
+        assert param.key == "metadata_patch"
+        assert param.value == {"a": 1}
+
+    def test_bind_strips_null_bytes(self) -> None:
+        """Postgres rejects U+0000 in jsonb; the patch binds through JsonbSafe."""
+        param = jsonb_patch({"note": "be\x00fore"}, "metadata_patch")
+        assert param.type.process_bind_param(param.value, postgresql.dialect()) == {"note": "before"}
+
+
+class TestJsonbShallowMerge:
+    def test_merges_in_sql_rather_than_in_python(self) -> None:
+        sql = _compile(jsonb_shallow_merge(ThreadORM.metadata_json, jsonb_patch({"a": 1}, "metadata_patch")))
+        assert "THEN thread.metadata_json ELSE '{}'::jsonb END || %(metadata_patch)s::JSONB" in sql
+
+    def test_non_object_metadata_starts_from_an_empty_object(self) -> None:
+        """``'[1,2]'::jsonb || '{"a":1}'::jsonb`` appends instead of merging."""
+        sql = _compile(jsonb_shallow_merge(ThreadORM.metadata_json, jsonb_patch({"a": 1}, "metadata_patch")))
+        assert "CASE WHEN (jsonb_typeof(thread.metadata_json) = %(jsonb_typeof_1)s)" in sql
+        assert "ELSE '{}'::jsonb END" in sql
+
+    def test_later_patches_are_applied_last(self) -> None:
+        sql = _compile(
+            jsonb_shallow_merge(
+                ThreadORM.metadata_json,
+                jsonb_patch({"a": 1}, "first_patch"),
+                jsonb_patch({"a": 2}, "second_patch"),
+            )
+        )
+        assert sql.index("%(first_patch)s") < sql.index("%(second_patch)s")


### PR DESCRIPTION
`PATCH /threads/{thread_id}` merges metadata by reading the column into Python, updating the dict and writing the whole document back:

```python
thread = await session.scalar(stmt)
...
if request.metadata:
    current_metadata = dict(thread.metadata_json or {})
    current_metadata.update(request.metadata)
    thread.metadata_json = current_metadata
await session.commit()
```

Nothing locks the row between that read and that write, and the write replaces the whole JSONB document, so two writers that read the same base silently discard each other's keys — a lost update whose window is a whole request round trip.

## Aegra races against itself

This is not only a client-versus-client problem. Run preparation performs the same read-modify-write on the same column (`services/run_preparation.py::update_thread_metadata`), so a client that writes thread metadata while a run is starting on that thread can lose its own keys, or Aegra's. Losing Aegra's is the worse half: `assistant_id` and `graph_id` are written there, and `POST /threads/{id}/state` refuses a thread whose metadata has no `graph_id`, so a normal `PATCH` at the wrong moment can leave a thread unable to accept state updates.

To observe it without patching anything, open two sessions against the same thread, let both read it, then let them commit in turn — the second commit wins whole. The two concurrency tests added here do exactly that, driving the real handlers on separate sessions; both fail on `main` and pass on this branch.

## What changed

Both sites now merge in a single statement, so Postgres reads the column it is writing while holding the row lock:

```sql
UPDATE thread
SET metadata_json = CASE WHEN jsonb_typeof(metadata_json) = 'object'
                         THEN metadata_json ELSE '{}'::jsonb END || :patch
WHERE ...
```

built by a small helper in `utils/jsonb.py` (`jsonb_patch` / `jsonb_shallow_merge`). Two details are load-bearing, both learned from running this in production:

- The patch binds through `JsonbSafe`, the type the JSONB columns already use. Postgres rejects U+0000 in `jsonb`, and a plain `cast(..., JSONB)` would start failing writes that the current Python path accepts, since the Python path never sends the value through the column type at all.
- The `jsonb_typeof` guard is there because `'[1,2]'::jsonb || '{"a":1}'::jsonb` appends to an array instead of merging. Thread metadata is written unvalidated on several paths, and a column holding a non-object now starts from `{}` — which is what `dict(value or {})` meant in Python, except that it raised instead of starting over.

`update_thread` keeps its pre-read: it is the 404 probe and the ownership check, and it no longer feeds the write. In `update_thread_metadata` the "name the thread from the first human message, but only if it has no name yet" rule moves into the statement as a `CASE`, so it too is decided at write time rather than from a read that may already be stale.

## Semantics

Unchanged. `||` is a top-level merge, which is exactly what `update_thread`'s docstring already promised ("shallow merge") and what `dict.update` did: a supplied key replaces that key wholesale, nested objects are not deep-merged, absent keys are untouched. `updated_at` is still bumped for a metadata-free `PATCH`, 404 and ownership behaviour are untouched, and `update_thread_metadata` still does not commit — the merge runs inside the caller's transaction.

The stale "dialect agnostic" note on `update_thread_metadata` is dropped: the column is `JSONB` and the driver is asyncpg, so the read-modify-write was not buying portability.

## Verification

Run on a local Postgres 18:

- `libs/aegra-api/tests/integration/test_thread_metadata_merge_db.py` — six new tests, including the two interleaved-session ones (PATCH versus PATCH, and PATCH versus a starting run), the NUL-byte regression guard, the non-object guard, and the shallow-merge and thread-naming semantics. All pass here; with `api/threads.py` and `services/run_preparation.py` reverted to `main`, the two concurrency tests and the non-object test fail, and the semantics tests still pass.
- `uv run --package aegra-api pytest libs/aegra-api/tests/unit libs/aegra-api/tests/integration` — 2087 passed.
- `make format`, `make lint` clean; `make type-check` reports the same 57 pre-existing diagnostics as `main`, none in the changed files.

The E2E suite was not run here (it needs the compose stack).

One thing worth a maintainer's call: like the existing `tests/integration/test_assistant_large_config_db.py`, these tests skip when no database is reachable, and the unit+integration CI job does not start one — so they will skip in CI as things stand. Happy to add a `postgres` service to that job in this PR if you want them actually running; I left CI alone to keep the change focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
