### PR TITLE
feat(api): expose the run's assistant to graphs and graph factories

### DIFF
--- a/docs/guides/authentication.mdx
+++ b/docs/guides/authentication.mdx
@@ -346,6 +346,11 @@ Convenience shortcuts are also available directly on `config["configurable"]`:
 - `config["configurable"]["user_id"]` -- the user's identity
 - `config["configurable"]["user_display_name"]` -- the user's display name
 
+Runs also carry `config["configurable"]["assistant_id"]`, the assistant the run
+executes as. Like `thread_id` and `run_id` it is server-authoritative: a value
+in the request body is overwritten, so it can be used to scope per-assistant
+credentials. See [factory graphs](/reference/configuration#factory-graphs).
+
 ## Provider examples
 
 <Tabs>

--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -199,6 +199,35 @@ Use `runtime.execution_runtime` to check whether the factory is being called for
 
 For a complete example combining both layers, see [`examples/factory/`](https://github.com/aegra/aegra/tree/main/examples/factory).
 
+#### Run identity in the factory
+
+Runs stamp the assistant they execute as into the run config, matching LangGraph
+Platform:
+
+```python
+def graph(config: dict):
+    assistant_id = config["configurable"]["assistant_id"]
+    return build_graph(load_settings_for(assistant_id))
+```
+
+The same value is on the runtime, so a factory taking only `runtime` does not
+have to also declare `config`:
+
+```python
+def graph(runtime: ServerRuntime):
+    assistant_id = runtime.assistant_id
+    ...
+```
+
+The server sets it from the resolved assistant and overwrites anything a client
+sends under `config.configurable.assistant_id`, so it is safe to key
+per-assistant credentials and prompts off it.
+
+It is `None` — and absent from `configurable` — outside run execution. State
+reads, state updates and schema extraction have no run and therefore no
+assistant, so a factory that reads it must tolerate `None` (every factory is
+called for `assistants.read` at least once, to extract schemas).
+
 ## `auth`
 
 Configure authentication and authorization.

--- a/libs/aegra-api/src/aegra_api/models/run_job.py
+++ b/libs/aegra-api/src/aegra_api/models/run_job.py
@@ -28,6 +28,11 @@ class RunIdentity(BaseModel):
     run_id: str
     thread_id: str
     graph_id: str
+    assistant_id: str | None = None
+    """Which assistant's configuration the run executes with.
+
+    ``None`` when the run's assistant row is gone (the column is nullable).
+    """
 
 
 class RunExecution(BaseModel):
@@ -99,6 +104,7 @@ class RunJob(BaseModel):
                 run_id=run_orm.run_id,
                 thread_id=run_orm.thread_id,
                 graph_id=params["graph_id"],
+                assistant_id=run_orm.assistant_id,
             ),
             user=User.model_validate(params["user"]),
             execution=RunExecution.model_validate(params["execution"]),

--- a/libs/aegra-api/src/aegra_api/services/graph_factory.py
+++ b/libs/aegra-api/src/aegra_api/services/graph_factory.py
@@ -19,6 +19,7 @@ import inspect
 import typing
 from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager
+from dataclasses import dataclass
 from typing import Any, Literal, get_args, get_origin
 
 import structlog
@@ -69,6 +70,31 @@ _FACTORY_CONTEXT_TYPES: dict[str, type | None] = {}
 
 # Concrete runtime classes used for ``issubclass`` checks during classification.
 _RUNTIME_CLASSES: tuple[type, ...] = (_ExecutionRuntime, _ReadRuntime)
+
+
+@dataclass(kw_only=True, slots=True, frozen=True)
+class AegraExecutionRuntime[ContextT](_ExecutionRuntime[ContextT]):
+    """``_ExecutionRuntime`` plus the assistant the run executes as."""
+
+    assistant_id: str | None = None
+    """The assistant whose configuration this run uses.
+
+    Server-authoritative: it comes from the resolved assistant row, never from
+    the request body. Also available as ``config["configurable"]["assistant_id"]``.
+    """
+
+
+@dataclass(kw_only=True, slots=True, frozen=True)
+class AegraReadRuntime[ContextT](_ReadRuntime[ContextT]):
+    """``_ReadRuntime`` plus the assistant field, always ``None``.
+
+    Read and introspection contexts have no run and therefore no assistant.
+    The field exists so a factory can read ``runtime.assistant_id`` in every
+    access context without branching.
+    """
+
+    assistant_id: str | None = None
+
 
 # Type alias for RunnableConfig — LangGraph uses ``dict[str, Any]``.
 _RunnableConfig = dict[str, Any]
@@ -318,12 +344,13 @@ def build_server_runtime(
     store: BaseStore | None,
     user: User | BaseUser | None = None,
     context: Any = None,
+    assistant_id: str | None = None,
 ) -> ServerRuntime:
     """Construct the appropriate ``ServerRuntime`` variant for the access context.
 
-    For ``threads.create_run``, returns an ``_ExecutionRuntime`` (which has
+    For ``threads.create_run``, returns an ``AegraExecutionRuntime`` (which has
     a ``context`` field populated with the coerced request context).
-    For all other contexts, returns a ``_ReadRuntime`` (no ``context`` field).
+    For all other contexts, returns an ``AegraReadRuntime`` (no ``context`` field).
 
     If *user* is ``None``, falls back to the current request's auth context.
 
@@ -332,23 +359,27 @@ def build_server_runtime(
         store: The persistence store for the graph run.
         user: The authenticated user, or ``None`` to auto-detect from auth context.
         context: The (optionally coerced) request context for the factory.
-            Only used for ``_ExecutionRuntime``.
+            Only used for the execution runtime.
+        assistant_id: The assistant the run executes as. ``None`` for every
+            non-execution context, which has no run and so no assistant.
 
     Returns:
-        A ``ServerRuntime`` instance (either ``_ExecutionRuntime`` or ``_ReadRuntime``).
+        A ``ServerRuntime`` instance (either ``AegraExecutionRuntime`` or
+        ``AegraReadRuntime``).
     """
     if user is None:
         auth_ctx = get_auth_ctx()
         user = auth_ctx.user if auth_ctx else None
 
     if is_for_execution(access_context):
-        return _ExecutionRuntime(
+        return AegraExecutionRuntime(
             access_context=access_context,
             user=user,
             store=store,
             context=context,
+            assistant_id=assistant_id,
         )
-    return _ReadRuntime(
+    return AegraReadRuntime(
         access_context=access_context,
         user=user,
         store=store,

--- a/libs/aegra-api/src/aegra_api/services/langgraph_service.py
+++ b/libs/aegra-api/src/aegra_api/services/langgraph_service.py
@@ -311,6 +311,7 @@ class LangGraphService:
         access_context: AccessContext = "threads.create_run",
         user: User | BaseUser | None = None,
         context: dict[str, Any] | None = None,
+        assistant_id: str | None = None,
     ) -> AsyncIterator[Pregel]:
         """Get a graph instance for execution with checkpointer/store injected.
 
@@ -341,6 +342,9 @@ class LangGraphService:
             context: The raw request context dict. For factories with
                 ``ServerRuntime[T]``, this is coerced to ``T`` and passed
                 to ``_ExecutionRuntime.context``.
+            assistant_id: The assistant this run executes as, exposed to the
+                factory as ``runtime.assistant_id``. ``None`` outside run
+                execution — read paths have no assistant.
 
         Yields:
             Compiled ``Pregel`` graph with Postgres checkpointer/store attached.
@@ -377,6 +381,7 @@ class LangGraphService:
                 store=store,
                 user=user,
                 context=coerced_context,
+                assistant_id=assistant_id,
             )
 
             result = invoke_factory(factory, graph_id, run_config, server_runtime)
@@ -703,14 +708,17 @@ def create_run_config(
     thread_id: str,
     user: User | BaseUser | None,
     *,
+    assistant_id: str | None = None,
     additional_config: dict[str, Any] | None = None,
     checkpoint: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Create LangGraph configuration for a specific run with full context.
 
-    Additive for client keys, except thread_id/run_id which are forced: a
-    body-supplied configurable.thread_id would redirect execution to another
-    user's thread (the checkpointer keys on thread_id alone).
+    Additive for client keys, except thread_id/run_id/assistant_id which are
+    forced: a body-supplied configurable.thread_id would redirect execution to
+    another user's thread (the checkpointer keys on thread_id alone), and a
+    body-supplied configurable.assistant_id would name another tenant's
+    assistant to a graph that keys its configuration off it.
     """
     from copy import deepcopy
 
@@ -720,6 +728,10 @@ def create_run_config(
     # Server-authoritative — overwrite, never honor a client override.
     cfg["configurable"]["thread_id"] = thread_id
     cfg["configurable"]["run_id"] = run_id
+    if assistant_id is not None:
+        cfg["configurable"]["assistant_id"] = assistant_id
+    else:
+        cfg["configurable"].pop("assistant_id", None)
 
     # Ensure the root run ID is set to match so that astream_events recognizes it
     cfg.setdefault("run_id", run_id)

--- a/libs/aegra-api/src/aegra_api/services/run_executor.py
+++ b/libs/aegra-api/src/aegra_api/services/run_executor.py
@@ -184,6 +184,7 @@ async def _stream_graph(job: RunJob) -> _GraphResult:
             access_context="threads.create_run",
             user=job.user,
             context=job.execution.context,
+            assistant_id=job.identity.assistant_id,
         ) as graph,
         with_auth_ctx(job.user, job.user.permissions),  # type: ignore[arg-type]
     ):
@@ -263,6 +264,7 @@ def _build_run_config(job: RunJob) -> dict[str, Any]:
         job.identity.run_id,
         job.identity.thread_id,
         job.user,
+        assistant_id=job.identity.assistant_id,
         additional_config=job.execution.config,
         checkpoint=job.execution.checkpoint,
     )

--- a/libs/aegra-api/src/aegra_api/services/run_preparation.py
+++ b/libs/aegra-api/src/aegra_api/services/run_preparation.py
@@ -252,7 +252,12 @@ async def _prepare_run(
 
     # Build the RunJob before persisting so we can store execution_params
     job = RunJob(
-        identity=RunIdentity(run_id=run_id, thread_id=thread_id, graph_id=assistant.graph_id),
+        identity=RunIdentity(
+            run_id=run_id,
+            thread_id=thread_id,
+            graph_id=assistant.graph_id,
+            assistant_id=assistant.assistant_id,
+        ),
         user=user,
         execution=RunExecution(
             input_data=request.input,  # preserve None so LangGraph resumes from checkpoint

--- a/libs/aegra-api/src/aegra_api/utils/run_utils.py
+++ b/libs/aegra-api/src/aegra_api/utils/run_utils.py
@@ -7,8 +7,10 @@ from langgraph.types import Command, Send
 logger = structlog.getLogger(__name__)
 
 # A body-supplied thread_id overrides the route-verified one (the checkpointer
-# keys on thread_id alone), so the server pins these instead of trusting them.
-SERVER_PINNED_CONFIG_KEYS: frozenset[str] = frozenset({"thread_id", "run_id"})
+# keys on thread_id alone), and a body-supplied assistant_id would name another
+# tenant's assistant to a factory that keys configuration off it. The server
+# pins these instead of trusting them.
+SERVER_PINNED_CONFIG_KEYS: frozenset[str] = frozenset({"thread_id", "run_id", "assistant_id"})
 
 
 def strip_pinned_config_keys(client_config: dict[str, Any]) -> dict[str, Any]:

--- a/libs/aegra-api/tests/integration/test_services/test_graph_factory_integration.py
+++ b/libs/aegra-api/tests/integration/test_services/test_graph_factory_integration.py
@@ -28,7 +28,7 @@ from aegra_api.services.graph_factory import (
     _FACTORY_KWARGS,
     classify_factory,
 )
-from aegra_api.services.langgraph_service import LangGraphService
+from aegra_api.services.langgraph_service import LangGraphService, create_run_config
 
 # Module-level context models for integration tests.
 # Defined here (not inside test methods) so that ``typing.get_type_hints()``
@@ -340,6 +340,85 @@ class TestGetGraphWithFactory:
                 pass
 
         assert received_config.get("configurable", {}).get("thread_id") == "t1"
+
+    @pytest.mark.asyncio
+    async def test_factory_reads_assistant_id_from_config(self) -> None:
+        """A run's assistant reaches a config-taking factory via configurable."""
+        seen: dict[str, Any] = {}
+
+        def factory(config: dict[str, Any]) -> Mock:
+            seen["assistant_id"] = config["configurable"]["assistant_id"]
+            g = Mock(spec=Pregel)
+            g.copy = Mock(return_value=g)
+            return g
+
+        service = LangGraphService()
+        service._graph_registry = {"fa": {"file_path": "f.py", "export_name": "graph"}}
+        service._graph_factories = {"fa": factory}
+
+        classify_factory(factory, "fa")
+
+        with patch("aegra_api.core.database.db_manager") as mock_db:
+            mock_db.get_checkpointer = Mock(return_value=Mock())
+            mock_db.get_store = Mock(return_value=Mock())
+
+            with patch(
+                "aegra_api.services.langgraph_service.get_tracing_callbacks",
+                return_value=[],
+            ):
+                run_config = create_run_config("run-1", "thread-1", None, assistant_id="asst-1")
+
+            async with service.get_graph("fa", config=run_config, assistant_id="asst-1") as _graph:
+                pass
+
+        assert seen["assistant_id"] == "asst-1"
+
+    @pytest.mark.asyncio
+    async def test_runtime_only_factory_reads_assistant_id(self) -> None:
+        """The same value reaches a factory that takes only ``runtime``."""
+        seen: dict[str, Any] = {}
+
+        def factory(runtime: ServerRuntime) -> Mock:
+            seen["assistant_id"] = runtime.assistant_id  # type: ignore[union-attr]
+            g = Mock(spec=Pregel)
+            g.copy = Mock(return_value=g)
+            return g
+
+        service = LangGraphService()
+        service._graph_registry = {"fra": {"file_path": "f.py", "export_name": "graph"}}
+        service._graph_factories = {"fra": factory}
+
+        classify_factory(factory, "fra")
+
+        with patch("aegra_api.core.database.db_manager") as mock_db:
+            mock_db.get_checkpointer = Mock(return_value=Mock())
+            mock_db.get_store = Mock(return_value=Mock())
+
+            async with service.get_graph("fra", config={"configurable": {}}, assistant_id="asst-1") as _graph:
+                pass
+
+        assert seen["assistant_id"] == "asst-1"
+
+    @pytest.mark.asyncio
+    async def test_read_path_factory_sees_no_assistant(self) -> None:
+        """Schema extraction has no run, so a factory reading the assistant gets ``None``."""
+        seen: dict[str, Any] = {}
+
+        def factory(runtime: ServerRuntime) -> Mock:
+            seen["assistant_id"] = runtime.assistant_id  # type: ignore[union-attr]
+            g = Mock(spec=Pregel)
+            g.copy = Mock(return_value=g)
+            return g
+
+        service = LangGraphService()
+        service._graph_registry = {"frr": {"file_path": "f.py", "export_name": "graph"}}
+        service._graph_factories = {"frr": factory}
+
+        classify_factory(factory, "frr")
+
+        await service.get_graph_for_validation("frr")
+
+        assert seen["assistant_id"] is None
 
     @pytest.mark.asyncio
     async def test_factory_receives_execution_runtime(self) -> None:

--- a/libs/aegra-api/tests/unit/test_services/test_graph_factory.py
+++ b/libs/aegra-api/tests/unit/test_services/test_graph_factory.py
@@ -20,6 +20,8 @@ from pydantic import BaseModel
 from aegra_api.services.graph_factory import (
     _FACTORY_CONTEXT_TYPES,
     _FACTORY_KWARGS,
+    AegraExecutionRuntime,
+    AegraReadRuntime,
     _classify_factory,
     _extract_context_type,
     _is_runtime_annotation,
@@ -675,6 +677,80 @@ class TestBuildServerRuntimeWithContext:
 
         assert isinstance(runtime, _ReadRuntime)
         assert not hasattr(runtime, "context")
+
+
+# ---------------------------------------------------------------------------
+# build_server_runtime — assistant identity
+# ---------------------------------------------------------------------------
+
+
+class TestBuildServerRuntimeAssistantId:
+    """The runtime carries the assistant a run executes as."""
+
+    def test_execution_runtime_carries_assistant_id(self) -> None:
+        runtime = build_server_runtime(
+            access_context="threads.create_run",
+            store=Mock(),
+            user=Mock(),
+            assistant_id="asst-1",
+        )
+
+        assert isinstance(runtime, AegraExecutionRuntime)
+        assert isinstance(runtime, _ExecutionRuntime)
+        assert runtime.assistant_id == "asst-1"
+
+    def test_execution_runtime_without_assistant_id(self) -> None:
+        runtime = build_server_runtime(
+            access_context="threads.create_run",
+            store=Mock(),
+            user=Mock(),
+        )
+
+        assert runtime.assistant_id is None
+
+    @pytest.mark.parametrize("access_context", ["threads.read", "threads.update", "assistants.read"])
+    def test_read_runtime_assistant_id_is_none(self, access_context: str) -> None:
+        """Read paths have no run and therefore no assistant."""
+        runtime = build_server_runtime(
+            access_context=access_context,  # type: ignore[arg-type]
+            store=None,
+            user=Mock(),
+            assistant_id="asst-1",
+        )
+
+        assert isinstance(runtime, AegraReadRuntime)
+        assert isinstance(runtime, _ReadRuntime)
+        assert runtime.assistant_id is None
+
+    def test_runtime_only_factory_reads_assistant_id(self) -> None:
+        """The zero-config factory signature can read the assistant without a config param."""
+        seen: dict[str, Any] = {}
+
+        def make_graph(runtime: ServerRuntime) -> str:
+            seen["assistant_id"] = runtime.assistant_id  # type: ignore[union-attr]
+            return "graph"
+
+        classify_factory(make_graph, "assistant_rt_graph")
+        runtime = build_server_runtime(
+            access_context="threads.create_run",
+            store=Mock(),
+            user=Mock(),
+            assistant_id="asst-1",
+        )
+
+        assert invoke_factory(make_graph, "assistant_rt_graph", {}, runtime) == "graph"
+        assert seen["assistant_id"] == "asst-1"
+
+    def test_read_path_factory_does_not_raise(self) -> None:
+        """A factory reading assistant_id still works for schema extraction."""
+
+        def make_graph(runtime: ServerRuntime) -> str | None:
+            return runtime.assistant_id  # type: ignore[union-attr]
+
+        classify_factory(make_graph, "assistant_read_graph")
+        runtime = build_server_runtime(access_context="assistants.read", store=None, user=None)
+
+        assert invoke_factory(make_graph, "assistant_read_graph", {}, runtime) is None
 
 
 # ---------------------------------------------------------------------------

--- a/libs/aegra-api/tests/unit/test_services/test_langgraph_service.py
+++ b/libs/aegra-api/tests/unit/test_services/test_langgraph_service.py
@@ -706,6 +706,86 @@ class TestLangGraphServiceConfigs:
         assert result["configurable"]["thread_id"] == "thread-456"
         assert result["configurable"]["checkpoint_id"] == "cp-9"
 
+    def test_create_run_config_stamps_assistant_id(self):
+        """The run's assistant reaches configurable, matching LangGraph Platform."""
+        mock_user = Mock()
+        mock_user.identity = "user-123"
+        mock_user.display_name = "Test User"
+
+        with patch(
+            "aegra_api.services.langgraph_service.get_tracing_callbacks",
+            return_value=[],
+        ):
+            result = create_run_config("run-789", "thread-456", mock_user, assistant_id="asst-1")
+
+        assert result["configurable"]["assistant_id"] == "asst-1"
+
+    def test_create_run_config_ignores_client_assistant_id_override(self):
+        """A client-supplied configurable.assistant_id must not name another assistant.
+
+        Factories key per-assistant configuration (credentials, prompts) off this
+        value, so honoring a body override would let a caller have the server
+        resolve another tenant's configuration.
+        """
+        mock_user = Mock()
+        mock_user.identity = "user-123"
+        mock_user.display_name = "Test User"
+
+        attacker_override = {"configurable": {"assistant_id": "victim-assistant"}}
+
+        with patch(
+            "aegra_api.services.langgraph_service.get_tracing_callbacks",
+            return_value=[],
+        ):
+            result = create_run_config(
+                "run-789",
+                "thread-456",
+                mock_user,
+                assistant_id="asst-1",
+                additional_config=attacker_override,
+            )
+
+        assert result["configurable"]["assistant_id"] == "asst-1"
+
+    def test_create_run_config_checkpoint_cannot_override_assistant_id(self):
+        """The checkpoint dict is merged last; it must not redefine assistant_id."""
+        mock_user = Mock()
+        mock_user.identity = "user-123"
+        mock_user.display_name = "Test User"
+
+        malicious_checkpoint = {"assistant_id": "victim-assistant", "checkpoint_id": "cp-9"}
+
+        with patch(
+            "aegra_api.services.langgraph_service.get_tracing_callbacks",
+            return_value=[],
+        ):
+            result = create_run_config(
+                "run-789",
+                "thread-456",
+                mock_user,
+                assistant_id="asst-1",
+                checkpoint=malicious_checkpoint,
+            )
+
+        assert result["configurable"]["assistant_id"] == "asst-1"
+        assert result["configurable"]["checkpoint_id"] == "cp-9"
+
+    def test_create_run_config_without_assistant_drops_client_value(self):
+        """With no server-side assistant the key is absent, not client-controlled."""
+        mock_user = Mock()
+        mock_user.identity = "user-123"
+        mock_user.display_name = "Test User"
+
+        attacker_override = {"configurable": {"assistant_id": "victim-assistant"}}
+
+        with patch(
+            "aegra_api.services.langgraph_service.get_tracing_callbacks",
+            return_value=[],
+        ):
+            result = create_run_config("run-789", "thread-456", mock_user, additional_config=attacker_override)
+
+        assert "assistant_id" not in result["configurable"]
+
     def test_create_run_config_with_tracing_callbacks(self):
         """Test creating run config with tracing callbacks"""
         mock_user = Mock()

--- a/libs/aegra-api/tests/unit/test_services/test_run_executor.py
+++ b/libs/aegra-api/tests/unit/test_services/test_run_executor.py
@@ -470,3 +470,55 @@ class TestTerminalStateRaces:
             await execute_run(_make_job())
 
         mock_signal_end.assert_not_awaited()
+
+
+class TestBuildRunConfigAssistantId:
+    """The run's assistant reaches the graph config and the graph factory."""
+
+    def test_build_run_config_stamps_assistant_id(self) -> None:
+        job = RunJob(
+            identity=RunIdentity(run_id="run-1", thread_id="thread-1", graph_id="graph-1", assistant_id="asst-1"),
+            user=User(identity="user-1"),
+            execution=RunExecution(input_data={"msg": "hello"}),
+        )
+
+        config = run_executor_module._build_run_config(job)
+
+        assert config["configurable"]["assistant_id"] == "asst-1"
+
+    def test_build_run_config_ignores_client_assistant_id(self) -> None:
+        """A run config posted by the client cannot name a different assistant."""
+        job = RunJob(
+            identity=RunIdentity(run_id="run-1", thread_id="thread-1", graph_id="graph-1", assistant_id="asst-1"),
+            user=User(identity="user-1"),
+            execution=RunExecution(
+                input_data={"msg": "hello"},
+                config={"configurable": {"assistant_id": "victim-assistant"}},
+            ),
+        )
+
+        config = run_executor_module._build_run_config(job)
+
+        assert config["configurable"]["assistant_id"] == "asst-1"
+
+    @pytest.mark.asyncio
+    async def test_stream_graph_passes_assistant_id_to_the_factory(self) -> None:
+        job = RunJob(
+            identity=RunIdentity(run_id="run-1", thread_id="thread-1", graph_id="graph-1", assistant_id="asst-1"),
+            user=User(identity="user-1"),
+            execution=RunExecution(input_data={"msg": "hello"}),
+        )
+
+        mock_graph = MagicMock()
+        mock_graph.__aenter__ = AsyncMock(return_value=mock_graph)
+        mock_graph.__aexit__ = AsyncMock(return_value=False)
+        mock_service = MagicMock()
+        mock_service.get_graph = MagicMock(return_value=mock_graph)
+
+        with (
+            patch("aegra_api.services.run_executor.get_langgraph_service", return_value=mock_service),
+            patch("aegra_api.services.run_executor.stream_graph_events", return_value=_empty_async_gen()),
+        ):
+            await run_executor_module._stream_graph(job)
+
+        assert mock_service.get_graph.call_args.kwargs["assistant_id"] == "asst-1"

--- a/libs/aegra-api/tests/unit/test_services/test_run_job.py
+++ b/libs/aegra-api/tests/unit/test_services/test_run_job.py
@@ -19,6 +19,15 @@ class TestRunIdentity:
         assert identity.thread_id == "t1"
         assert identity.graph_id == "g1"
 
+    def test_assistant_id_defaults_to_none(self) -> None:
+        """Read paths and assistant-less rows have no assistant."""
+        identity = RunIdentity(run_id="r1", thread_id="t1", graph_id="g1")
+        assert identity.assistant_id is None
+
+    def test_assistant_id_carried(self) -> None:
+        identity = RunIdentity(run_id="r1", thread_id="t1", graph_id="g1", assistant_id="asst-1")
+        assert identity.assistant_id == "asst-1"
+
 
 class TestRunExecution:
     def test_defaults(self) -> None:
@@ -55,7 +64,7 @@ class TestRunJob:
     @pytest.fixture()
     def sample_job(self) -> RunJob:
         return RunJob(
-            identity=RunIdentity(run_id="run-1", thread_id="thread-1", graph_id="graph-1"),
+            identity=RunIdentity(run_id="run-1", thread_id="thread-1", graph_id="graph-1", assistant_id="asst-1"),
             user=User(identity="user-1", is_authenticated=True, permissions=["read"]),
             execution=RunExecution(
                 input_data={"message": "hello"},
@@ -84,6 +93,7 @@ class TestRunJob:
         class FakeORM:
             run_id = "run-1"
             thread_id = "thread-1"
+            assistant_id = "asst-1"
             execution_params = sample_job.to_execution_params()
 
         restored = RunJob.from_run_orm(FakeORM())
@@ -98,6 +108,23 @@ class TestRunJob:
         assert "run_id" not in params
         assert "thread_id" not in params
 
+    def test_from_run_orm_reads_assistant_id_from_the_column(self) -> None:
+        """assistant_id is a runs column, so rows persisted before this change restore it."""
+
+        class LegacyORM:
+            run_id = "r1"
+            thread_id = "t1"
+            assistant_id = "asst-42"
+            execution_params = {
+                "graph_id": "g1",
+                "user": {"identity": "u1", "is_authenticated": True, "permissions": []},
+                "execution": {},
+                "behavior": {},
+            }
+
+        restored = RunJob.from_run_orm(LegacyORM())
+        assert restored.identity.assistant_id == "asst-42"
+
     def test_extra_user_fields_preserved(self) -> None:
         """User model allows extra fields (ConfigDict extra='allow')."""
         job = RunJob(
@@ -110,6 +137,7 @@ class TestRunJob:
         class FakeORM:
             run_id = "r1"
             thread_id = "t1"
+            assistant_id = "asst-1"
             execution_params = params
 
         restored = RunJob.from_run_orm(FakeORM())
@@ -138,6 +166,7 @@ class TestRunJob:
         class FakeORM:
             run_id = "r1"
             thread_id = "t1"
+            assistant_id = "asst-1"
             execution_params = params
 
         restored = RunJob.from_run_orm(FakeORM())
@@ -149,6 +178,7 @@ class TestRunJob:
         class LegacyORM:
             run_id = "r1"
             thread_id = "t1"
+            assistant_id = "asst-1"
             execution_params = {
                 "graph_id": "g1",
                 "user": {"identity": "u1", "is_authenticated": True, "permissions": []},

--- a/libs/aegra-api/tests/unit/test_services/test_run_preparation.py
+++ b/libs/aegra-api/tests/unit/test_services/test_run_preparation.py
@@ -76,3 +76,79 @@ class TestValidateResumeCommand:
         session = _session_returning(_thread("idle"))
         await _validate_resume_command(session, "t1", None)
         session.scalar.assert_not_awaited()
+
+
+class TestPrepareRunAssistantIdentity:
+    """The resolved assistant becomes the run's server-authoritative identity."""
+
+    @staticmethod
+    def _session(assistant: object, thread: object) -> AsyncMock:
+        """A session that answers the assistant lookup, then the thread lookup."""
+        session = AsyncMock()
+        session.scalar = AsyncMock(side_effect=[assistant, thread])
+        session.execute = AsyncMock(return_value=MagicMock(rowcount=1))
+        session.add = MagicMock()
+        return session
+
+    @staticmethod
+    def _assistant() -> SimpleNamespace:
+        return SimpleNamespace(
+            assistant_id="asst-1",
+            graph_id="graph-1",
+            config={},
+            context={},
+        )
+
+    async def _prepare(self, monkeypatch: pytest.MonkeyPatch, request_config: dict | None) -> object:
+        from aegra_api.models import RunCreate, User
+
+        thread = SimpleNamespace(
+            thread_id="thread-1",
+            status="idle",
+            metadata_json={"owner": "user-1"},
+            user_id="user-1",
+        )
+        session = self._session(self._assistant(), thread)
+
+        service = MagicMock()
+        service.list_graphs = MagicMock(return_value={"graph-1": "graph.py:graph"})
+        monkeypatch.setattr(mod, "get_langgraph_service", lambda: service)
+
+        submitted: list[object] = []
+        submit = AsyncMock(side_effect=lambda job: submitted.append(job))
+        monkeypatch.setattr(mod.executor, "submit", submit)
+
+        await mod._prepare_run(
+            session,
+            "thread-1",
+            RunCreate(
+                assistant_id="asst-1",
+                input={"message": "hi"},
+                config=request_config,
+            ),
+            User(identity="user-1"),
+            initial_status="pending",
+        )
+
+        return submitted[0]
+
+    async def test_identity_carries_the_resolved_assistant(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        job = await self._prepare(monkeypatch, None)
+
+        assert job.identity.assistant_id == "asst-1"
+
+    async def test_client_supplied_assistant_id_is_ignored(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Posting another assistant's id under config.configurable must not take effect.
+
+        The graph is built and configured from this value, so honoring the
+        client's would let a caller reach another tenant's configuration.
+        """
+        from aegra_api.services.run_executor import _build_run_config
+
+        job = await self._prepare(
+            monkeypatch,
+            {"configurable": {"assistant_id": "victim-assistant"}},
+        )
+
+        assert job.identity.assistant_id == "asst-1"
+        assert _build_run_config(job)["configurable"]["assistant_id"] == "asst-1"

--- a/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
+++ b/libs/aegra-api/tests/unit/test_services/test_worker_executor.py
@@ -55,6 +55,7 @@ def _make_run_orm(
     *,
     run_id: str = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
     thread_id: str = "11111111-2222-3333-4444-555555555555",
+    assistant_id: str = "99999999-8888-7777-6666-555555555555",
     status: str = "pending",
     execution_params: dict | None = None,
 ) -> MagicMock:
@@ -62,6 +63,7 @@ def _make_run_orm(
     orm = MagicMock()
     orm.run_id = run_id
     orm.thread_id = thread_id
+    orm.assistant_id = assistant_id
     orm.status = status
     orm.execution_params = execution_params or {
         "graph_id": "test-graph",


### PR DESCRIPTION
## The gap

A graph factory is never told which assistant it is running as. The identity exists server-side at every step of run preparation and is simply not forwarded.

- `RunIdentity` carries `run_id`, `thread_id`, `graph_id` and nothing else, although `_prepare_run` has the resolved `assistant` row in hand when it builds one.
- `create_run_config` stamps `thread_id`, `run_id` and the user keys into `configurable` and stops there.
- `build_server_runtime` passes `access_context`, `user`, `store`, `context`.

So a factory that needs per-assistant configuration — credentials, prompt selection, tool surface, trace attribution — has nowhere authoritative to read the assistant from. LangGraph Platform stamps `configurable.assistant_id` on every run, so code ported from the Platform reads `None` on Aegra, silently.

## What a consumer has to do without it

The only identity a factory can see today is `runtime.user`, so per-assistant lookups end up keyed off the caller's JWT subject. A deployment we run does exactly that, and it costs:

- one token subject per assistant, minted by every client;
- a client that manages several assistants (a dashboard, say) cannot use a shared subject, because `_prepare_run` scopes assistants to `user_id == identity OR "system"` — under a shared subject it can no longer list or manage the assistants it created.

The obvious workaround is worse. Putting a pointer in the assistant's own `config` does not work, because run config merges *over* assistant config: a caller can name another tenant's configuration in the request body and have the server resolve it, with that tenant's credentials.

## What changed

`assistant_id` is threaded from the resolved assistant to both places a factory can read it.

- `RunIdentity` gains `assistant_id: str | None`, populated in `_prepare_run` from `assistant.assistant_id`. `from_run_orm` reads it from the existing `runs.assistant_id` column rather than `execution_params`, so runs persisted before this change restore it too and no migration is needed.
- `_build_run_config` forwards it to `create_run_config(..., assistant_id=...)`, which stamps `configurable["assistant_id"]`.
- `build_server_runtime` takes it and puts it on the runtime, so the `def graph(runtime: ServerRuntime)` signature — the zero-config one Aegra advertises — can read `runtime.assistant_id` without also declaring `config`.
- `assistant_id` joins `SERVER_PINNED_CONFIG_KEYS`, so a client-supplied checkpoint cannot redirect it either.

The name follows the Platform key, per the API-compatibility rule in CONTRIBUTING.md.

Stateless runs (`POST /runs`, `/runs/stream`, `/runs/wait`) need no change: they generate an ephemeral thread and delegate to the threaded handlers, so they reach the same `_prepare_run` and get the same stamped value. `test_delegates_to_threaded_wait` already pins that delegation.

Read paths get `None`. `threads.read`, `threads.update` and `assistants.read` have no run and therefore no assistant, so the runtime's field is `None` there and the config key is absent. A factory that reads it must tolerate `None` — it is called for `assistants.read` at least once, for schema extraction — and there is a test for that.

### Why the value is server-authoritative

This is the part that matters for review. The key is **overwritten, never merged**, exactly as `thread_id` and `run_id` are:

```python
cfg["configurable"]["thread_id"] = thread_id
cfg["configurable"]["run_id"] = run_id
if assistant_id is not None:
    cfg["configurable"]["assistant_id"] = assistant_id
else:
    cfg["configurable"].pop("assistant_id", None)
```

A `setdefault` here would be a cross-tenant hazard rather than a convenience. The whole point of the key is that a factory keys configuration off it, so a client-overridable `configurable.assistant_id` would let a caller name another tenant's assistant and have the server resolve that tenant's prompts and credentials — the same hole as the assistant-config workaround above, just moved into Aegra. The `else` branch matters for the same reason: when the server has no assistant, the key is dropped rather than left client-controlled.

Adding it to `SERVER_PINNED_CONFIG_KEYS` closes the second door: `checkpoint` is a free-form client dict merged into `configurable` last, both in `create_run_config` and in `PATCH /threads/{id}/state`.

### One wrinkle worth a maintainer's opinion

`ServerRuntime`'s variants are frozen, slotted dataclasses owned by `langgraph_sdk`, so a field cannot be added to them from here. This PR subclasses them (`AegraExecutionRuntime`, `AegraReadRuntime`) and constructs those instead. Runtime behaviour is unchanged — `isinstance` checks, `execution_runtime` narrowing and factory classification all still work, covered by the existing tests — but a user annotating a factory parameter as `ServerRuntime` will not see `assistant_id` on it from a type checker, because the SDK's dataclass does not declare it.

If you would rather not carry an Aegra-only attribute on the runtime, the `configurable` half of this PR stands on its own and the subclasses can be dropped; factories would then have to take `config` as well. Say the word and I will split it. The alternative is to land `assistant_id` on the SDK's `_ServerRuntimeBase` upstream first and follow it here.

## Relationship to #525

#525 makes the identical argument one level down: `graph_id` says which code runs, `assistant_id` says whose configuration it runs with, and neither reaches `configurable`. They are the same gap, and a deployment that hits one usually hits both.

**I would keep them as two PRs rather than merging them**, for two reasons:

1. The merge semantics differ, and the difference is the interesting part. #525 proposes `setdefault("graph_id", graph_id)`, which is fine on its own terms; `assistant_id` must overwrite, because it is a tenant boundary. Reviewing both under one diff invites the wrong default for one of them.
2. #525 has an author who offered to open a PR. This PR does not block that one and does not touch `graph_id`.

One thing they should agree on, though: #525 wants `graph_id` for per-agent spend attribution, and attribution off a key a client can set is attribution a client can forge. I would argue `graph_id` should also be server-pinned rather than `setdefault`, for the weaker version of the reason given above. That is a comment for #525, not a change here.

## How it was verified

- `make format`, `make lint`, `make type-check` — clean. (`type-check` reports 57 pre-existing diagnostics on `main`; this branch reports the same 57, none in the changed files.)
- `uv run --package aegra-api pytest libs/aegra-api/tests/unit libs/aegra-api/tests/integration` — 2097 passed. The single failure is `test_assistant_large_config_db`, which wants a Postgres role and fails identically on `main` without a database.
- Every new test was confirmed to fail against unmodified sources before the change, so none of them pass vacuously.

New tests:

- `create_run_config` stamps the assistant; a client `configurable.assistant_id` naming a different assistant is ignored; a `checkpoint` carrying one is ignored; with no server-side assistant the key is dropped rather than left client-controlled.
- `_prepare_run` puts the resolved assistant on `RunIdentity`, and a run posted with `config.configurable.assistant_id` set to another assistant still builds a run config naming the resolved one.
- A factory reading `config["configurable"]["assistant_id"]` sees it; a factory taking only `runtime` sees the same value; read-path invocations see `None` and do not raise.
- `RunJob.from_run_orm` restores the assistant from the `runs` column, including for rows whose `execution_params` predate this change.

Docs updated: the factory section of `docs/reference/configuration.mdx` and the `configurable` shortcut list in `docs/guides/authentication.mdx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
