### PR TITLE
feat(api): resolve a default graph_id for assistant creates

### DIFF
--- a/docs/guides/assistants.mdx
+++ b/docs/guides/assistants.mdx
@@ -44,6 +44,32 @@ async def main():
 asyncio.run(main())
 ```
 
+### Omitting `graph_id`
+
+A deployment with one graph has only one answer, so `graph_id` is optional:
+
+```python
+assistant = await client.assistants.create(name="Customer Support Agent")
+```
+
+With several graphs, nominate one with `default_graph_id` in `aegra.json` and
+creates that omit `graph_id` use it:
+
+```json
+{
+  "graphs": {
+    "agent": "./src/agent/graph.py:graph",
+    "agent_hitl": "./src/agent_hitl/graph.py:graph"
+  },
+  "default_graph_id": "agent"
+}
+```
+
+An explicit `graph_id` always wins. With several graphs and no
+`default_graph_id`, a create that omits `graph_id` answers `422` listing the
+graphs it could have meant. See the
+[configuration reference](/reference/configuration) for the key.
+
 ### Idempotent creation
 
 Use `if_exists` to avoid errors when the assistant already exists:

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3501,14 +3501,7 @@
             "description": "Assistant context"
           },
           "graph_id": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
+            "type": "string",
             "title": "Graph Id",
             "description": "LangGraph graph ID from aegra.json. Optional when the deployment resolves a default graph \u2014 `default_graph_id`, or the sole entry in `graphs`; required otherwise."
           },

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3501,9 +3501,16 @@
             "description": "Assistant context"
           },
           "graph_id": {
-            "type": "string",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
             "title": "Graph Id",
-            "description": "LangGraph graph ID from aegra.json"
+            "description": "LangGraph graph ID from aegra.json. Optional when the deployment resolves a default graph \u2014 `default_graph_id`, or the sole entry in `graphs`; required otherwise."
           },
           "metadata": {
             "anyOf": [

--- a/docs/reference/configuration.mdx
+++ b/docs/reference/configuration.mdx
@@ -30,6 +30,7 @@ aegra dev
     "agent": "./src/react_agent/graph.py:graph",
     "agent_hitl": "./src/react_agent_hitl/graph.py:graph"
   },
+  "default_graph_id": "agent",
   "auth": {
     "path": "./my_auth.py:auth",
     "disable_studio_auth": false
@@ -199,6 +200,34 @@ Use `runtime.execution_runtime` to check whether the factory is being called for
 
 For a complete example combining both layers, see [`examples/factory/`](https://github.com/aegra/aegra/tree/main/examples/factory).
 
+## `default_graph_id`
+
+Nominate the graph that `POST /assistants` uses when a request omits `graph_id`.
+
+```json
+{
+  "graphs": {
+    "agent": "./src/agent/graph.py:graph",
+    "agent_hitl": "./src/agent_hitl/graph.py:graph"
+  },
+  "default_graph_id": "agent"
+}
+```
+
+| Type | Description |
+|------|-------------|
+| `string` | A key of `graphs`. Optional. |
+
+- A config with exactly one graph defaults to it without setting this key
+- A value that names no configured graph fails startup, listing the graph ids that exist
+- Set nothing with several graphs configured and `graph_id` stays required — a create that omits it answers `422`
+- An explicit `graph_id` in the request always wins
+
+The resolved default is published in the OpenAPI schema, so clients generated
+against a deployment that has one need not send `graph_id` at all.
+
+See [assistants guide](/guides/assistants) for how creates use it.
+
 ## `auth`
 
 Configure authentication and authorization.
@@ -322,6 +351,18 @@ If neither `checkpointer.ttl` nor `AEGRA_THREAD_TTL` is configured, threads neve
   "graphs": {
     "agent": "./src/agent/graph.py:graph"
   }
+}
+```
+
+### With a house default graph
+
+```json
+{
+  "graphs": {
+    "agent": "./src/agent/graph.py:graph",
+    "agent_hitl": "./src/agent_hitl/graph.py:graph"
+  },
+  "default_graph_id": "agent"
 }
 ```
 

--- a/libs/aegra-api/src/aegra_api/config.py
+++ b/libs/aegra-api/src/aegra_api/config.py
@@ -1,6 +1,7 @@
 """Configuration management for Aegra HTTP settings"""
 
 import json
+from functools import cache
 from pathlib import Path
 from typing import TypedDict
 
@@ -237,6 +238,50 @@ def load_auth_config() -> AuthConfig | None:
         return auth_config
 
     return None
+
+
+def _resolve_default_graph_id(config: dict | None) -> str | None:
+    """Resolve the graph a create falls back to when the request omits ``graph_id``.
+
+    An explicit ``default_graph_id`` wins; otherwise a deployment with exactly
+    one graph defaults to it, because no other choice was available. Returns
+    None when several graphs are configured and none is nominated, which keeps
+    ``graph_id`` required.
+
+    Raises:
+        ValueError: ``default_graph_id`` does not name a configured graph.
+    """
+    if not config:
+        return None
+
+    graphs = config.get("graphs") or {}
+    configured = config.get("default_graph_id")
+
+    if configured is not None:
+        if not isinstance(configured, str) or configured not in graphs:
+            available = ", ".join(graphs) or "(none)"
+            raise ValueError(
+                f"default_graph_id {configured!r} does not name a configured graph. Available graph ids: {available}"
+            )
+        return configured
+
+    if len(graphs) == 1:
+        return next(iter(graphs))
+
+    return None
+
+
+@cache
+def get_default_graph_id() -> str | None:
+    """Resolve the deployment-wide default graph id from aegra.json or langgraph.json.
+
+    Resolved once and cached. Invalid config raises so a default naming no
+    graph fails the boot instead of surfacing at the first assistant create.
+
+    Returns:
+        Default graph id, or None when ``graph_id`` stays required
+    """
+    return _resolve_default_graph_id(load_config())
 
 
 def get_config_dir() -> Path | None:

--- a/libs/aegra-api/src/aegra_api/main.py
+++ b/libs/aegra-api/src/aegra_api/main.py
@@ -19,7 +19,13 @@ from aegra_api.api.runs import router as runs_router
 from aegra_api.api.stateless_runs import router as stateless_runs_router
 from aegra_api.api.store import router as store_router
 from aegra_api.api.threads import router as threads_router
-from aegra_api.config import CorsConfig, HttpConfig, get_config_dir, load_http_config
+from aegra_api.config import (
+    CorsConfig,
+    HttpConfig,
+    get_config_dir,
+    get_default_graph_id,
+    load_http_config,
+)
 from aegra_api.core.app_loader import load_custom_app
 from aegra_api.core.auth_deps import auth_dependency
 from aegra_api.core.auth_enforcement import apply_auth_enforcement
@@ -81,6 +87,11 @@ def _log_connection_help(error: Exception) -> None:
 @asynccontextmanager
 async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     """FastAPI lifespan context manager for startup/shutdown"""
+    # Resolve the default graph_id first: a default_graph_id naming no graph is
+    # a config typo, and should fail the boot before anything expensive starts.
+    if (default_graph_id := get_default_graph_id()) is not None:
+        logger.info("assistants default to graph", graph_id=default_graph_id)
+
     # Multi-pod K8s: set RUN_MIGRATIONS_ON_STARTUP=false + run `aegra db upgrade`
     # out-of-band. See docs/guides/deployment.mdx.
     if settings.app.RUN_MIGRATIONS_ON_STARTUP:

--- a/libs/aegra-api/src/aegra_api/models/assistants.py
+++ b/libs/aegra-api/src/aegra_api/models/assistants.py
@@ -21,6 +21,12 @@ def _publish_default_graph_id(schema: dict[str, Any]) -> None:
 
     if default is None:
         graph_id.pop("default", None)
+        # Non-nullable as well as required. The field is nullable on the model
+        # only because a default may stand in for it; with no default, a null
+        # is treated as omitted and answered 422, so publishing the nullable
+        # branch would describe {"graph_id": null} as valid when it is not.
+        graph_id.pop("anyOf", None)
+        graph_id["type"] = "string"
         required = schema.setdefault("required", [])
         if "graph_id" not in required:
             required.append("graph_id")

--- a/libs/aegra-api/src/aegra_api/models/assistants.py
+++ b/libs/aegra-api/src/aegra_api/models/assistants.py
@@ -5,6 +5,29 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from aegra_api.config import get_default_graph_id
+
+
+def _publish_default_graph_id(schema: dict[str, Any]) -> None:
+    """Describe this deployment's ``graph_id`` contract in the generated schema.
+
+    Whether a create may omit ``graph_id`` is a property of the deployment's
+    config rather than of the model, so it is stamped when the schema is built
+    rather than when the class is defined. Generated clients then see the value
+    the server will use, or that they still have to supply one.
+    """
+    graph_id = schema["properties"]["graph_id"]
+    default = get_default_graph_id()
+
+    if default is None:
+        graph_id.pop("default", None)
+        required = schema.setdefault("required", [])
+        if "graph_id" not in required:
+            required.append("graph_id")
+        return
+
+    graph_id["default"] = default
+
 
 class AssistantCreate(BaseModel):
     """Request model for creating assistants"""
@@ -17,11 +40,19 @@ class AssistantCreate(BaseModel):
     description: str | None = Field(None, description="Assistant description")
     config: dict[str, Any] | None = Field(default_factory=dict, description="Assistant configuration")
     context: dict[str, Any] | None = Field(default_factory=dict, description="Assistant context")
-    graph_id: str = Field(..., description="LangGraph graph ID from aegra.json")
+    graph_id: str | None = Field(
+        None,
+        description=(
+            "LangGraph graph ID from aegra.json. Optional when the deployment resolves a default "
+            "graph — `default_graph_id`, or the sole entry in `graphs`; required otherwise."
+        ),
+    )
     metadata: dict[str, Any] | None = Field(
         default_factory=dict, description="Metadata to use for searching and filtering assistants."
     )
     if_exists: str | None = Field("error", description="What to do if assistant exists: error or do_nothing")
+
+    model_config = ConfigDict(json_schema_extra=_publish_default_graph_id)
 
 
 class Assistant(BaseModel):

--- a/libs/aegra-api/src/aegra_api/services/assistant_service.py
+++ b/libs/aegra-api/src/aegra_api/services/assistant_service.py
@@ -26,6 +26,7 @@ from sqlalchemy import func, or_, select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from aegra_api.config import get_default_graph_id
 from aegra_api.core.auth_deps import get_current_user
 from aegra_api.core.auth_filters import build_metadata_filter
 from aegra_api.core.orm import Assistant as AssistantORM
@@ -159,14 +160,23 @@ class AssistantService(Authenticated):
 
     async def create_assistant(self, request: AssistantCreate) -> Assistant:
         """Create a new assistant"""
+        available_graphs = self.langgraph_service.list_graphs()
+
+        # Resolve the default before dispatch so auth handlers see the graph the
+        # create will actually use, not the omitted field.
+        graph_id = request.graph_id if request.graph_id is not None else get_default_graph_id()
+        if graph_id is None:
+            raise HTTPException(
+                422,
+                "graph_id is required: this deployment has no default graph. "
+                "Pass graph_id, or set 'default_graph_id' in aegra.json. "
+                f"Available: {list(available_graphs.keys())}",
+            )
+        request.graph_id = graph_id
+
         value = request.model_dump()
         await self._dispatch("create", value)
         request.metadata = _injected_metadata(request.metadata, value)
-
-        available_graphs = self.langgraph_service.list_graphs()
-
-        # Use graph_id as the main identifier
-        graph_id = request.graph_id
 
         if graph_id not in available_graphs:
             raise HTTPException(

--- a/libs/aegra-api/tests/conftest.py
+++ b/libs/aegra-api/tests/conftest.py
@@ -135,6 +135,21 @@ def clear_auth_cache():
     get_auth_backend.cache_clear()
 
 
+@pytest.fixture(autouse=True)
+def clear_default_graph_id_cache():
+    """Clear the resolved default graph_id between tests.
+
+    get_default_graph_id() is @cache'd so it resolves once per process; tests
+    that point the config resolver at a temp directory must not leak their
+    answer into the next test.
+    """
+    from aegra_api.config import get_default_graph_id
+
+    get_default_graph_id.cache_clear()
+    yield
+    get_default_graph_id.cache_clear()
+
+
 # --- AUTO-SKIP GEO-BLOCK FAILURES ---
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_makereport(item, call):

--- a/libs/aegra-api/tests/conftest.py
+++ b/libs/aegra-api/tests/conftest.py
@@ -4,11 +4,13 @@ This file contains shared fixtures and configuration that are available
 to all tests across the test suite.
 """
 
+from collections.abc import Iterator
 from unittest.mock import AsyncMock
 
 import pytest
 from httpx import HTTPStatusError
 
+from aegra_api.config import get_default_graph_id
 from tests.fixtures.auth import DummyUser
 from tests.fixtures.clients import (
     create_test_app,
@@ -136,15 +138,13 @@ def clear_auth_cache():
 
 
 @pytest.fixture(autouse=True)
-def clear_default_graph_id_cache():
+def clear_default_graph_id_cache() -> Iterator[None]:
     """Clear the resolved default graph_id between tests.
 
     get_default_graph_id() is @cache'd so it resolves once per process; tests
     that point the config resolver at a temp directory must not leak their
     answer into the next test.
     """
-    from aegra_api.config import get_default_graph_id
-
     get_default_graph_id.cache_clear()
     yield
     get_default_graph_id.cache_clear()

--- a/libs/aegra-api/tests/e2e/test_assistants/test_default_graph_id.py
+++ b/libs/aegra-api/tests/e2e/test_assistants/test_default_graph_id.py
@@ -12,6 +12,7 @@ every other E2E test runs against. They are covered at the unit level, where the
 resolver is pointed at a temporary config instead.
 """
 
+import uuid
 from collections.abc import AsyncIterator
 
 import httpx
@@ -49,15 +50,24 @@ async def test_create_without_graph_id_is_rejected_naming_the_graphs(http_client
 @pytest.mark.e2e
 @pytest.mark.asyncio
 async def test_explicit_graph_id_still_creates(http_client: httpx.AsyncClient) -> None:
-    """The deployment still creates normally when the caller names a graph."""
+    """The deployment still creates normally when the caller names a graph.
+
+    The config is unique per run because a create dedupes on
+    ``(graph_id, config)`` for the calling user: with the default empty config
+    this would match an assistant another test left behind, hand back its id,
+    and have the cleanup below delete something this test never created.
+    """
+    config = {"tags": [f"default-graph-id-e2e-{uuid.uuid4()}"]}
+
     response = await http_client.post(
         "/assistants",
-        json={"name": "Explicit graph id", "graph_id": "agent", "if_exists": "do_nothing"},
+        json={"name": "Explicit graph id", "graph_id": "agent", "config": config},
     )
 
     assert response.status_code == 200, response.text
     created = response.json()
     assert created["graph_id"] == "agent"
+    assert created["config"] == config, "a pre-existing assistant was returned instead of a new one"
 
     try:
         elog("Create with explicit graph_id succeeded", {"assistant_id": created["assistant_id"]})

--- a/libs/aegra-api/tests/e2e/test_assistants/test_default_graph_id.py
+++ b/libs/aegra-api/tests/e2e/test_assistants/test_default_graph_id.py
@@ -66,10 +66,12 @@ async def test_explicit_graph_id_still_creates(http_client: httpx.AsyncClient) -
 
     assert response.status_code == 200, response.text
     created = response.json()
-    assert created["graph_id"] == "agent"
-    assert created["config"] == config, "a pre-existing assistant was returned instead of a new one"
 
+    # Everything that can fail goes inside, so a failed assertion still cleans
+    # up the assistant it created.
     try:
+        assert created["graph_id"] == "agent"
+        assert created["config"] == config, "a pre-existing assistant was returned instead of a new one"
         elog("Create with explicit graph_id succeeded", {"assistant_id": created["assistant_id"]})
     finally:
         await http_client.delete(f"/assistants/{created['assistant_id']}")

--- a/libs/aegra-api/tests/e2e/test_assistants/test_default_graph_id.py
+++ b/libs/aegra-api/tests/e2e/test_assistants/test_default_graph_id.py
@@ -1,0 +1,65 @@
+"""The default graph_id rule, against a real server and its real aegra.json.
+
+This repo's own `aegra.json` registers several graphs and nominates no
+`default_graph_id`, so the deployment these tests run against is the "no default
+resolves" case: `graph_id` stays required, and omitting it is a 422 that names
+the graphs the caller could have meant.
+
+The positive halves of the rule — a configured `default_graph_id`, and the
+single-graph deployment that needs no key — cannot be exercised here without
+changing the example deployment's own configuration, which would change what
+every other E2E test runs against. They are covered at the unit level, where the
+resolver is pointed at a temporary config instead.
+"""
+
+from collections.abc import AsyncIterator
+
+import httpx
+import pytest
+
+from aegra_api.settings import settings
+from tests.e2e._utils import elog
+
+
+@pytest.fixture
+async def http_client() -> AsyncIterator[httpx.AsyncClient]:
+    """Raw HTTP, because the SDK's create() cannot omit graph_id."""
+    async with httpx.AsyncClient(base_url=settings.app.SERVER_URL, timeout=30.0) as client:
+        yield client
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_create_without_graph_id_is_rejected_naming_the_graphs(http_client: httpx.AsyncClient) -> None:
+    """With several graphs and no default, an omitted graph_id is a 422 that helps."""
+    response = await http_client.post("/assistants", json={"name": "No graph id"})
+
+    assert response.status_code == 422, response.text
+
+    message = response.json()["message"]
+    elog("Create without graph_id rejected", {"status": response.status_code, "message": message})
+
+    assert "graph_id is required" in message
+    assert "default_graph_id" in message, "the error should say how to configure a default"
+    # Naming the real registered graphs is the part that makes this actionable,
+    # and the part a mocked service cannot prove.
+    assert "agent" in message
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+async def test_explicit_graph_id_still_creates(http_client: httpx.AsyncClient) -> None:
+    """The deployment still creates normally when the caller names a graph."""
+    response = await http_client.post(
+        "/assistants",
+        json={"name": "Explicit graph id", "graph_id": "agent", "if_exists": "do_nothing"},
+    )
+
+    assert response.status_code == 200, response.text
+    created = response.json()
+    assert created["graph_id"] == "agent"
+
+    try:
+        elog("Create with explicit graph_id succeeded", {"assistant_id": created["assistant_id"]})
+    finally:
+        await http_client.delete(f"/assistants/{created['assistant_id']}")

--- a/libs/aegra-api/tests/integration/test_api/test_assistants_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_assistants_crud.py
@@ -1,6 +1,9 @@
 """Integration tests for assistants CRUD operations"""
 
+from unittest.mock import MagicMock
+
 import pytest
+from fastapi.testclient import TestClient
 
 from aegra_api.services.assistant_service import get_assistant_service
 from tests.fixtures.clients import create_test_app, make_client
@@ -49,7 +52,7 @@ class TestCreateAssistant:
         assert data["graph_id"] == "test-graph"
         mock_assistant_service.create_assistant.assert_called_once()
 
-    def test_create_assistant_without_graph_id(self, client, mock_assistant_service):
+    def test_create_assistant_without_graph_id(self, client: TestClient, mock_assistant_service: MagicMock) -> None:
         """graph_id may be omitted: the request boundary no longer rejects it.
 
         Which graph it resolves to is the service's business; the API layer only

--- a/libs/aegra-api/tests/integration/test_api/test_assistants_crud.py
+++ b/libs/aegra-api/tests/integration/test_api/test_assistants_crud.py
@@ -49,6 +49,20 @@ class TestCreateAssistant:
         assert data["graph_id"] == "test-graph"
         mock_assistant_service.create_assistant.assert_called_once()
 
+    def test_create_assistant_without_graph_id(self, client, mock_assistant_service):
+        """graph_id may be omitted: the request boundary no longer rejects it.
+
+        Which graph it resolves to is the service's business; the API layer only
+        has to let the create through.
+        """
+        assistant = make_assistant()
+        mock_assistant_service.create_assistant.return_value = assistant
+
+        resp = client.post("/assistants", json={"name": "Test Assistant"})
+
+        assert resp.status_code == 200
+        assert mock_assistant_service.create_assistant.call_args.args[0].graph_id is None
+
     def test_create_assistant_with_metadata(self, client, mock_assistant_service):
         """Test creating assistant with rich metadata"""
         assistant = make_assistant(metadata={"description": "A helpful assistant", "tags": ["prod", "v1"]})

--- a/libs/aegra-api/tests/unit/test_core/test_config.py
+++ b/libs/aegra-api/tests/unit/test_core/test_config.py
@@ -264,14 +264,14 @@ def _write_config(tmp_path: Path, config: dict) -> None:
 class TestDefaultGraphId:
     """get_default_graph_id resolves the fallback for POST /assistants."""
 
-    def test_single_graph_is_the_default(self, tmp_path, monkeypatch):
+    def test_single_graph_is_the_default(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """One graph is unambiguous, so it needs no configuration to be the default."""
         monkeypatch.chdir(tmp_path)
         _write_config(tmp_path, {"graphs": {"agent": "./agent.py:graph"}})
 
         assert get_default_graph_id() == "agent"
 
-    def test_several_graphs_have_no_default(self, tmp_path, monkeypatch):
+    def test_several_graphs_have_no_default(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """With a choice to make, the server does not make it — graph_id stays required."""
         monkeypatch.chdir(tmp_path)
         _write_config(
@@ -281,7 +281,9 @@ class TestDefaultGraphId:
 
         assert get_default_graph_id() is None
 
-    def test_configured_default_selects_one_of_several_graphs(self, tmp_path, monkeypatch):
+    def test_configured_default_selects_one_of_several_graphs(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """default_graph_id nominates the house default for a multi-graph deployment."""
         monkeypatch.chdir(tmp_path)
         _write_config(
@@ -294,14 +296,16 @@ class TestDefaultGraphId:
 
         assert get_default_graph_id() == "other"
 
-    def test_configured_default_wins_over_the_sole_graph(self, tmp_path, monkeypatch):
+    def test_configured_default_wins_over_the_sole_graph(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """An explicit key is honoured even where the single-graph rule would also fire."""
         monkeypatch.chdir(tmp_path)
         _write_config(tmp_path, {"default_graph_id": "agent", "graphs": {"agent": "./agent.py:graph"}})
 
         assert get_default_graph_id() == "agent"
 
-    def test_should_raise_when_default_names_no_configured_graph(self, tmp_path, monkeypatch):
+    def test_should_raise_when_default_names_no_configured_graph(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         """A typo fails loudly, naming both the bad value and what was available."""
         monkeypatch.chdir(tmp_path)
         _write_config(
@@ -319,7 +323,7 @@ class TestDefaultGraphId:
         assert "agnet" in message
         assert "agent, other" in message
 
-    def test_should_raise_when_default_is_not_a_string(self, tmp_path, monkeypatch):
+    def test_should_raise_when_default_is_not_a_string(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """A non-string default can never name a graph."""
         monkeypatch.chdir(tmp_path)
         _write_config(tmp_path, {"default_graph_id": ["agent"], "graphs": {"agent": "./agent.py:graph"}})
@@ -327,13 +331,13 @@ class TestDefaultGraphId:
         with pytest.raises(ValueError):
             get_default_graph_id()
 
-    def test_no_config_file_has_no_default(self, tmp_path, monkeypatch):
+    def test_no_config_file_has_no_default(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """Nothing to resolve from means graph_id stays required."""
         monkeypatch.chdir(tmp_path)
 
         assert get_default_graph_id() is None
 
-    def test_langgraph_json_fallback_resolves_a_default(self, tmp_path, monkeypatch):
+    def test_langgraph_json_fallback_resolves_a_default(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """The compatibility config file is read the same way."""
         monkeypatch.chdir(tmp_path)
         (tmp_path / "langgraph.json").write_text(json.dumps({"graphs": {"agent": "./agent.py:graph"}}))

--- a/libs/aegra-api/tests/unit/test_core/test_config.py
+++ b/libs/aegra-api/tests/unit/test_core/test_config.py
@@ -5,7 +5,12 @@ from pathlib import Path
 
 import pytest
 
-from aegra_api.config import load_checkpointer_config, load_http_config, load_store_config
+from aegra_api.config import (
+    get_default_graph_id,
+    load_checkpointer_config,
+    load_http_config,
+    load_store_config,
+)
 
 
 def test_load_http_config_from_aegra_json(tmp_path, monkeypatch):
@@ -250,3 +255,87 @@ def test_load_checkpointer_config_no_config(tmp_path: Path, monkeypatch: pytest.
     config = load_checkpointer_config()
 
     assert config is None
+
+
+def _write_config(tmp_path: Path, config: dict) -> None:
+    (tmp_path / "aegra.json").write_text(json.dumps(config))
+
+
+class TestDefaultGraphId:
+    """get_default_graph_id resolves the fallback for POST /assistants."""
+
+    def test_single_graph_is_the_default(self, tmp_path, monkeypatch):
+        """One graph is unambiguous, so it needs no configuration to be the default."""
+        monkeypatch.chdir(tmp_path)
+        _write_config(tmp_path, {"graphs": {"agent": "./agent.py:graph"}})
+
+        assert get_default_graph_id() == "agent"
+
+    def test_several_graphs_have_no_default(self, tmp_path, monkeypatch):
+        """With a choice to make, the server does not make it — graph_id stays required."""
+        monkeypatch.chdir(tmp_path)
+        _write_config(
+            tmp_path,
+            {"graphs": {"agent": "./agent.py:graph", "other": "./other.py:graph"}},
+        )
+
+        assert get_default_graph_id() is None
+
+    def test_configured_default_selects_one_of_several_graphs(self, tmp_path, monkeypatch):
+        """default_graph_id nominates the house default for a multi-graph deployment."""
+        monkeypatch.chdir(tmp_path)
+        _write_config(
+            tmp_path,
+            {
+                "default_graph_id": "other",
+                "graphs": {"agent": "./agent.py:graph", "other": "./other.py:graph"},
+            },
+        )
+
+        assert get_default_graph_id() == "other"
+
+    def test_configured_default_wins_over_the_sole_graph(self, tmp_path, monkeypatch):
+        """An explicit key is honoured even where the single-graph rule would also fire."""
+        monkeypatch.chdir(tmp_path)
+        _write_config(tmp_path, {"default_graph_id": "agent", "graphs": {"agent": "./agent.py:graph"}})
+
+        assert get_default_graph_id() == "agent"
+
+    def test_should_raise_when_default_names_no_configured_graph(self, tmp_path, monkeypatch):
+        """A typo fails loudly, naming both the bad value and what was available."""
+        monkeypatch.chdir(tmp_path)
+        _write_config(
+            tmp_path,
+            {
+                "default_graph_id": "agnet",
+                "graphs": {"agent": "./agent.py:graph", "other": "./other.py:graph"},
+            },
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            get_default_graph_id()
+
+        message = str(exc_info.value)
+        assert "agnet" in message
+        assert "agent, other" in message
+
+    def test_should_raise_when_default_is_not_a_string(self, tmp_path, monkeypatch):
+        """A non-string default can never name a graph."""
+        monkeypatch.chdir(tmp_path)
+        _write_config(tmp_path, {"default_graph_id": ["agent"], "graphs": {"agent": "./agent.py:graph"}})
+
+        with pytest.raises(ValueError):
+            get_default_graph_id()
+
+    def test_no_config_file_has_no_default(self, tmp_path, monkeypatch):
+        """Nothing to resolve from means graph_id stays required."""
+        monkeypatch.chdir(tmp_path)
+
+        assert get_default_graph_id() is None
+
+    def test_langgraph_json_fallback_resolves_a_default(self, tmp_path, monkeypatch):
+        """The compatibility config file is read the same way."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "langgraph.json").write_text(json.dumps({"graphs": {"agent": "./agent.py:graph"}}))
+
+        assert get_default_graph_id() == "agent"

--- a/libs/aegra-api/tests/unit/test_main.py
+++ b/libs/aegra-api/tests/unit/test_main.py
@@ -227,3 +227,42 @@ async def test_lifespan_skips_ttl_sweeper_without_config() -> None:
 
         mock_sweeper.start.assert_not_awaited()
         mock_sweeper.stop.assert_not_awaited()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_lifespan_fails_on_default_graph_id_that_names_no_graph(tmp_path, monkeypatch) -> None:
+    """A default_graph_id typo fails the boot, naming the value and the choices.
+
+    Resolution happens before migrations or the database connection, so the
+    error is the config's, not a downstream symptom of it.
+    """
+    import json
+
+    import aegra_api.main as main_module
+
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "aegra.json").write_text(
+        json.dumps(
+            {
+                "default_graph_id": "agnet",
+                "graphs": {"agent": "./agent.py:graph", "other": "./other.py:graph"},
+            }
+        )
+    )
+
+    with (
+        patch("aegra_api.main.run_migrations_async", new_callable=AsyncMock) as mock_migrations,
+        patch("aegra_api.main.db_manager") as mock_db_manager,
+    ):
+        mock_db_manager.initialize = AsyncMock()
+
+        with pytest.raises(ValueError) as exc_info:
+            async with main_module.lifespan(MagicMock()):
+                pass
+
+    message = str(exc_info.value)
+    assert "agnet" in message
+    assert "agent, other" in message
+    mock_migrations.assert_not_called()
+    mock_db_manager.initialize.assert_not_called()

--- a/libs/aegra-api/tests/unit/test_main.py
+++ b/libs/aegra-api/tests/unit/test_main.py
@@ -1,6 +1,8 @@
 """Tests for application lifespan and startup logic"""
 
 import importlib
+import json
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -231,14 +233,14 @@ async def test_lifespan_skips_ttl_sweeper_without_config() -> None:
 
 @pytest.mark.unit
 @pytest.mark.asyncio
-async def test_lifespan_fails_on_default_graph_id_that_names_no_graph(tmp_path, monkeypatch) -> None:
+async def test_lifespan_fails_on_default_graph_id_that_names_no_graph(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """A default_graph_id typo fails the boot, naming the value and the choices.
 
     Resolution happens before migrations or the database connection, so the
     error is the config's, not a downstream symptom of it.
     """
-    import json
-
     import aegra_api.main as main_module
 
     monkeypatch.chdir(tmp_path)

--- a/libs/aegra-api/tests/unit/test_models/test_assistants_default_graph_schema.py
+++ b/libs/aegra-api/tests/unit/test_models/test_assistants_default_graph_schema.py
@@ -57,3 +57,32 @@ def test_schema_keeps_graph_id_required_without_a_default(tmp_path: Path, monkey
 
     assert "graph_id" in schema["required"]
     assert "default" not in schema["properties"]["graph_id"]
+
+
+def test_schema_without_a_default_does_not_permit_null(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Required and non-nullable go together, because a null is refused.
+
+    The model's field is nullable because a resolved default can stand in for
+    it. Where nothing resolves, a null is treated as omitted and answered 422,
+    so publishing the nullable branch would describe a request the server
+    refuses as schema-valid.
+    """
+    _use_config(
+        tmp_path,
+        monkeypatch,
+        {"graphs": {"agent": "./agent.py:graph", "other": "./other.py:graph"}},
+    )
+
+    graph_id = AssistantCreate.model_json_schema()["properties"]["graph_id"]
+
+    assert graph_id["type"] == "string"
+    assert "anyOf" not in graph_id
+
+
+def test_schema_with_a_default_still_permits_null(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Where a default resolves, a null means "use it", so it stays valid."""
+    _use_config(tmp_path, monkeypatch, {"graphs": {"agent": "./agent.py:graph"}})
+
+    graph_id = AssistantCreate.model_json_schema()["properties"]["graph_id"]
+
+    assert {"type": "null"} in graph_id["anyOf"]

--- a/libs/aegra-api/tests/unit/test_models/test_assistants_default_graph_schema.py
+++ b/libs/aegra-api/tests/unit/test_models/test_assistants_default_graph_schema.py
@@ -18,7 +18,7 @@ def _use_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, config: dict) -
     (tmp_path / "aegra.json").write_text(json.dumps(config))
 
 
-def test_schema_advertises_the_resolved_default(tmp_path, monkeypatch):
+def test_schema_advertises_the_resolved_default(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """A resolvable default is optional, and clients are told which graph it is."""
     _use_config(
         tmp_path,
@@ -35,7 +35,7 @@ def test_schema_advertises_the_resolved_default(tmp_path, monkeypatch):
     assert "graph_id" not in schema.get("required", [])
 
 
-def test_schema_advertises_the_sole_graph_as_the_default(tmp_path, monkeypatch):
+def test_schema_advertises_the_sole_graph_as_the_default(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """The single-graph deployment needs no config to publish its default."""
     _use_config(tmp_path, monkeypatch, {"graphs": {"agent": "./agent.py:graph"}})
 
@@ -45,7 +45,7 @@ def test_schema_advertises_the_sole_graph_as_the_default(tmp_path, monkeypatch):
     assert "graph_id" not in schema.get("required", [])
 
 
-def test_schema_keeps_graph_id_required_without_a_default(tmp_path, monkeypatch):
+def test_schema_keeps_graph_id_required_without_a_default(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Several graphs and no nominated default: clients must still send one."""
     _use_config(
         tmp_path,

--- a/libs/aegra-api/tests/unit/test_models/test_assistants_default_graph_schema.py
+++ b/libs/aegra-api/tests/unit/test_models/test_assistants_default_graph_schema.py
@@ -1,0 +1,59 @@
+"""The published schema for AssistantCreate describes the deployment it came from.
+
+Whether `graph_id` may be omitted depends on `aegra.json`, so the generated
+schema — and every client generated from it — has to say which case this
+deployment is in.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from aegra_api.models.assistants import AssistantCreate
+
+
+def _use_config(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, config: dict) -> None:
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "aegra.json").write_text(json.dumps(config))
+
+
+def test_schema_advertises_the_resolved_default(tmp_path, monkeypatch):
+    """A resolvable default is optional, and clients are told which graph it is."""
+    _use_config(
+        tmp_path,
+        monkeypatch,
+        {
+            "default_graph_id": "other",
+            "graphs": {"agent": "./agent.py:graph", "other": "./other.py:graph"},
+        },
+    )
+
+    schema = AssistantCreate.model_json_schema()
+
+    assert schema["properties"]["graph_id"]["default"] == "other"
+    assert "graph_id" not in schema.get("required", [])
+
+
+def test_schema_advertises_the_sole_graph_as_the_default(tmp_path, monkeypatch):
+    """The single-graph deployment needs no config to publish its default."""
+    _use_config(tmp_path, monkeypatch, {"graphs": {"agent": "./agent.py:graph"}})
+
+    schema = AssistantCreate.model_json_schema()
+
+    assert schema["properties"]["graph_id"]["default"] == "agent"
+    assert "graph_id" not in schema.get("required", [])
+
+
+def test_schema_keeps_graph_id_required_without_a_default(tmp_path, monkeypatch):
+    """Several graphs and no nominated default: clients must still send one."""
+    _use_config(
+        tmp_path,
+        monkeypatch,
+        {"graphs": {"agent": "./agent.py:graph", "other": "./other.py:graph"}},
+    )
+
+    schema = AssistantCreate.model_json_schema()
+
+    assert "graph_id" in schema["required"]
+    assert "default" not in schema["properties"]["graph_id"]

--- a/libs/aegra-api/tests/unit/test_services/test_assistant_service.py
+++ b/libs/aegra-api/tests/unit/test_services/test_assistant_service.py
@@ -1203,3 +1203,76 @@ class TestAuthDispatch:
         stmt = assistant_service.session.scalars.call_args.args[0]
         compiled = stmt.compile(dialect=postgresql.dialect())
         assert {"owner": "user-123"} in compiled.params.values()
+
+
+class TestAssistantServiceDefaultGraph:
+    """graph_id may be omitted when the deployment resolves a default graph."""
+
+    @pytest.fixture
+    def two_graphs(self, assistant_service: AssistantService) -> None:
+        assistant_service.langgraph_service.list_graphs.return_value = {
+            "test-graph": {},
+            "other-graph": {},
+        }
+
+    @pytest.mark.asyncio
+    async def test_create_assistant_falls_back_to_the_default_graph(
+        self,
+        assistant_service: AssistantService,
+    ) -> None:
+        """An omitted graph_id resolves to the deployment default."""
+        insert_wins(assistant_service.session)
+
+        with patch("aegra_api.services.assistant_service.get_default_graph_id", return_value="test-graph"):
+            result = await assistant_service.create_assistant(AssistantCreate(name="Test Assistant"))
+
+        assert result.graph_id == "test-graph"
+        assistant_service.langgraph_service.get_graph_for_validation.assert_awaited_once_with("test-graph")
+
+    @pytest.mark.asyncio
+    async def test_create_assistant_prefers_an_explicit_graph_id(
+        self,
+        assistant_service: AssistantService,
+        two_graphs: None,
+    ) -> None:
+        """The request wins over the configured default."""
+        insert_wins(assistant_service.session)
+
+        with patch("aegra_api.services.assistant_service.get_default_graph_id", return_value="other-graph"):
+            result = await assistant_service.create_assistant(
+                AssistantCreate(name="Test Assistant", graph_id="test-graph")
+            )
+
+        assert result.graph_id == "test-graph"
+
+    @pytest.mark.asyncio
+    async def test_should_return_422_when_omitted_and_no_default_resolves(
+        self,
+        assistant_service: AssistantService,
+        two_graphs: None,
+    ) -> None:
+        """Without a default the field is still required, and the error names the choices."""
+        with (
+            patch("aegra_api.services.assistant_service.get_default_graph_id", return_value=None),
+            pytest.raises(HTTPException) as exc_info,
+        ):
+            await assistant_service.create_assistant(AssistantCreate(name="Test Assistant"))
+
+        assert exc_info.value.status_code == 422
+        assert "test-graph" in exc_info.value.detail
+        assert "other-graph" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_create_assistant_dispatches_the_resolved_graph_id(
+        self,
+        assistant_service: AssistantService,
+    ) -> None:
+        """Auth handlers see the graph the create will use, not the omitted field."""
+        insert_wins(assistant_service.session)
+        dispatch = AsyncMock()
+        assistant_service._dispatch = dispatch
+
+        with patch("aegra_api.services.assistant_service.get_default_graph_id", return_value="test-graph"):
+            await assistant_service.create_assistant(AssistantCreate(name="Test Assistant"))
+
+        assert dispatch.await_args.args[1]["graph_id"] == "test-graph"


### PR DESCRIPTION
## The coupling

`POST /assistants` requires `graph_id`. In a deployment with one graph — the shape `aegra init` produces, and the shape most deployments start in — that is a value the server could not have chosen differently, and every client has to carry it anyway: every integration, in every language, hard-codes the graph name of the deployment it talks to. Rename or replace the graph later and all of them are wrong, for a value none of them had a reason to know.

There is no server-side default and no way to configure one. We run a deployment that resolves this in application code — an application-specific key in `aegra.json` read at startup, and a request model shadowing `AssistantCreate` to apply it — which works only because Aegra's config loader accepts unknown top-level keys. That is an accident of the loader, not a contract, and it is the kind of thing that belongs in the server.

## What this does

Two rules, composed:

- **`default_graph_id`** at the top level of `aegra.json` (or `langgraph.json`) nominates the graph that creates fall back to. This covers the multi-graph deployment with a house default.
- **A single graph is its own default.** With exactly one entry in `graphs` there is nothing to choose, so no key is needed. Zero configuration, and unambiguous by construction.

`default_graph_id` wins where both apply; with several graphs and no key, `graph_id` stays required. They compose because the first is explicit and the second is only reachable when there is no choice to make — neither can quietly pick a graph the operator did not name or did not deploy alone.

Resolution lives in `config.py` and is cached, and the lifespan resolves it before migrations or the database connection. A `default_graph_id` that names no configured graph therefore fails the boot, with an error naming both the bad value and the graph ids that exist:

```
default_graph_id 'agnet' does not name a configured graph. Available graph ids: agent, other
```

A create that omits `graph_id` where nothing resolves answers `422` naming the graphs it could have meant, rather than inventing one.

The resolved default is stamped into the generated schema when the schema is built, not when the model class is defined, because which case a deployment is in is a property of its config. Clients generated against a deployment with a default see `graph_id` optional and carrying that value; clients generated against a deployment without one see it still required. `docs/openapi.json` is regenerated here from this repo's own `aegra.json`, which has eight graphs and no `default_graph_id` — so in the published spec `graph_id` stays required, and the only change is that the field is now nullable and better described.

The default is resolved before auth dispatch, so `@auth.on.assistants.create` handlers see the graph the create will actually use rather than an absent field.

## Compatibility

Strictly additive.

- An explicit `graph_id` keeps winning, in every combination. An empty string is still an explicit value and still answers `400`.
- A deployment that sets nothing and has several graphs sees no change at all — same required field, same schema shape in `required`.
- A deployment that sets nothing and has one graph gains the ability to omit the field; nothing it sends today stops working.
- No new required config, no migration, no change to any response.

## Docs

- `docs/reference/configuration.mdx` — a `default_graph_id` section, the key in the complete example, and a "house default graph" entry under common configurations.
- `docs/guides/assistants.mdx` — how a create omits `graph_id`, and what happens when no default resolves.

## Verification

- `make format`, `make lint` — clean.
- `make type-check` — 57 diagnostics, identical to the count on `main` with these four source files reverted; this change adds none.
- `make openapi` — regenerated `docs/openapi.json` is included.
- `uv run --package aegra-api pytest libs/aegra-api/tests/unit libs/aegra-api/tests/integration` — 2092 passed. (`tests/integration/test_assistant_large_config_db.py` needs a live PostgreSQL and was not run; the e2e suites need Docker and were not run.)

New tests:

- `tests/unit/test_core/test_config.py` — the single-graph default, several graphs with no default, a configured default among several, a configured default over the sole graph, a default that names no graph, a non-string default, no config file, and the `langgraph.json` fallback.
- `tests/unit/test_models/test_assistants_default_graph_schema.py` — the published schema advertises the resolved default and drops `graph_id` from `required`, or keeps it required with no default.
- `tests/unit/test_services/test_assistant_service.py` — an omitted `graph_id` falls back to the default, an explicit one wins over it, no default resolving answers `422` naming the available graphs, and the resolved id is what reaches auth dispatch.
- `tests/unit/test_main.py` — a `default_graph_id` naming no graph fails the lifespan before migrations run or the database is touched.
- `tests/integration/test_api/test_assistants_crud.py` — the request boundary accepts a create with no `graph_id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
