### PR TITLE
fix(api): reject a run context the graph's declared type cannot accept

### DIFF
--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -188,6 +188,8 @@ async def graph(runtime: ServerRuntime[MyContext]):
 
 Use `runtime.execution_runtime` to check whether the factory is being called for actual execution (returns the execution runtime with `.context`) or for introspection like schema extraction (returns `None`).
 
+Declaring `ServerRuntime[T]` makes `T` the contract for the run context. Aegra validates the run's context — the request's `context` (or `config.configurable` when `context` is absent) merged over the assistant's stored context — against `T` when the run is created, and rejects a context `T` cannot accept with `422` naming the offending fields. No run is created. `model_config = ConfigDict(extra="forbid")` on `T` therefore rejects unexpected keys, and fields with defaults keep a context permissive. A factory annotated with plain `ServerRuntime` declares no shape and receives whatever context the request carries, as a raw dict.
+
 **When to use which:**
 
 | Need | Use | Works with |

--- a/libs/aegra-api/src/aegra_api/services/graph_factory.py
+++ b/libs/aegra-api/src/aegra_api/services/graph_factory.py
@@ -253,20 +253,96 @@ def is_for_execution(access_context: AccessContext) -> bool:
 
 
 # ---------------------------------------------------------------------------
-# Context coercion
+# Context validation and coercion
 # ---------------------------------------------------------------------------
+
+
+class ContextValidationError(ValueError):
+    """A context does not satisfy the context type declared by a graph factory.
+
+    Carries Pydantic-shaped ``errors`` (``loc``/``msg``/``type`` entries, ``loc``
+    rooted at ``context``) so the API layer can hand them to the caller as a
+    ``422`` body without re-deriving field locations.
+    """
+
+    def __init__(self, graph_id: str, context_type: type, errors: list[dict[str, Any]]) -> None:
+        self.graph_id = graph_id
+        self.context_type = context_type
+        self.errors = errors
+        super().__init__(f"context does not satisfy {context_type.__name__} declared by graph '{graph_id}'")
+
+
+def validate_context(context: dict[str, Any] | None, graph_id: str) -> None:
+    """Check *context* against the factory's declared context type ``T``.
+
+    A no-op when the graph declares no context type — an unannotated factory
+    accepts any context, so there is nothing to check against.
+
+    Raises:
+        ContextValidationError: If the graph declares ``ServerRuntime[T]`` and
+            *context* cannot be converted to ``T``.
+    """
+    ctx_type = _FACTORY_CONTEXT_TYPES.get(graph_id)
+    if context is None or ctx_type is None:
+        return
+
+    try:
+        _instantiate_context(context, ctx_type)
+    except Exception as exc:
+        raise ContextValidationError(graph_id, ctx_type, _context_errors(exc)) from exc
+
+
+def _instantiate_context(context: dict[str, Any], ctx_type: type) -> Any:
+    """Build a ``ctx_type`` from *context*, or return it unchanged.
+
+    Pydantic ``BaseModel`` → ``T.model_validate(context)``; ``dataclass`` →
+    ``T(**context)``. Any other declared type has no known construction path,
+    so the raw dict is returned rather than guessed at.
+    """
+    if _is_pydantic_model(ctx_type):
+        return ctx_type.model_validate(context)
+    if dataclasses.is_dataclass(ctx_type):
+        return ctx_type(**context)
+    return context
+
+
+def _context_errors(exc: Exception) -> list[dict[str, Any]]:
+    """Render *exc* as Pydantic-shaped error entries rooted at ``context``.
+
+    Pydantic's ``ValidationError.errors()`` is used when available; anything
+    else (notably the ``TypeError`` a dataclass raises for a missing or
+    unexpected field) collapses to a single entry pointing at ``context``.
+    Only ``loc``/``msg``/``type`` are carried through — ``input`` would echo
+    the submitted values back into the response body.
+    """
+    errors_fn = getattr(exc, "errors", None)
+    if callable(errors_fn):
+        try:
+            return [
+                {
+                    "loc": ["context", *(entry.get("loc") or ())],
+                    "msg": entry.get("msg", ""),
+                    "type": entry.get("type", "value_error"),
+                }
+                for entry in errors_fn()
+            ]
+        except Exception:
+            # Duck-typed call — an ``errors`` that is not Pydantic's falls
+            # through to the generic entry rather than losing the rejection.
+            pass
+    return [{"loc": ["context"], "msg": str(exc), "type": "value_error"}]
 
 
 def coerce_context(context: dict[str, Any] | None, graph_id: str) -> Any:
     """Coerce a raw context dict to the factory's declared context type ``T``.
 
     If the factory declared ``ServerRuntime[T]``, the raw dict is converted
-    to an instance of ``T``:
-    - Pydantic ``BaseModel`` → ``T.model_validate(context)``
-    - ``dataclass`` → ``T(**context)``
+    to an instance of ``T``.
 
-    On failure (e.g., validation error or missing fields), logs a warning
-    and returns the raw dict for graceful degradation.
+    Contexts are checked by :func:`validate_context` when the run is created,
+    so a failure here means an unchecked context reached execution. Handing the
+    graph the raw dict instead would run it against something other than the
+    type it declared, so the failure is logged and re-raised.
 
     Args:
         context: The raw context dict from the request, or ``None``.
@@ -274,6 +350,9 @@ def coerce_context(context: dict[str, Any] | None, graph_id: str) -> Any:
 
     Returns:
         A coerced ``T`` instance, the raw dict, or ``None``.
+
+    Raises:
+        ContextValidationError: If *context* cannot be converted to ``T``.
     """
     if context is None:
         return None
@@ -283,19 +362,15 @@ def coerce_context(context: dict[str, Any] | None, graph_id: str) -> Any:
         return context
 
     try:
-        if _is_pydantic_model(ctx_type):
-            return ctx_type.model_validate(context)
-        if dataclasses.is_dataclass(ctx_type):
-            return ctx_type(**context)
+        return _instantiate_context(context, ctx_type)
     except Exception as exc:
-        logger.warning(
+        logger.error(
             "context_coercion_failed",
             graph_id=graph_id,
             context_type=ctx_type.__name__,
             exc=str(exc),
-            msg="Falling back to raw dict",
         )
-    return context
+        raise ContextValidationError(graph_id, ctx_type, _context_errors(exc)) from exc
 
 
 def _is_pydantic_model(cls: type) -> bool:

--- a/libs/aegra-api/src/aegra_api/services/run_preparation.py
+++ b/libs/aegra-api/src/aegra_api/services/run_preparation.py
@@ -22,6 +22,7 @@ from aegra_api.core.orm import _get_session_maker
 from aegra_api.models import Run, RunCreate, User
 from aegra_api.models.run_job import RunBehavior, RunExecution, RunIdentity, RunJob
 from aegra_api.services.executor import executor
+from aegra_api.services.graph_factory import ContextValidationError, validate_context
 from aegra_api.services.langgraph_service import get_langgraph_service
 from aegra_api.services.run_status import set_thread_status
 from aegra_api.utils.assistants import resolve_assistant_id
@@ -186,6 +187,31 @@ async def update_thread_metadata(
     )
 
 
+def _format_context_errors(graph_id: str, errors: list[dict[str, Any]]) -> str:
+    """One-line 422 message naming each field that failed validation."""
+    parts = [f"{'.'.join(str(p) for p in entry['loc'])}: {entry['msg']}" for entry in errors]
+    return f"Invalid context for graph '{graph_id}': " + "; ".join(parts)
+
+
+def _validate_context_against_graph(context: dict[str, Any], graph_id: str) -> None:
+    """Reject a context the graph's declared context type cannot accept.
+
+    A factory annotated ``ServerRuntime[T]`` declares the shape of the context
+    its runs accept, so a context that is not a ``T`` asks for a run the graph
+    cannot perform. Rejecting here keeps that a request error rather than a
+    failed run: nothing is persisted or enqueued yet.
+
+    Graphs that declare no context type are unaffected — there is nothing to
+    validate against, and any context reaches them as a raw dict as before.
+    """
+    try:
+        validate_context(context, graph_id)
+    except ContextValidationError as exc:
+        http_exc = HTTPException(422, detail=_format_context_errors(graph_id, exc.errors))
+        http_exc.details = {"errors": exc.errors}  # type: ignore[attr-defined]
+        raise http_exc from exc
+
+
 async def _prepare_run(
     session: AsyncSession,
     thread_id: str,
@@ -243,6 +269,8 @@ async def _prepare_run(
     available_graphs = langgraph_service.list_graphs()
     if assistant.graph_id not in available_graphs:
         raise HTTPException(404, f"Graph '{assistant.graph_id}' not found for assistant")
+
+    _validate_context_against_graph(context, assistant.graph_id)
 
     # Mark thread as busy and update metadata
     await update_thread_metadata(

--- a/libs/aegra-api/tests/integration/test_services/test_graph_factory_integration.py
+++ b/libs/aegra-api/tests/integration/test_services/test_graph_factory_integration.py
@@ -26,6 +26,7 @@ from pydantic import BaseModel
 from aegra_api.services.graph_factory import (
     _FACTORY_CONTEXT_TYPES,
     _FACTORY_KWARGS,
+    ContextValidationError,
     classify_factory,
 )
 from aegra_api.services.langgraph_service import LangGraphService
@@ -589,37 +590,40 @@ class TestGetGraphWithContext:
         assert received_runtime.context is ctx
 
     @pytest.mark.asyncio
-    async def test_invalid_context_falls_back_to_raw_dict(self) -> None:
-        """Factory with ServerRuntime[_TestRequiredConfig] + invalid context → fallback."""
-        received_runtime = None
+    async def test_invalid_context_never_reaches_the_factory(self) -> None:
+        """An invalid context fails the run rather than reaching the factory as a raw dict."""
+        called = False
 
         def factory(runtime: ServerRuntime[_TestRequiredConfig]) -> Mock:
-            nonlocal received_runtime
-            received_runtime = runtime
+            nonlocal called
+            called = True
             g = Mock(spec=Pregel)
             g.copy = Mock(return_value=g)
             return g
 
         service = LangGraphService()
-        service._graph_registry = {"fallback": {"file_path": "f.py", "export_name": "graph"}}
-        service._graph_factories = {"fallback": factory}
-        classify_factory(factory, "fallback")
+        service._graph_registry = {"strict": {"file_path": "f.py", "export_name": "graph"}}
+        service._graph_factories = {"strict": factory}
+        classify_factory(factory, "strict")
 
-        invalid_ctx = {"wrong_field": "oops"}
-        with patch("aegra_api.core.database.db_manager") as mock_db:
+        with (
+            patch("aegra_api.core.database.db_manager") as mock_db,
+            pytest.raises(ContextValidationError) as exc_info,
+        ):
             mock_db.get_checkpointer = Mock(return_value=Mock())
             mock_db.get_store = Mock(return_value=Mock())
 
             async with service.get_graph(
-                "fallback",
+                "strict",
                 access_context="threads.create_run",
-                context=invalid_ctx,
+                context={"wrong_field": "oops"},
             ) as _graph:
                 pass
 
-        assert isinstance(received_runtime, _ExecutionRuntime)
-        # Should fall back to raw dict, not crash
-        assert received_runtime.context is invalid_ctx
+        assert not called
+        assert exc_info.value.errors == [
+            {"loc": ["context", "required_field"], "msg": "Field required", "type": "missing"}
+        ]
 
 
 # ---------------------------------------------------------------------------

--- a/libs/aegra-api/tests/unit/test_api/test_runs.py
+++ b/libs/aegra-api/tests/unit/test_api/test_runs.py
@@ -1,11 +1,15 @@
 """Unit tests for standard run endpoints (create, get, list, update, join)."""
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 from datetime import UTC, datetime
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
 from fastapi import HTTPException
+from pydantic import BaseModel
 from redis import RedisError
 
 from aegra_api.api.runs import (
@@ -21,6 +25,7 @@ from aegra_api.core.orm import Assistant as AssistantORM
 from aegra_api.core.orm import Run as RunORM
 from aegra_api.core.orm import Thread as ThreadORM
 from aegra_api.models import Run, RunCreate, RunStatus, User
+from aegra_api.services.graph_factory import _FACTORY_CONTEXT_TYPES
 
 
 class TestRunsEndpoints:
@@ -599,3 +604,152 @@ class TestApplyCreateRunAuth:
 
         assert request.config == {"original": "kept", "injected": True}
         assert request.context == {"injected_ctx": 2}
+
+
+class _RunContext(BaseModel):
+    """Context type a graph factory declares via ``ServerRuntime[_RunContext]``."""
+
+    prompt_version: int
+
+
+class TestCreateRunContextValidation:
+    """A context the graph's declared type rejects must 422, not create a run."""
+
+    @pytest.fixture
+    def mock_user(self) -> User:
+        return User(identity="test-user", scopes=[])
+
+    @pytest.fixture
+    def mock_session(self) -> AsyncMock:
+        session = AsyncMock()
+        session.refresh = AsyncMock()
+        session.add = MagicMock()  # session.add is synchronous
+        return session
+
+    @pytest.fixture
+    def declared_context_type(self) -> Iterator[None]:
+        _FACTORY_CONTEXT_TYPES.clear()
+        _FACTORY_CONTEXT_TYPES["test-graph"] = _RunContext
+        try:
+            yield
+        finally:
+            _FACTORY_CONTEXT_TYPES.clear()
+
+    @pytest.fixture
+    def assistant(self) -> AssistantORM:
+        return AssistantORM(
+            assistant_id="test-assistant",
+            graph_id="test-graph",
+            config={},
+            context={},
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+
+    @contextmanager
+    def _prepared(self, mock_session: AsyncMock, assistant: AssistantORM) -> Iterator[SimpleNamespace]:
+        with (
+            patch("aegra_api.services.run_preparation._validate_resume_command", new_callable=AsyncMock),
+            patch("aegra_api.services.run_preparation.get_langgraph_service") as mock_lg_service,
+            patch("aegra_api.services.run_preparation.resolve_assistant_id", return_value="test-assistant"),
+            patch("aegra_api.services.run_preparation.update_thread_metadata", new_callable=AsyncMock) as mock_metadata,
+            patch("aegra_api.services.run_preparation.set_thread_status", new_callable=AsyncMock) as mock_status,
+            patch("aegra_api.services.run_preparation.executor.submit", new_callable=AsyncMock) as mock_submit,
+            patch("aegra_api.api.runs.active_runs", {}),
+        ):
+            mock_lg_service.return_value.list_graphs.return_value = ["test-graph"]
+            mock_session.scalar.side_effect = [None, assistant]
+            yield SimpleNamespace(submit=mock_submit, thread_metadata=mock_metadata, thread_status=mock_status)
+
+    @pytest.mark.asyncio
+    async def test_invalid_context_returns_422_and_touches_nothing(
+        self,
+        mock_user: User,
+        mock_session: AsyncMock,
+        assistant: AssistantORM,
+        declared_context_type: None,
+    ) -> None:
+        """Rejection precedes every write: no run row, no ghost thread, no busy status."""
+        request = RunCreate(assistant_id="test-assistant", input={}, context={"prompt_version": "abc"})
+
+        with self._prepared(mock_session, assistant) as mocks:
+            with pytest.raises(HTTPException) as exc:
+                await create_run("test-thread-123", request, mock_user, mock_session)
+
+            assert exc.value.status_code == 422
+            assert "context.prompt_version" in exc.value.detail
+            mock_session.add.assert_not_called()
+            mock_session.commit.assert_not_called()
+            mocks.thread_metadata.assert_not_awaited()
+            mocks.thread_status.assert_not_awaited()
+            mocks.submit.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_valid_context_still_creates_the_run(
+        self,
+        mock_user: User,
+        mock_session: AsyncMock,
+        assistant: AssistantORM,
+        declared_context_type: None,
+    ) -> None:
+        request = RunCreate(assistant_id="test-assistant", input={}, context={"prompt_version": 3})
+
+        with self._prepared(mock_session, assistant) as mocks:
+            result = await create_run("test-thread-123", request, mock_user, mock_session)
+
+        assert result.context == {"prompt_version": 3}
+        mocks.submit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_graph_without_declared_type_accepts_any_context(
+        self, mock_user: User, mock_session: AsyncMock, assistant: AssistantORM
+    ) -> None:
+        """No ``ServerRuntime[T]`` annotation → the context reaches the graph unchecked, as before."""
+        _FACTORY_CONTEXT_TYPES.clear()
+        request = RunCreate(assistant_id="test-assistant", input={}, context={"prompt_version": "abc"})
+
+        with self._prepared(mock_session, assistant) as mocks:
+            result = await create_run("test-thread-123", request, mock_user, mock_session)
+
+        assert result.context == {"prompt_version": "abc"}
+        mocks.submit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_context_inherited_from_the_assistant_is_validated(
+        self, mock_user: User, mock_session: AsyncMock, declared_context_type: None
+    ) -> None:
+        """The merged context is what runs, so a bad stored context is rejected too."""
+        assistant = AssistantORM(
+            assistant_id="test-assistant",
+            graph_id="test-graph",
+            config={},
+            context={"prompt_version": "abc"},
+            created_at=datetime.now(UTC),
+            updated_at=datetime.now(UTC),
+        )
+        request = RunCreate(assistant_id="test-assistant", input={})
+
+        with self._prepared(mock_session, assistant), pytest.raises(HTTPException) as exc:
+            await create_run("test-thread-123", request, mock_user, mock_session)
+
+        assert exc.value.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_configurable_fallback_is_validated(
+        self,
+        mock_user: User,
+        mock_session: AsyncMock,
+        assistant: AssistantORM,
+        declared_context_type: None,
+    ) -> None:
+        """``config.configurable`` becomes the context when none is given, so it is checked."""
+        request = RunCreate(
+            assistant_id="test-assistant",
+            input={},
+            config={"configurable": {"prompt_version": "abc"}},
+        )
+
+        with self._prepared(mock_session, assistant), pytest.raises(HTTPException) as exc:
+            await create_run("test-thread-123", request, mock_user, mock_session)
+
+        assert exc.value.status_code == 422

--- a/libs/aegra-api/tests/unit/test_services/test_graph_factory.py
+++ b/libs/aegra-api/tests/unit/test_services/test_graph_factory.py
@@ -15,11 +15,13 @@ from langgraph_sdk.runtime import (
     _ExecutionRuntime,
     _ReadRuntime,
 )
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
+from structlog.testing import capture_logs
 
 from aegra_api.services.graph_factory import (
     _FACTORY_CONTEXT_TYPES,
     _FACTORY_KWARGS,
+    ContextValidationError,
     _classify_factory,
     _extract_context_type,
     _is_runtime_annotation,
@@ -31,6 +33,7 @@ from aegra_api.services.graph_factory import (
     invoke_factory,
     is_factory,
     is_for_execution,
+    validate_context,
 )
 
 # ---------------------------------------------------------------------------
@@ -570,6 +573,14 @@ class _DataclassCtx:
     value: int
 
 
+class _StrictCtx(BaseModel):
+    """Pydantic model that forbids unexpected keys."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str
+
+
 class TestCoerceContext:
     """Test context coercion from raw dict to T."""
 
@@ -613,23 +624,116 @@ class TestCoerceContext:
         assert result.name == "test"
         assert result.value == 42
 
-    def test_pydantic_validation_error_falls_back(self) -> None:
-        """Invalid data for Pydantic model → graceful fallback to raw dict."""
+    def test_pydantic_validation_error_raises(self) -> None:
+        """Invalid data for a Pydantic model raises rather than degrading to the raw dict."""
         _FACTORY_CONTEXT_TYPES["g"] = _PydanticCtx
-        ctx = {"wrong_field": "nope"}
 
-        result = coerce_context(ctx, "g")
+        with pytest.raises(ContextValidationError) as exc_info:
+            coerce_context({"wrong_field": "nope"}, "g")
 
-        assert result is ctx  # raw dict fallback
+        assert exc_info.value.graph_id == "g"
+        assert exc_info.value.context_type is _PydanticCtx
 
-    def test_dataclass_missing_field_falls_back(self) -> None:
-        """Missing fields for dataclass → graceful fallback to raw dict."""
+    def test_dataclass_missing_field_raises(self) -> None:
+        """Missing fields for a dataclass raise rather than degrading to the raw dict."""
         _FACTORY_CONTEXT_TYPES["g"] = _DataclassCtx
-        ctx = {"name": "test"}  # missing 'value'
 
-        result = coerce_context(ctx, "g")
+        with pytest.raises(ContextValidationError):
+            coerce_context({"name": "test"}, "g")  # missing 'value'
 
-        assert result is ctx  # raw dict fallback
+    def test_coercion_failure_logs_at_error(self) -> None:
+        """A context that was never validated at the edge must be loud, not a warning."""
+        _FACTORY_CONTEXT_TYPES["g"] = _PydanticCtx
+
+        with capture_logs() as logs, pytest.raises(ContextValidationError):
+            coerce_context({"wrong_field": "nope"}, "g")
+
+        entries = [entry for entry in logs if entry["event"] == "context_coercion_failed"]
+        assert len(entries) == 1
+        assert entries[0]["log_level"] == "error"
+        assert entries[0]["graph_id"] == "g"
+        assert entries[0]["context_type"] == "_PydanticCtx"
+
+
+# ---------------------------------------------------------------------------
+# validate_context
+# ---------------------------------------------------------------------------
+
+
+class TestValidateContext:
+    """Validation of a request context against the factory's declared type."""
+
+    def test_valid_pydantic_context_passes(self) -> None:
+        _FACTORY_CONTEXT_TYPES["g"] = _PydanticCtx
+        validate_context({"name": "test", "value": 42}, "g")
+
+    def test_valid_dataclass_context_passes(self) -> None:
+        _FACTORY_CONTEXT_TYPES["g"] = _DataclassCtx
+        validate_context({"name": "test", "value": 42}, "g")
+
+    def test_none_context_is_skipped(self) -> None:
+        _FACTORY_CONTEXT_TYPES["g"] = _PydanticCtx
+        validate_context(None, "g")
+
+    def test_graph_without_declared_type_accepts_anything(self) -> None:
+        """Plain ServerRuntime declares no shape, so nothing is rejected."""
+        _FACTORY_CONTEXT_TYPES["g"] = None
+        validate_context({"anything": "goes"}, "g")
+
+    def test_unregistered_graph_accepts_anything(self) -> None:
+        validate_context({"anything": "goes"}, "unregistered")
+
+    def test_wrong_type_names_the_offending_field(self) -> None:
+        _FACTORY_CONTEXT_TYPES["g"] = _PydanticCtx
+
+        with pytest.raises(ContextValidationError) as exc_info:
+            validate_context({"name": "test", "value": "abc"}, "g")
+
+        assert exc_info.value.errors == [
+            {
+                "loc": ["context", "value"],
+                "msg": "Input should be a valid integer, unable to parse string as an integer",
+                "type": "int_parsing",
+            }
+        ]
+
+    def test_missing_field_names_the_offending_field(self) -> None:
+        _FACTORY_CONTEXT_TYPES["g"] = _PydanticCtx
+
+        with pytest.raises(ContextValidationError) as exc_info:
+            validate_context({"name": "test"}, "g")
+
+        assert exc_info.value.errors == [{"loc": ["context", "value"], "msg": "Field required", "type": "missing"}]
+
+    def test_extra_forbid_rejects_unexpected_key(self) -> None:
+        """``extra="forbid"`` now rejects, where it used to drop the whole context."""
+        _FACTORY_CONTEXT_TYPES["g"] = _StrictCtx
+
+        with pytest.raises(ContextValidationError) as exc_info:
+            validate_context({"name": "test", "surprise": 1}, "g")
+
+        assert exc_info.value.errors == [
+            {"loc": ["context", "surprise"], "msg": "Extra inputs are not permitted", "type": "extra_forbidden"}
+        ]
+
+    def test_dataclass_error_collapses_to_one_context_entry(self) -> None:
+        """A dataclass TypeError has no field locations, so it points at ``context``."""
+        _FACTORY_CONTEXT_TYPES["g"] = _DataclassCtx
+
+        with pytest.raises(ContextValidationError) as exc_info:
+            validate_context({"name": "test"}, "g")
+
+        assert [e["loc"] for e in exc_info.value.errors] == [["context"]]
+        assert exc_info.value.errors[0]["type"] == "value_error"
+
+    def test_errors_do_not_echo_submitted_values(self) -> None:
+        """The 422 body must not reflect the caller's own values back at them."""
+        _FACTORY_CONTEXT_TYPES["g"] = _PydanticCtx
+
+        with pytest.raises(ContextValidationError) as exc_info:
+            validate_context({"name": "test", "value": "s3cr3t-value"}, "g")
+
+        assert "s3cr3t-value" not in repr(exc_info.value.errors)
 
 
 # ---------------------------------------------------------------------------

--- a/libs/aegra-api/tests/unit/test_services/test_run_preparation.py
+++ b/libs/aegra-api/tests/unit/test_services/test_run_preparation.py
@@ -1,12 +1,16 @@
 """Unit tests for run_preparation helpers."""
 
+from collections.abc import Iterator
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi import HTTPException
+from pydantic import BaseModel, ConfigDict
 
 from aegra_api.services import run_preparation as mod
+from aegra_api.services.graph_factory import _FACTORY_CONTEXT_TYPES
 from aegra_api.services.run_preparation import _validate_resume_command
 
 
@@ -76,3 +80,92 @@ class TestValidateResumeCommand:
         session = _session_returning(_thread("idle"))
         await _validate_resume_command(session, "t1", None)
         session.scalar.assert_not_awaited()
+
+
+class _Ctx(BaseModel):
+    """Context type a graph factory declares via ``ServerRuntime[_Ctx]``."""
+
+    prompt_version: int
+
+
+class _StrictCtx(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    prompt_version: int
+
+
+@pytest.fixture
+def _declared_contexts() -> Iterator[dict[str, type | None]]:
+    """Register factory context types for the duration of a test."""
+    _FACTORY_CONTEXT_TYPES.clear()
+    try:
+        yield _FACTORY_CONTEXT_TYPES
+    finally:
+        _FACTORY_CONTEXT_TYPES.clear()
+
+
+class TestValidateContextAgainstGraph:
+    def test_graph_without_declared_type_accepts_anything(self, _declared_contexts: dict) -> None:
+        mod._validate_context_against_graph({"anything": "goes"}, "untyped-graph")
+
+    def test_plain_server_runtime_accepts_anything(self, _declared_contexts: dict) -> None:
+        _declared_contexts["g"] = None
+        mod._validate_context_against_graph({"anything": "goes"}, "g")
+
+    def test_valid_context_passes(self, _declared_contexts: dict) -> None:
+        _declared_contexts["g"] = _Ctx
+        mod._validate_context_against_graph({"prompt_version": 3}, "g")
+
+    def test_invalid_value_is_422_naming_the_field(self, _declared_contexts: dict) -> None:
+        _declared_contexts["g"] = _Ctx
+
+        with pytest.raises(HTTPException) as exc:
+            mod._validate_context_against_graph({"prompt_version": "abc"}, "g")
+
+        assert exc.value.status_code == 422
+        assert "context.prompt_version" in exc.value.detail
+        assert "g" in exc.value.detail
+
+    def test_structured_errors_ride_along_in_details(self, _declared_contexts: dict) -> None:
+        _declared_contexts["g"] = _Ctx
+
+        with pytest.raises(HTTPException) as exc:
+            mod._validate_context_against_graph({"prompt_version": "abc"}, "g")
+
+        assert exc.value.details == {  # type: ignore[attr-defined]
+            "errors": [
+                {
+                    "loc": ["context", "prompt_version"],
+                    "msg": "Input should be a valid integer, unable to parse string as an integer",
+                    "type": "int_parsing",
+                }
+            ]
+        }
+
+    def test_extra_forbid_rejects_instead_of_dropping_the_context(self, _declared_contexts: dict) -> None:
+        """The point of ``extra="forbid"``: an unexpected key is an error, not a downgrade."""
+        _declared_contexts["g"] = _StrictCtx
+
+        with pytest.raises(HTTPException) as exc:
+            mod._validate_context_against_graph({"prompt_version": 3, "typo": 1}, "g")
+
+        assert exc.value.status_code == 422
+        assert "context.typo" in exc.value.detail
+
+
+class TestEveryRunCreationPathIsValidated:
+    """Run rows are built in exactly one place, so one check covers every path.
+
+    ``/threads/{id}/runs``, ``/threads/{id}/runs/stream``, ``/threads/{id}/runs/wait``,
+    the stateless ``/runs*`` endpoints, the v2 ``run.start`` command, cron creation
+    and the cron scheduler all reach the database through ``_prepare_run``. A new
+    endpoint that builds its own ``RunORM`` would skip context validation, so fail
+    here instead.
+    """
+
+    def test_run_rows_are_only_constructed_in_run_preparation(self) -> None:
+        src = Path(mod.__file__).parent.parent
+        constructing = sorted(
+            path.relative_to(src).as_posix() for path in src.rglob("*.py") if "RunORM(" in path.read_text()
+        )
+        assert constructing == ["services/run_preparation.py"]


### PR DESCRIPTION
## What is accepted and ignored today

A graph factory annotated `ServerRuntime[T]` declares the type of the context its runs accept. `coerce_context` (`services/graph_factory.py`) converts the request's raw context dict into `T`, and when that conversion fails it logs a warning and hands the graph the raw dict anyway:

```python
except Exception as exc:
    logger.warning(
        "context_coercion_failed", graph_id=graph_id, context_type=ctx_type.__name__,
        exc=str(exc), msg="Falling back to raw dict",
    )
return context
```

So a caller who sends a malformed context gets a `200` and a run that quietly ignored what it asked for. A `prompt_version` of `"abc"` does not fail; the graph falls back to whatever its own defaults or the assistant's stored configuration name, and nothing in the run record says a different prompt was requested. The only signal is a warning on a server the caller usually does not operate.

Two consequences are worth separating out:

- **The declared type is advisory.** `extra="forbid"` cannot reject an unexpected key — it drops the whole context off the typed path onto the untyped one. Declaring a strict type is strictly worse than declaring none, which is the opposite of what the annotation reads like.
- **Wrong values and absent values are indistinguishable.** There is no response, status or stored field that differs between "you sent a valid context" and "you sent nonsense".

## Why this is a compatibility break, not leniency

`CONTRIBUTING.md` states the rule, added in #575: *"Every request field the LangGraph SDK can send must either change behavior or return 422. Never accept a field and ignore it."* `context` is a request field that today does neither — it is accepted, and when it does not satisfy the declared type it is ignored. This is the same fail-closed argument #503 makes for `durability`, `if_not_exists` and `stream_resumable`, applied to the one field whose shape the graph author has already written down.

Failing inside the factory is also a worse error than failing at the edge: the caller gets a failed run rather than a `422`, after the run row has been written, persisted and enqueued.

We run a deployment on top of Aegra where this costs real code. Its graph factory revalidates Aegra's fallback inside the factory — because a context the schema rejects would otherwise reach the graph unchecked — and its context type is declared `extra="allow"` with a comment explaining that this is tolerance rather than a contract, because `extra="forbid"` would not do what it says. Every graph that wants a typed context has to write both of those.

## What changed

- `validate_context()` in `services/graph_factory.py` checks a context against the graph's declared type and raises `ContextValidationError` carrying Pydantic-shaped `loc`/`msg`/`type` entries rooted at `context`. Only those three keys are carried through; Pydantic's `input` would echo the caller's submitted values back into the response body.
- `_prepare_run` (`services/run_preparation.py`) calls it after the assistant is resolved and the graph id is known, before the run row is built. A rejection is a `422` whose message names each offending field (`Invalid context for graph 'agent': context.prompt_version: Input should be a valid integer...`), with the structured entries on the error's `details`. Nothing is persisted and nothing is submitted to the executor.
- `coerce_context` stays the runtime path but no longer degrades. With validation at the edge its failure branch means an unchecked context reached execution, so it logs at `error` and raises rather than running the graph against something other than the type it declared.

The validated value is the context the run will actually execute with: the request's `context` — or `config.configurable`, which `_prepare_run` copies into `context` when `context` is absent — merged over the assistant's stored context. Validating only the request half would leave a run that still silently degrades.

### Every run-creation path is covered

`/threads/{id}/runs`, `/threads/{id}/runs/stream`, `/threads/{id}/runs/wait`, the stateless `/runs`, `/runs/stream` and `/runs/wait` endpoints, the v2 `run.start` command, cron creation (`POST /runs/crons`) and the cron scheduler's own firing all reach the database through `_prepare_run`; the stateless endpoints delegate to the threaded handlers rather than duplicating them. A drift test asserts that `run_preparation.py` is the only module that constructs a `RunORM`, so a future endpoint that builds its own run row fails CI rather than quietly skipping validation.

For the cron scheduler the rejection is not a response — a firing whose context no longer validates is logged and the schedule is not advanced, which is the existing behaviour for any `HTTPException` out of `_prepare_run`. That is the right outcome: a cron that has been silently running with an ignored context stops, visibly, instead of continuing to look healthy.

## Unconditional, with no `strict_context` flag

The original write-up floated gating this behind config for existing deployments. I think that is the wrong call, and the reason is that a per-graph opt-out already exists and costs one keystroke.

Only graphs that annotate `ServerRuntime[T]` are affected at all. A factory taking plain `ServerRuntime`, a `RunnableConfig` factory, a 0-arg factory and a static graph are byte-for-byte unchanged — validation is a no-op when no type is declared. An author who wants the old leniency drops the `[T]`, or gives `T` defaults and `extra="allow"`. That opt-out is local to the graph that wants it, visible in the code that declares the contract, and cannot be forgotten at deploy time — all things a server flag is not.

A flag would also have to default to lenient to protect anyone, and a lenient default leaves the `CONTRIBUTING.md` rule violated out of the box for exactly the graphs that took the trouble to declare a type. The rule has no "unless configured" clause, and this repo has no precedent for a boolean that restores a known-wrong behaviour: the existing booleans in `settings.py` enable features, they do not weaken contracts.

Finally, every deployment a flag would protect is one whose runs are already ignoring what their callers asked for. The flag would preserve the symptom, not a capability.

## Behaviour change for existing deployments, stated plainly

If your graph factory is annotated `ServerRuntime[T]`, run creation now returns `422` instead of `200` when the effective context does not satisfy `T`. Concretely:

- A context with a wrong-typed or unknown field is rejected where it used to be accepted and dropped. With `extra="forbid"` on `T`, an unexpected key is now an error rather than a silent downgrade of the entire context.
- If `T` has required fields and a run supplies none of them, that run now `422`s. Such a run previously handed the factory `{}`, so it was already broken — it just failed later, or not visibly at all.
- `config.configurable` is validated on requests that send no `context`, because the server copies `configurable` into `context`. This is the widest edge of the change: a caller writing Platform-portable payloads that put extra keys under `configurable` will now be rejected by a graph whose `T` forbids extras. Giving `T` `extra="allow"`, or declaring the keys, restores it.
- Runs created before this change and resumed afterwards are coerced at execution as before, but a coercion failure now fails the run loudly instead of running it against a raw dict.

Graphs that declare no context type see no change whatsoever.

## How it was verified

`make format` and `make lint` are clean. `make type-check` reports the same 57 diagnostics as `upstream/main`, none of them in the changed code.

New tests:

- `tests/unit/test_services/test_graph_factory.py::TestValidateContext` — valid contexts pass; `None`, an undeclared type and an unregistered graph are no-ops; a wrong type and a missing field each name the offending field; `extra="forbid"` rejects an unexpected key; dataclass errors collapse to a single `context` entry; submitted values never appear in the errors.
- `TestCoerceContext` — coercion failure raises and logs at `error` with the graph id and the context type.
- `tests/unit/test_api/test_runs.py::TestCreateRunContextValidation` — an invalid context is a `422` naming the field, with no run row, no auto-created thread, no `busy` status and no executor submission; a valid context still creates the run; a graph with no declared type accepts anything; a context inherited from the assistant and a `config.configurable` fallback are both validated.
- `tests/unit/test_services/test_run_preparation.py` — the `422` message and the structured `details`, plus the drift test pinning `RunORM` construction to `run_preparation.py`.
- `tests/integration/test_services/test_graph_factory_integration.py` — an invalid context never reaches the factory, and the raised error carries the field location.

Three existing tests asserted the permissive behaviour directly and were rewritten, which is the clearest evidence that this was a real contract and not an accident of implementation: `test_pydantic_validation_error_falls_back`, `test_dataclass_missing_field_falls_back` and `test_invalid_context_falls_back_to_raw_dict`. Nothing else in the suite depended on it — `2098 passed` across `tests/unit` and `tests/integration`. The one failure, `test_insert_assistant_with_large_configurable_prompt_succeeds`, needs a live Postgres and fails identically on `upstream/main` in this environment; `tests/e2e` was not run for the same reason, so CI is the first place the e2e suite sees this change.

`docs/reference/configuration.mdx` now states what declaring `ServerRuntime[T]` commits the caller to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
